### PR TITLE
Filter

### DIFF
--- a/testacc/data_source_aci_vzFilter_test.go
+++ b/testacc/data_source_aci_vzFilter_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestAccAciFilterDataSource_Basic(t *testing.T) {
-	resourceName := "aci_filter.test"                                                 // defining name of resource
-	dataSourceName := "data.aci_filter.test"                                          // defining name of data source
-	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz") // creating random string of 5 characters (to give as random parameter)
+	resourceName := "aci_filter.test"                                                
+	dataSourceName := "data.aci_filter.test"                                          
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz") 
 	randomValue := acctest.RandString(5)
 	rName := makeTestVariable(acctest.RandString(5))
 	resource.ParallelTest(t, resource.TestCase{
@@ -21,19 +21,19 @@ func TestAccAciFilterDataSource_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckAciFilterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      CreateAccFilterDSWithoutTenant(rName),           // creating data source for application profile without required arguement tenant_dn
-				ExpectError: regexp.MustCompile(`Missing required argument`), // test step expect error which should be match with defined regex
+				Config:      CreateAccFilterDSWithoutTenant(rName),           
+				ExpectError: regexp.MustCompile(`Missing required argument`), 
 			},
 			{
-				Config:      CreateAccFilterDSWithoutName(rName), // creating data source for application profile without required arguement name
+				Config:      CreateAccFilterDSWithoutName(rName), 
 				ExpectError: regexp.MustCompile(`Missing required argument`),
 			},
 			{
-				Config: CreateAccFilterConfigDataSource(rName), // creating data source with required arguements from the resource
+				Config: CreateAccFilterConfigDataSource(rName), 
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"), // comparing value of parameter description in data source and resoruce
-					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),   // comparing value of parameter description in data source and resoruce
-					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),   // comparing value of parameter description in data source and resoruce
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"), 
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),   
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),  
 
 					resource.TestCheckResourceAttrPair(dataSourceName, "tenant_dn", resourceName, "tenant_dn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
@@ -44,8 +44,8 @@ func TestAccAciFilterDataSource_Basic(t *testing.T) {
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
 			},
 			{
-				Config:      CreateAccFilterDSWithInvalidName(rName),          // data source configuration with invalid application profile profile name
-				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`), // test step expect error which should be match with defined regex
+				Config:      CreateAccFilterDSWithInvalidName(rName),         
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`), 
 			},
 			{
 				Config: CreateAccFilterDataSourceUpdate(rName, "description", "description"),

--- a/testacc/data_source_aci_vzFilter_test.go
+++ b/testacc/data_source_aci_vzFilter_test.go
@@ -1,0 +1,174 @@
+package acctest
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciFilterDataSource_Basic(t *testing.T) {
+	resourceName := "aci_filter.test"                                                 // defining name of resource
+	dataSourceName := "data.aci_filter.test"                                          // defining name of data source
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz") // creating random string of 5 characters (to give as random parameter)
+	randomValue := acctest.RandString(5)
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateAccFilterDSWithoutTenant(rName),           // creating data source for application profile without required arguement tenant_dn
+				ExpectError: regexp.MustCompile(`Missing required argument`), // test step expect error which should be match with defined regex
+			},
+			{
+				Config:      CreateAccFilterDSWithoutName(rName), // creating data source for application profile without required arguement name
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccFilterConfigDataSource(rName), // creating data source with required arguements from the resource
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"), // comparing value of parameter description in data source and resoruce
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),   // comparing value of parameter description in data source and resoruce
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),   // comparing value of parameter description in data source and resoruce
+
+					resource.TestCheckResourceAttrPair(dataSourceName, "tenant_dn", resourceName, "tenant_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+				),
+			},
+			{
+				Config:      CreateAccFilterDataSourceUpdateRandomAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccFilterDSWithInvalidName(rName),          // data source configuration with invalid application profile profile name
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`), // test step expect error which should be match with defined regex
+			},
+			{
+				Config: CreateAccFilterDataSourceUpdate(rName, "description", "description"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccFilterDataSourceUpdateRandomAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  Basic: testing filter data source update for attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+	resource "aci_filter" "test"{
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	data "aci_filter" "test" {
+		name = aci_filter.test.name
+		tenant_dn = aci_filter.test.tenant_dn
+		%s = "%s"
+	}
+	`, rName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccFilterDataSourceUpdate(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  Basic: testing filter data source update for attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+	resource "aci_filter" "test"{
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+		%s = "%s"
+	}
+	data "aci_filter" "test" {
+		name = aci_filter.test.name
+		tenant_dn = aci_filter.test.tenant_dn
+	}
+	`, rName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccFilterConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  Basic: testing filter creation for data source test")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_filter" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	data "aci_filter" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = aci_filter.test.name
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccFilterDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  Basic: testing filter reading with invalid name")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_filter" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	data "aci_filter" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "${aci_filter.test.name}xyz"
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccFilterDSWithoutTenant(rName string) string {
+	fmt.Println("=== STEP  Basic: testing filter reading without giving tenant_dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_filter" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	data "aci_filter" "test" {
+		name = "%s"
+	}
+	`, rName, rName, rName)
+	return resource
+}
+
+func CreateAccFilterDSWithoutName(rName string) string {
+	fmt.Println("=== STEP  Basic: testing filter reading without giving name")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_filter" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	data "aci_filter" "test" {
+		tenant_dn = aci_tenant.test.id
+	}
+	`, rName, rName)
+	return resource
+}

--- a/testacc/resource_aci_fvap_test.go
+++ b/testacc/resource_aci_fvap_test.go
@@ -46,6 +46,8 @@ func TestAccAciApplicationProfile_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "relation_fv_rs_ap_mon_pol", ""),
 					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"), // comparing with default value of annotation
 					resource.TestCheckResourceAttr(resourceName, "prio", "unspecified"),                  // comparing with default value of prio
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
 				),
 			},
 			{
@@ -58,6 +60,8 @@ func TestAccAciApplicationProfile_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "relation_fv_rs_ap_mon_pol", ""),
 					resource.TestCheckResourceAttr(resourceName, "annotation", "tag"),                                    // comparing annotation with value which is given in configuration
 					resource.TestCheckResourceAttr(resourceName, "prio", "level1"),                                       // comparing prio with value which is given in configuration
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
 					testAccCheckAciApplicationProfileIdEqual(&application_profile_default, &application_profile_updated), // this function will check whether id or dn of both resource are same or not to make sure updation is performed on the same resource
 				),
 			},

--- a/testacc/resource_aci_vzfilter_test.go
+++ b/testacc/resource_aci_vzfilter_test.go
@@ -1,0 +1,400 @@
+package acctest
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciFilter_Basic(t *testing.T) {
+	var filter_default models.Filter
+	var filter_updated models.Filter
+	resourceName := "aci_filter.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rOther := makeTestVariable(acctest.RandString(5))
+	longrName := acctest.RandString(65)
+	prOther := makeTestVariable(acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateAccFilterWithoutName(rName),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateAccFilterWithoutTenant(rName),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				// step terraform will create application profile with only required arguements i.e. name and tenant_dn
+				Config: CreateAccFilterConfig(rName), // configuration to create application profile with required fields only
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFilterExists(resourceName, &filter_default), // this function will check whether any resource is exist or not in state file with given resource name
+					// now will compare value of all attributes with default for given resource
+					resource.TestCheckResourceAttr(resourceName, "description", ""), // no default value for description so comparing with ""
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_filt_graph_att", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_fwd_r_flt_p_att", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_rev_r_flt_p_att", ""),   // no default value for name_alias so comparing with ""
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"), // comparing with default value of annotation
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+				),
+			},
+			{
+				Config: CreateAccFilterConfigWithOptionalValues(rName), // configuration to update optional filelds
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFilterExists(resourceName, &filter_updated),
+					resource.TestCheckResourceAttr(resourceName, "description", "From Terraform"), // comparing description with value which is given in configuration
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "alias_filter"),    // comparing name_alias with value which is given in configuration
+					resource.TestCheckResourceAttr(resourceName, "annotation", "tag_filter"),
+					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_filt_graph_att", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_fwd_r_flt_p_att", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_rev_r_flt_p_att", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)), // comparing prio with value which is given in configuration
+					testAccCheckAciFilterIdEqual(&filter_default, &filter_updated),                             // this function will check whether id or dn of both resource are same or not to make sure updation is performed on the same resource
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccFilterRemovingRequiredField(), // configuration to update optional filelds
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateAccFilterConfigUpdatedName(rName, longrName), // passing invalid name for application profile
+				ExpectError: regexp.MustCompile(fmt.Sprintf("property name of flt-%s failed validation for value '%s'", longrName, longrName)),
+			},
+			{
+				Config: CreateAccFilterConfigWithParentAndName(rName, rOther), // creating resource with same parent name and different resource name
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFilterExists(resourceName, &filter_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rOther),                               // comparing name attribute of applicaiton profile
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)), // comparing tenant_dn attribute of application profile
+					testAccCheckAciFilterIdNotEqual(&filter_default, &filter_updated),                          // checking whether id or dn of both resource are different because name changed and terraform need to create another resource
+				),
+			},
+			{
+				Config: CreateAccFilterConfig(rName), // creating resource with required parameters only
+			},
+			{
+				Config: CreateAccFilterConfigWithParentAndName(prOther, rName), // creating resource with same name but different parent resource name
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFilterExists(resourceName, &filter_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", prOther)),
+					testAccCheckAciFilterIdNotEqual(&filter_default, &filter_updated), // checking whether id or dn of both resource are different because tenant_dn changed and terraform need to create another resource
+				),
+			},
+		},
+	},
+	)
+}
+
+func TestAccFilter_NegativeCases(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	longDescAnnotation := acctest.RandString(129)                                     // creating random string of 129 characters
+	longNameAlias := acctest.RandString(64)                                           // creating random string of 64 characters                                              // creating random string of 6 characters
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz") // creating random string of 5 characters (to give as random parameter)
+	randomValue := acctest.RandString(5)                                              // creating random string of 5 characters (to give as random value of random parameter)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccFilterConfig(rName), // creating application profile with required arguements only
+			},
+			{
+				Config:      CreateAccFilterWithInValidTenantDn(rName),                                       // checking application profile creation with invalid tenant_dn value
+				ExpectError: regexp.MustCompile(`unknown property value (.)+, name dn, class vzFilter (.)+`), // test step expect error which should be match with defined regex
+			},
+			{
+				Config:      CreateAccFilterUpdatedAttr(rName, "description", longDescAnnotation), // checking application profile creation with invalid description value
+				ExpectError: regexp.MustCompile(`property descr of (.)+ failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccFilterUpdatedAttr(rName, "annotation", longDescAnnotation), // checking application profile creation with invalid annotation value
+				ExpectError: regexp.MustCompile(`property annotation of (.)+ failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccFilterUpdatedAttr(rName, "name_alias", longNameAlias), // checking application profile creation with invalid name_alias value
+				ExpectError: regexp.MustCompile(`property nameAlias of (.)+ failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccFilterUpdatedAttr(rName, randomParameter, randomValue), // checking application profile creation with randomly created parameter and value
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccFilterConfig(rName), // creating application profile with required arguements only
+			},
+		},
+	})
+}
+
+func TestAccFilter_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciFilterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccFiltersConfig(rName),
+			},
+		},
+	})
+}
+
+func CreateAccFiltersConfig(rName string) string {
+	fmt.Println("=== STEP  creating multiple filter")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_filter" "test1"{
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_filter" "test2"{
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_filter" "test3"{
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	`, rName, rName+"1", rName+"2", rName+"3")
+	return resource
+}
+
+func CreateAccFilterUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing filter attribute: %s=%s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_filter" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+		%s = "%s"
+	}
+	`, rName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccFilterWithInValidTenantDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing filter creation with invalid tenant_dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_vrf" "test"{
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_filter" "test" {
+		tenant_dn = aci_vrf.test.id
+		name = "%s"
+	}
+	`, rName, rName, rName)
+	return resource
+}
+
+func testAccCheckAciFilterIdNotEqual(f1, f2 *models.Filter) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if f1.DistinguishedName == f2.DistinguishedName {
+			return fmt.Errorf("Filter DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateAccFilterConfigWithParentAndName(prName, rName string) string {
+	fmt.Printf("=== STEP  Basic: testing filter creation with tenant name %s name %s\n", prName, rName)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_filter" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	`, prName, rName)
+	return resource
+}
+
+func CreateAccFilterConfigUpdatedName(rName, longrName string) string {
+	fmt.Println("=== STEP  Basic: testing filter creation with invalid name")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_filter" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	`, rName, longrName)
+	return resource
+}
+
+func CreateAccFilterWithoutName(rName string) string {
+	fmt.Println("=== STEP  Basic: testing filter creation without giving name")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_filter" "test" {
+		tenant_dn = aci_tenant.test.id
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccFilterWithoutTenant(rName string) string {
+	fmt.Println("=== STEP  Basic: testing filter creation without giving name")
+	resource := fmt.Sprintf(`
+
+	resource "aci_filter" "test" {
+		name="%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccFilterWithoutFilter(rName string) string {
+	fmt.Println("=== STEP  Basic: testing filter creation without creating tenant")
+	resource := fmt.Sprintf(`
+	resource "aci_filter" "test" {
+		name = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccFilterConfig(rName string) string {
+	fmt.Println("=== STEP  testing filter creation with required arguements")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_filter" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccFilterConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing filter creation with optional parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_filter" "test" {
+        tenant_dn   = aci_tenant.test.id
+        description = "From Terraform"
+        name        = "%s"
+        annotation  = "tag_filter"
+        name_alias  = "alias_filter"
+    }
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccFilterRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing filter creation with optional parameters")
+	resource := fmt.Sprintln(`
+
+	resource "aci_filter" "test" {
+        description = "From Terraform"
+        annotation  = "tag"
+        name_alias  = "alias_filter"
+    }
+	`)
+	return resource
+}
+
+func testAccCheckAciFilterIdEqual(f1, f2 *models.Filter) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if f1.DistinguishedName != f2.DistinguishedName {
+			return fmt.Errorf("filter DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciFilterExists(name string, filter *models.Filter) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Filter %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Filter dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		filterFound := models.FilterFromContainer(cont)
+		if filterFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Filter %s not found", rs.Primary.ID)
+		}
+		*filter = *filterFound
+		return nil
+	}
+}
+
+func testAccCheckAciFilterDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*client.Client)
+
+	for _, rs := range s.RootModule().Resources {
+
+		if rs.Type == "aci_filter" {
+			cont, err := client.Get(rs.Primary.ID)
+			filter := models.FilterFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Filter %s Still exists", filter.DistinguishedName)
+			}
+
+		} else {
+			continue
+		}
+	}
+
+	return nil
+}

--- a/testacc/resource_aci_vzfilter_test.go
+++ b/testacc/resource_aci_vzfilter_test.go
@@ -379,6 +379,7 @@ func testAccCheckAciFilterExists(name string, filter *models.Filter) resource.Te
 }
 
 func testAccCheckAciFilterDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing filter destroy")
 	client := testAccProvider.Meta().(*client.Client)
 
 	for _, rs := range s.RootModule().Resources {

--- a/testacc/resource_aci_vzfilter_test.go
+++ b/testacc/resource_aci_vzfilter_test.go
@@ -36,34 +36,33 @@ func TestAccAciFilter_Basic(t *testing.T) {
 				ExpectError: regexp.MustCompile(`Missing required argument`),
 			},
 			{
-				// step terraform will create application profile with only required arguements i.e. name and tenant_dn
-				Config: CreateAccFilterConfig(rName), // configuration to create application profile with required fields only
+				
+				Config: CreateAccFilterConfig(rName), 
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFilterExists(resourceName, &filter_default), // this function will check whether any resource is exist or not in state file with given resource name
-					// now will compare value of all attributes with default for given resource
-					resource.TestCheckResourceAttr(resourceName, "description", ""), // no default value for description so comparing with ""
+					testAccCheckAciFilterExists(resourceName, &filter_default), 
+					resource.TestCheckResourceAttr(resourceName, "description", ""), 
 					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
 					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_filt_graph_att", ""),
 					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_fwd_r_flt_p_att", ""),
-					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_rev_r_flt_p_att", ""),   // no default value for name_alias so comparing with ""
-					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"), // comparing with default value of annotation
+					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_rev_r_flt_p_att", ""),   
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"), 
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
 				),
 			},
 			{
-				Config: CreateAccFilterConfigWithOptionalValues(rName), // configuration to update optional filelds
+				Config: CreateAccFilterConfigWithOptionalValues(rName), 
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciFilterExists(resourceName, &filter_updated),
-					resource.TestCheckResourceAttr(resourceName, "description", "From Terraform"), // comparing description with value which is given in configuration
-					resource.TestCheckResourceAttr(resourceName, "name_alias", "alias_filter"),    // comparing name_alias with value which is given in configuration
+					resource.TestCheckResourceAttr(resourceName, "description", "From Terraform"), 
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "alias_filter"),    
 					resource.TestCheckResourceAttr(resourceName, "annotation", "tag_filter"),
 					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_filt_graph_att", ""),
 					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_fwd_r_flt_p_att", ""),
 					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_rev_r_flt_p_att", ""),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)), // comparing prio with value which is given in configuration
-					testAccCheckAciFilterIdEqual(&filter_default, &filter_updated),                             // this function will check whether id or dn of both resource are same or not to make sure updation is performed on the same resource
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)), 
+					testAccCheckAciFilterIdEqual(&filter_default, &filter_updated),                             
 				),
 			},
 			{
@@ -72,32 +71,32 @@ func TestAccAciFilter_Basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:      CreateAccFilterRemovingRequiredField(), // configuration to update optional filelds
+				Config:      CreateAccFilterRemovingRequiredField(),
 				ExpectError: regexp.MustCompile(`Missing required argument`),
 			},
 			{
-				Config:      CreateAccFilterConfigUpdatedName(rName, longrName), // passing invalid name for application profile
+				Config:      CreateAccFilterConfigUpdatedName(rName, longrName), 
 				ExpectError: regexp.MustCompile(fmt.Sprintf("property name of flt-%s failed validation for value '%s'", longrName, longrName)),
 			},
 			{
-				Config: CreateAccFilterConfigWithParentAndName(rName, rOther), // creating resource with same parent name and different resource name
+				Config: CreateAccFilterConfigWithParentAndName(rName, rOther), 
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciFilterExists(resourceName, &filter_updated),
-					resource.TestCheckResourceAttr(resourceName, "name", rOther),                               // comparing name attribute of applicaiton profile
-					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)), // comparing tenant_dn attribute of application profile
-					testAccCheckAciFilterIdNotEqual(&filter_default, &filter_updated),                          // checking whether id or dn of both resource are different because name changed and terraform need to create another resource
+					resource.TestCheckResourceAttr(resourceName, "name", rOther),                              
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)), 
+					testAccCheckAciFilterIdNotEqual(&filter_default, &filter_updated),                          
 				),
 			},
 			{
-				Config: CreateAccFilterConfig(rName), // creating resource with required parameters only
+				Config: CreateAccFilterConfig(rName), 
 			},
 			{
-				Config: CreateAccFilterConfigWithParentAndName(prOther, rName), // creating resource with same name but different parent resource name
+				Config: CreateAccFilterConfigWithParentAndName(prOther, rName), 
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciFilterExists(resourceName, &filter_updated),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", prOther)),
-					testAccCheckAciFilterIdNotEqual(&filter_default, &filter_updated), // checking whether id or dn of both resource are different because tenant_dn changed and terraform need to create another resource
+					testAccCheckAciFilterIdNotEqual(&filter_default, &filter_updated), 
 				),
 			},
 		},
@@ -107,41 +106,41 @@ func TestAccAciFilter_Basic(t *testing.T) {
 
 func TestAccFilter_NegativeCases(t *testing.T) {
 	rName := makeTestVariable(acctest.RandString(5))
-	longDescAnnotation := acctest.RandString(129)                                     // creating random string of 129 characters
-	longNameAlias := acctest.RandString(64)                                           // creating random string of 64 characters                                              // creating random string of 6 characters
-	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz") // creating random string of 5 characters (to give as random parameter)
-	randomValue := acctest.RandString(5)                                              // creating random string of 5 characters (to give as random value of random parameter)
+	longDescAnnotation := acctest.RandString(129)                                     
+	longNameAlias := acctest.RandString(64)                                                                                        
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz") 
+	randomValue := acctest.RandString(5)                                              
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAciFilterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: CreateAccFilterConfig(rName), // creating application profile with required arguements only
+				Config: CreateAccFilterConfig(rName), 
 			},
 			{
-				Config:      CreateAccFilterWithInValidTenantDn(rName),                                       // checking application profile creation with invalid tenant_dn value
-				ExpectError: regexp.MustCompile(`unknown property value (.)+, name dn, class vzFilter (.)+`), // test step expect error which should be match with defined regex
+				Config:      CreateAccFilterWithInValidTenantDn(rName),                                      
+				ExpectError: regexp.MustCompile(`unknown property value (.)+, name dn, class vzFilter (.)+`), 
 			},
 			{
-				Config:      CreateAccFilterUpdatedAttr(rName, "description", longDescAnnotation), // checking application profile creation with invalid description value
+				Config:      CreateAccFilterUpdatedAttr(rName, "description", longDescAnnotation), 
 				ExpectError: regexp.MustCompile(`property descr of (.)+ failed validation for value '(.)+'`),
 			},
 			{
-				Config:      CreateAccFilterUpdatedAttr(rName, "annotation", longDescAnnotation), // checking application profile creation with invalid annotation value
+				Config:      CreateAccFilterUpdatedAttr(rName, "annotation", longDescAnnotation), 
 				ExpectError: regexp.MustCompile(`property annotation of (.)+ failed validation for value '(.)+'`),
 			},
 			{
-				Config:      CreateAccFilterUpdatedAttr(rName, "name_alias", longNameAlias), // checking application profile creation with invalid name_alias value
+				Config:      CreateAccFilterUpdatedAttr(rName, "name_alias", longNameAlias), 
 				ExpectError: regexp.MustCompile(`property nameAlias of (.)+ failed validation for value '(.)+'`),
 			},
 
 			{
-				Config:      CreateAccFilterUpdatedAttr(rName, randomParameter, randomValue), // checking application profile creation with randomly created parameter and value
+				Config:      CreateAccFilterUpdatedAttr(rName, randomParameter, randomValue), 
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
 			},
 			{
-				Config: CreateAccFilterConfig(rName), // creating application profile with required arguements only
+				Config: CreateAccFilterConfig(rName), 
 			},
 		},
 	})


### PR DESCRIPTION
kanchi.shukla@CLW511-831 MINGW64 ~/Desktop/Filter/terraform-provider-aci (Filter)
$ make fmt && make testacc
gofmt -w $(find . -name '*.go' |grep -v vendor)
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?       github.com/terraform-providers/terraform-provider-aci   [no test files]
?       github.com/terraform-providers/terraform-provider-aci/aci       [no test files]
=== RUN   TestAccAciFilterDataSource_Basic
=== STEP  Basic: testing filter reading without giving tenant_dn
=== STEP  Basic: testing filter reading without giving name
=== STEP  Basic: testing filter creation for data source test
=== STEP  Basic: testing filter data source update for attribute: alhsg = bditb
=== STEP  Basic: testing filter reading with invalid name
=== STEP  Basic: testing filter data source update for attribute: description = description
=== PAUSE TestAccAciFilterDataSource_Basic
=== RUN   TestProvider
--- PASS: TestProvider (0.02s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccAciFilter_Basic
=== STEP  Basic: testing filter creation without giving name
=== STEP  Basic: testing filter creation without giving name
=== STEP  testing filter creation with required arguements
=== STEP  Basic: testing filter creation with optional parameters
=== STEP  Basic: testing filter creation with optional parameters
=== STEP  Basic: testing filter creation with invalid name
=== STEP  Basic: testing filter creation with tenant name acctestm86e1 name acctest0bd13
=== STEP  testing filter creation with required arguements
=== STEP  Basic: testing filter creation with tenant name acctesthc9b8 name acctestm86e1
=== STEP  testing filter destroy
--- PASS: TestAccAciFilter_Basic (235.00s)
=== RUN   TestAccFilter_NegativeCases
=== STEP  testing filter creation with required arguements
=== STEP  Negative Case: testing filter creation with invalid tenant_dn
=== STEP  testing filter attribute: description=9n2no0k7tmp4c021h6l6bk0gblth6wslqyuptxzm3z2e3mimq3csyx0s8zfhcs6dsg068ls3bsbkknflmdqnuht9gau93dkljn0wj74vdcnovhhikjv6ffkfo4c3u4cjq
=== STEP  testing filter attribute: annotation=9n2no0k7tmp4c021h6l6bk0gblth6wslqyuptxzm3z2e3mimq3csyx0s8zfhcs6dsg068ls3bsbkknflmdqnuht9gau93dkljn0wj74vdcnovhhikjv6ffkfo4c3u4cjq
=== STEP  testing filter attribute: name_alias=4b9emxuqexdrtv0my72mizajh7pun4jgnb7cixr8dnsdud110itpsfsxe88uwk03
=== STEP  testing filter attribute: yspgu=kfwwh
=== STEP  testing filter creation with required arguements
=== PAUSE TestAccFilter_NegativeCases
=== RUN   TestAccFilter_MultipleCreateDelete
=== STEP  creating multiple filter
=== STEP  testing filter destroy
--- PASS: TestAccFilter_MultipleCreateDelete (55.23s)
=== CONT  TestAccAciFilterDataSource_Basic
=== CONT  TestAccFilter_NegativeCases
=== STEP  testing filter destroy
--- PASS: TestAccAciFilterDataSource_Basic (117.29s)
=== STEP  testing filter destroy
--- PASS: TestAccFilter_NegativeCases (154.30s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   445.667s

