### PR TITLE
Added test script for ospfIfP and updated EPG to Contract

### DIFF
--- a/aci/resource_aci_fvepselector.go
+++ b/aci/resource_aci_fvepselector.go
@@ -77,7 +77,7 @@ func resourceAciEndpointSecurityGroupSelectorImport(d *schema.ResourceData, m in
 	if err != nil {
 		return nil, err
 	}
-	d.Set("endpoint_security_group_dn",GetParentDn(dn,fmt.Sprintf("/epselector-[%s]",fvEPSelector.MatchExpression)))
+	d.Set("endpoint_security_group_dn", GetParentDn(dn, fmt.Sprintf("/epselector-[%s]", fvEPSelector.MatchExpression)))
 	schemaFilled, err := setEndpointSecurityGroupSelectorAttributes(fvEPSelector, d)
 	if err != nil {
 		return nil, err

--- a/aci/resource_aci_ospfifp.go
+++ b/aci/resource_aci_ospfifp.go
@@ -20,7 +20,7 @@ func resourceAciOSPFInterfaceProfile() *schema.Resource {
 		DeleteContext: resourceAciOSPFInterfaceProfileDelete,
 
 		Importer: &schema.ResourceImporter{
-			State: resourceAciInterfaceProfileImport,
+			State: resourceAciOSPFInterfaceProfileImport,
 		},
 
 		SchemaVersion: 1,
@@ -120,7 +120,7 @@ func resourceAciOSPFInterfaceProfileImport(d *schema.ResourceData, m interface{}
 	if err != nil {
 		return nil, err
 	}
-
+	d.Set("logical_interface_profile_dn", GetParentDn(dn, "/ospfIfP"))
 	log.Printf("[DEBUG] %s: Import finished successfully", d.Id())
 
 	return []*schema.ResourceData{schemaFilled}, nil

--- a/testacc/data_source_aci_fvrsprovcons_test.go
+++ b/testacc/data_source_aci_fvrsprovcons_test.go
@@ -58,7 +58,7 @@ func TestAccAciEPGToContractDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccEPGToContractUpdatedConfigDataSourceRandomAttr(rName, attribute, value string) string {
-	fmt.Println("=== STEP  Basic: Testing EPG to Contract data source with updated resource")
+	fmt.Println("=== STEP  Basic: Testing EPG to Contract data source with Random Attribute")
 	resource := fmt.Sprintf(`
 	resource "aci_tenant" "test"{
 		name = "%s"
@@ -273,7 +273,7 @@ func CreateAccEPGToContractDSWithoutContract(rName string) string {
 	return resource
 }
 func CreateAccEPGToContractDSWithoutContractType(rName string) string {
-	fmt.Println("=== STEP  Basic: Testing EPG to Contract data source without Application EPG")
+	fmt.Println("=== STEP  Basic: Testing EPG to Contract data source without Contract Type")
 	resource := fmt.Sprintf(`
 	resource "aci_tenant" "test"{
 		name = "%s"

--- a/testacc/data_source_aci_ospfifp_test.go
+++ b/testacc/data_source_aci_ospfifp_test.go
@@ -1,0 +1,295 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciL3outOspfInterfaceProfileDataSource_Basic(t *testing.T) {
+	resourceName := "aci_l3out_ospf_interface_profile.test"
+	dataSourceName := "data.aci_l3out_ospf_interface_profile.test"
+	rName := acctest.RandString(5)
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciL3outOspfInterfaceProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateAccL3outOspfInterfaceProfileDSWithoutLogicalInterfaceProfile(rName),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateAccL3outOspfInterfaceProfileDSWithoutAuthKey(rName),
+				ExpectError: regexp.MustCompile(`Object may not exists`),
+			},
+			{
+				Config: CreateAccL3outOspfInterfaceProfileConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "auth_key", resourceName, "auth_key"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "auth_key_id", resourceName, "auth_key_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "auth_type", resourceName, "auth_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "logical_interface_profile_dn", resourceName, "logical_interface_profile_dn"),
+				),
+			},
+			{
+				Config:      CreateAccL3outOspfInterfaceProfileUpdatedConfigDataSourceRandomAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccL3outOspfInterfaceProfileUpdatedConfigDataSource(rName, "description", randomValue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+				),
+			},
+			{
+				Config:      CreateAccL3outOspfInterfaceProfileDSWithInvalidLogicalInterfaceProfileDn(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+		},
+	})
+}
+
+func CreateAccL3outOspfInterfaceProfileUpdatedConfigDataSourceRandomAttr(rName, attribute, value string) string {
+	fmt.Println("=== STEP  Basic: Testing L3out Ospf Interface Profile data source with updated resource")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		description = "logical_interface_profile created while acceptance testing"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_ospf_interface_profile" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		auth_key = "%s"
+	}
+
+	data "aci_l3out_ospf_interface_profile" "test" {
+		logical_interface_profile_dn = aci_l3out_ospf_interface_profile.test.logical_interface_profile_dn
+		auth_key = aci_l3out_ospf_interface_profile.test.auth_key
+		%s = "%s"
+	}
+	`, rName, rName, rName, rName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccL3outOspfInterfaceProfileUpdatedConfigDataSource(rName, attribute, value string) string {
+	fmt.Println("=== STEP  Basic: Testing L3out Ospf Interface Profile data source with updated resource")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		description = "logical_interface_profile created while acceptance testing"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_ospf_interface_profile" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		auth_key = "%s"
+		%s = "%s"
+	}
+
+	data "aci_l3out_ospf_interface_profile" "test" {
+		logical_interface_profile_dn = aci_l3out_ospf_interface_profile.test.logical_interface_profile_dn
+		auth_key = aci_l3out_ospf_interface_profile.test.auth_key
+	}
+
+	`, rName, rName, rName, rName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccL3outOspfInterfaceProfileConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  Basic: L3out Ospf Interface Profile subject data source")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		description = "logical_interface_profile created while acceptance testing"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_ospf_interface_profile" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		auth_key = "%s"
+	}
+
+	data "aci_l3out_ospf_interface_profile" "test" {
+		logical_interface_profile_dn = aci_l3out_ospf_interface_profile.test.logical_interface_profile_dn
+		auth_key = aci_l3out_ospf_interface_profile.test.auth_key
+	}
+	`, rName, rName, rName, rName, rName)
+	return resource
+}
+
+func CreateAccL3outOspfInterfaceProfileDSWithInvalidLogicalInterfaceProfileDn(rName string) string {
+	fmt.Println("=== STEP  Basic: testing L3out Ospf Interface Profile reading with Invalid Logical Interface Profile Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		description = "logical_interface_profile created while acceptance testing"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_ospf_interface_profile" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		auth_key = "%s"
+	}
+
+	data "aci_l3out_ospf_interface_profile" "test" {
+		logical_interface_profile_dn = "${aci_l3out_ospf_interface_profile.test.logical_interface_profile_dn}abc"
+		auth_key = aci_l3out_ospf_interface_profile.test.auth_key
+	}
+
+	`, rName, rName, rName, rName, rName)
+	return resource
+}
+
+func CreateAccL3outOspfInterfaceProfileDSWithoutLogicalInterfaceProfile(rName string) string {
+	fmt.Println("=== STEP  Basic: testing L3out Ospf Interface Profile reading without giving Logical Interface Profile")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		description = "logical_interface_profile created while acceptance testing"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_ospf_interface_profile" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		auth_key = "%s"
+	}
+
+	data "aci_l3out_ospf_interface_profile" "test" {
+		auth_key = aci_l3out_ospf_interface_profile.test.auth_key
+	}
+	`, rName, rName, rName, rName, rName)
+	return resource
+}
+
+func CreateAccL3outOspfInterfaceProfileDSWithoutAuthKey(rName string) string {
+	fmt.Println("=== STEP  Basic: testing contract subject reading without giving name")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		description = "logical_interface_profile created while acceptance testing"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_ospf_interface_profile" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		auth_key = "%s"
+	}
+
+	data "aci_l3out_ospf_interface_profile" "test" {
+		logical_interface_profile_dn = "${aci_l3out_ospf_interface_profile.test.logical_interface_profile_dn}abc"
+	}
+	`, rName, rName, rName, rName, rName)
+	return resource
+}

--- a/testacc/resource_aci_ospfifp_test.go
+++ b/testacc/resource_aci_ospfifp_test.go
@@ -1,0 +1,514 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciL3outOspfInterfaceProfile_Basic(t *testing.T) {
+	var l3out_ospf_interface_profile_default models.OSPFInterfaceProfile
+	var l3out_ospf_interface_profile_updated models.OSPFInterfaceProfile
+	resourceName := "aci_l3out_ospf_interface_profile.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	randomValue := acctest.RandString(5)
+	randomValueUpdated := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciL3outOspfInterfaceProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateL3outOspfInterfaceProfileWithoutRequired(rName, rName, rName, rName, "logical_interface_profile_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateL3outOspfInterfaceProfileWithoutRequired(rName, rName, rName, rName, "auth_key"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccL3outOspfInterfaceProfileConfig(rName, rName, rName, rName, randomValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outOspfInterfaceProfileExists(resourceName, &l3out_ospf_interface_profile_default),
+					resource.TestCheckResourceAttr(resourceName, "logical_interface_profile_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s/lifp-%s", rName, rName, rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "auth_key", randomValue),
+					resource.TestCheckResourceAttr(resourceName, "auth_key_id", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auth_type", "none"),
+					resource.TestCheckResourceAttr(resourceName, "relation_ospf_rs_if_pol", ""),
+				),
+			},
+			{
+				// in this step all optional attribute expect realational attribute are given for the same resource and then compared
+				Config: CreateAccL3outOspfInterfaceProfileConfigWithOptionalValues(rName, rName, rName, rName, randomValueUpdated), // configuration to update optional filelds
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outOspfInterfaceProfileExists(resourceName, &l3out_ospf_interface_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_l3out_ospf_interface_profile"),
+					resource.TestCheckResourceAttr(resourceName, "auth_key", randomValueUpdated),
+					resource.TestCheckResourceAttr(resourceName, "auth_key_id", "2"),
+					resource.TestCheckResourceAttr(resourceName, "auth_type", "md5"),
+					resource.TestCheckResourceAttr(resourceName, "relation_ospf_rs_if_pol", ""),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"auth_key"},
+			},
+			{
+				Config: CreateAccL3outOspfInterfaceProfileConfigWithRequiredParams(rNameUpdated, randomValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outOspfInterfaceProfileExists(resourceName, &l3out_ospf_interface_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "logical_interface_profile_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s/lifp-%s", rNameUpdated, rNameUpdated, rNameUpdated, rNameUpdated)),
+					testAccCheckAciL3outOspfInterfaceProfileIdNotEqual(&l3out_ospf_interface_profile_default, &l3out_ospf_interface_profile_updated),
+				),
+			},
+			{
+				Config:      CreateAccL3outOspfInterfaceProfileConfigUpdateWithoutRequiredParameters(rName, "description", "test_coverage"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccL3outOspfInterfaceProfileConfig(rName, rName, rName, rName, randomValue),
+			},
+		},
+	})
+}
+
+func TestAccAciL3outOspfInterfaceProfile_Update(t *testing.T) {
+	var l3out_ospf_interface_profile_default models.OSPFInterfaceProfile
+	var l3out_ospf_interface_profile_updated models.OSPFInterfaceProfile
+	resourceName := "aci_l3out_ospf_interface_profile.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	randomValue := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciL3outOspfInterfaceProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccL3outOspfInterfaceProfileConfig(rName, rName, rName, rName, randomValue),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outOspfInterfaceProfileExists(resourceName, &l3out_ospf_interface_profile_default),
+				),
+			},
+			{
+				Config: CreateAccL3outOspfInterfaceProfileUpdatedAttr(rName, "auth_type", "simple"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outOspfInterfaceProfileExists(resourceName, &l3out_ospf_interface_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "auth_type", "simple"),
+					testAccCheckAciL3outOspfInterfaceProfileIdEqual(&l3out_ospf_interface_profile_default, &l3out_ospf_interface_profile_updated),
+				),
+			},
+			{
+				Config: CreateAccL3outOspfInterfaceProfileConfig(rName, rName, rName, rName, randomValue),
+			},
+		},
+	})
+}
+
+func TestAccAciL3outOspfInterfaceProfile_Negative(t *testing.T) {
+
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciL3outOspfInterfaceProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccL3outOspfInterfaceProfileConfig(rName, rName, rName, rName, randomValue),
+			},
+			{
+				Config:      CreateAccL3outOspfInterfaceProfileWithInValidParentDn(rName, rName, rName, rName),
+				ExpectError: regexp.MustCompile(`configured object (.)+ not found (.)+,`),
+			},
+			{
+				Config:      CreateAccL3outOspfInterfaceProfileUpdatedAttr(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccL3outOspfInterfaceProfileUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccL3outOspfInterfaceProfileUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccL3outOspfInterfaceProfileUpdatedAttr(rName, "auth_key_id", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccL3outOspfInterfaceProfileUpdatedAttr(rName, "auth_type", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)*to be one of(.)*, got(.)*`),
+			},
+			{
+				Config:      CreateAccL3outOspfInterfaceProfileUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named(.)*is not expected here.`),
+			},
+			{
+				Config: CreateAccL3outOspfInterfaceProfileConfig(rName, rName, rName, rName, randomValue),
+			},
+		},
+	})
+}
+
+func testAccCheckAciL3outOspfInterfaceProfileExists(name string, l3out_ospf_interface_profile *models.OSPFInterfaceProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("L3out Ospf Interface Profile %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No L3out Ospf Interface Profile dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		l3out_ospf_interface_profileFound := models.OSPFInterfaceProfileFromContainer(cont)
+		if l3out_ospf_interface_profileFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("L3out Ospf Interface Profile %s not found", rs.Primary.ID)
+		}
+		*l3out_ospf_interface_profile = *l3out_ospf_interface_profileFound
+		return nil
+	}
+}
+
+func testAccCheckAciL3outOspfInterfaceProfileDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing l3out_ospf_interface_profile destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_l3out_ospf_interface_profile" {
+			cont, err := client.Get(rs.Primary.ID)
+			l3out_ospf_interface_profile := models.OSPFInterfaceProfileFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("L3out Ospf Interface Profile %s Still exists", l3out_ospf_interface_profile.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciL3outOspfInterfaceProfileIdEqual(m1, m2 *models.OSPFInterfaceProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("l3out_ospf_interface_profile DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciL3outOspfInterfaceProfileIdNotEqual(m1, m2 *models.OSPFInterfaceProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("l3out_ospf_interface_profile DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateL3outOspfInterfaceProfileWithoutRequired(fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing l3out_ospf_interface_profile creation without ", attrName)
+	rBlock := `
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+		
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		description = "logical_interface_profile created while acceptance testing"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	`
+	switch attrName {
+	case "logical_interface_profile_dn":
+		rBlock += `
+		resource "aci_l3out_ospf_interface_profile" "test" {
+		#	logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+			auth_key = "random"
+			description = "created while acceptance testing"
+	}
+	`
+	case "auth_key":
+		rBlock += `
+		resource "aci_l3out_ospf_interface_profile" "test" {
+				logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+				#auth_key = "random"
+				description = "created while acceptance testing"
+			}`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName)
+}
+
+func CreateAccL3outOspfInterfaceProfileConfigWithRequiredParams(rName, randomValue string) string {
+	fmt.Println("=== STEP  testing l3out_ospf_interface_profile creation with required arguements only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		description = "logical_interface_profile created while acceptance testing"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_ospf_interface_profile" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		auth_key = "%s"
+	}
+	`, rName, rName, rName, rName, randomValue)
+	return resource
+}
+
+func CreateAccL3outOspfInterfaceProfileUpdatedAttr(rName, attribute, value string) string {
+	fmt.Println("=== STEP  testing l3out_ospf_interface_profile creation with required arguements only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		description = "logical_interface_profile created while acceptance testing"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_ospf_interface_profile" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		auth_key = "%s"
+		%s = "%s"
+	}
+	`, rName, rName, rName, rName, value, attribute, value)
+	return resource
+}
+
+func CreateAccL3outOspfInterfaceProfileConfigUpdateWithoutRequiredParameters(rName, attribute, value string) string {
+	fmt.Println("=== STEP  testing l3out_ospf_interface_profile updation without required arguements")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		description = "logical_interface_profile created while acceptance testing"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_ospf_interface_profile" "test" {
+		auth_key = "random"
+		%s = "%s"
+	}
+	`, rName, rName, rName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccL3outOspfInterfaceProfileConfig(fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, randomValue string) string {
+	fmt.Println("=== STEP  testing l3out_ospf_interface_profile creation with required arguements only")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		description = "logical_interface_profile created while acceptance testing"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_ospf_interface_profile" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		auth_key = "%s"
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, randomValue)
+	return resource
+}
+
+func CreateAccL3outOspfInterfaceProfileWithInValidParentDn(fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName string) string {
+	fmt.Println("=== STEP  Negative Case: testing l3out_ospf_interface_profile creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		description = "logical_interface_profile created while acceptance testing"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_ospf_interface_profile" "test" {
+		logical_interface_profile_dn  = "${aci_logical_interface_profile.test.id}invalid"	
+		auth_key = "random"
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName)
+	return resource
+}
+
+func CreateAccL3outOspfInterfaceProfileConfigWithOptionalValues(fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, randomValue string) string {
+	fmt.Println("=== STEP  Basic: testing l3out_ospf_interface_profile creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		description = "logical_interface_profile created while acceptance testing"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_ospf_interface_profile" "test" {
+		logical_interface_profile_dn  = "${aci_logical_interface_profile.test.id}"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_l3out_ospf_interface_profile"
+		auth_key = "%s"
+		auth_key_id = "2"
+		auth_type = "md5"
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, randomValue)
+
+	return resource
+}
+
+func CreateAccL3outOspfInterfaceProfileRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing l3out_ospf_interface_profile creation with optional parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_l3out_ospf_interface_profile" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_l3out_ospf_interface_profile"
+		auth_key = ""auth_key_id = "2"auth_key_id = ""auth_type = "md5"
+	}
+	`)
+
+	return resource
+}

--- a/website/docs/r/epg_to_contract.html.markdown
+++ b/website/docs/r/epg_to_contract.html.markdown
@@ -30,7 +30,7 @@ resource "aci_epg_to_contract" "example" {
 - `contract_type` - (Required) Type of relationship. Allowed values are "consumer" and "provider".
 - `annotation` - (Optional) Annotation for EPg to contract relationship.
 - `description` - (Optional) Description for EPg to contract relationship.
-- `match_t` - (Optional) Provider matching criteria. Allowed values: "All", "AtleastOne", "AtmostOne", "None". Default value: "AtleastOne".
+- `match_t` - (Optional) Provider matching criteria. Allowed values: "All", "AtleastOne", "AtmostOne", "None". Default value: "AtleastOne". This attribute is supported only for resources with "contract_type" with value "provider"
 - `prio` - (Optional) Priority of relation object. Allowed values: "unspecified", "level1", "level2", "level3", "level4", "level5", "level6". Default value: "unspecified".
 
 ## Attribute Reference


### PR DESCRIPTION
$make fmt && make testacc
gofmt -w $(find . -name '*.go' |grep -v vendor)
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?       github.com/terraform-providers/terraform-provider-aci   [no test files]
?       github.com/terraform-providers/terraform-provider-aci/aci       [no test files]
=== RUN   TestAccAciEPGToContractDataSource_Basic
=== STEP  Basic: Testing EPG to Contract data source without Application EPG
=== STEP  Basic: Testing EPG to Contract data source without Contract
=== STEP  Basic: Testing EPG to Contract data source without Contract Type
=== STEP  Basic: Testing EPG to Contract data source
=== STEP  Basic: Testing EPG to Contract data source with Random Attribute
=== STEP  Basic: Testing EPG to Contract data source with updated resource
=== PAUSE TestAccAciEPGToContractDataSource_Basic
=== RUN   TestAccAciL3outOspfInterfaceProfileDataSource_Basic
=== STEP  Basic: testing L3out Ospf Interface Profile reading without giving Logical Interface Profile
=== STEP  Basic: testing contract subject reading without giving name
=== STEP  Basic: L3out Ospf Interface Profile subject data source
=== STEP  Basic: Testing L3out Ospf Interface Profile data source with updated resource
=== STEP  Basic: Testing L3out Ospf Interface Profile data source with updated resource
=== STEP  Basic: testing L3out Ospf Interface Profile reading with Invalid Logical Interface Profile Dn
=== PAUSE TestAccAciL3outOspfInterfaceProfileDataSource_Basic
=== RUN   TestProvider
--- PASS: TestProvider (0.02s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccAciEPGToContract_Basic
=== STEP  Basic: testing epg_to_contract without creating application_epg
=== STEP  Basic: testing epg_to_contract without creating contract
=== STEP  Basic: testing epg_to_contract without passing contract type attribute
=== STEP  Basic: testing EPG to Contract creation with required paramters only
=== STEP  Basic: testing EPG to Contract creation with optional paramters
=== STEP  Basic: testing EPG to Contract creation with Updated Contract
=== STEP  Basic: testing EPG to Contract creation with required paramters only
=== STEP  Basic: testing EPG to Contract creation with Updated Application EPG
=== STEP  Basic: testing EPG to Contract creation with required paramters only
=== STEP  Basic: testing EPG to Contract updation without Required Parameters annotation = v18tl
=== STEP  Basic: testing EPG to Contract creation with required paramters only
=== STEP  Basic: testing EPG to Contract creation with Updated Contract Type
=== STEP  Basic: testing EPG to Contract creation with required paramters only
=== PAUSE TestAccAciEPGToContract_Basic
=== RUN   TestAccAciEPGToContract_Update
=== STEP  Basic: testing EPG to Contract creation with required paramters only
=== STEP  Basic: testing EPG to Contract match_t = All
=== STEP  Basic: testing EPG to Contract match_t = AtmostOne
=== STEP  Basic: testing EPG to Contract match_t = None
=== STEP  Basic: testing EPG to Contract prio = level2
=== STEP  Basic: testing EPG to Contract prio = level3
=== STEP  Basic: testing EPG to Contract prio = level4
=== STEP  Basic: testing EPG to Contract prio = level5
=== STEP  Basic: testing EPG to Contract prio = level6
=== PAUSE TestAccAciEPGToContract_Update
=== RUN   TestAccAciEPGToContract_NegativeCases
=== STEP  Basic: testing EPG to Contract creation with required paramters only
=== STEP  Basic: testing EPG to Contract updation with Invalid application_epg_dn
=== STEP  Basic: testing EPG to Contract updation with Invalid application_epg_dn
=== STEP  Basic: testing EPG to Contract annotation = 28l211k62yluoch0a0fephkddp0yz89fvl0queiibb9tancj1suj7qs6d1aoio69eg7bkm9q2hyhpxfetztf4alr9w2snq1denjquddo8s3tgypbhaaajxseg0cipjtso
=== STEP  Basic: testing EPG to Contract eyrskyvwne = 41nea04pd7
=== STEP  Basic: testing EPG to Contract match_t = 41nea04pd7
=== STEP  Basic: testing EPG to Contract prio = 41nea04pd7
=== STEP  Basic: testing EPG to Contract creation with required paramters only
=== PAUSE TestAccAciEPGToContract_NegativeCases
=== RUN   TestAccAciEPGToContracts_MultipleCreateDelete
=== STEP  creating multiple epg_to_contracts
=== STEP  testing EPG To Contract destroy
--- PASS: TestAccAciEPGToContracts_MultipleCreateDelete (70.12s)
=== RUN   TestAccAciL3outOspfInterfaceProfile_Basic
=== STEP  Basic: testing l3out_ospf_interface_profile creation without  logical_interface_profile_dn
=== STEP  Basic: testing l3out_ospf_interface_profile creation without  auth_key
=== STEP  testing l3out_ospf_interface_profile creation with required arguements only
=== STEP  Basic: testing l3out_ospf_interface_profile creation with optional parameters
=== STEP  testing l3out_ospf_interface_profile creation with required arguements only
=== STEP  testing l3out_ospf_interface_profile updation without required arguements
=== STEP  testing l3out_ospf_interface_profile creation with required arguements only
=== PAUSE TestAccAciL3outOspfInterfaceProfile_Basic
=== RUN   TestAccAciL3outOspfInterfaceProfile_Update
=== STEP  testing l3out_ospf_interface_profile creation with required arguements only
=== STEP  testing l3out_ospf_interface_profile creation with required arguements only
=== STEP  testing l3out_ospf_interface_profile creation with required arguements only
=== PAUSE TestAccAciL3outOspfInterfaceProfile_Update
=== RUN   TestAccAciL3outOspfInterfaceProfile_Negative
=== STEP  testing l3out_ospf_interface_profile creation with required arguements only
=== STEP  Negative Case: testing l3out_ospf_interface_profile creation with invalid parent Dn
=== STEP  testing l3out_ospf_interface_profile creation with required arguements only
=== STEP  testing l3out_ospf_interface_profile creation with required arguements only
=== STEP  testing l3out_ospf_interface_profile creation with required arguements only
=== STEP  testing l3out_ospf_interface_profile creation with required arguements only
=== STEP  testing l3out_ospf_interface_profile creation with required arguements only
=== STEP  testing l3out_ospf_interface_profile creation with required arguements only
=== STEP  testing l3out_ospf_interface_profile creation with required arguements only
=== PAUSE TestAccAciL3outOspfInterfaceProfile_Negative
=== CONT  TestAccAciEPGToContractDataSource_Basic
=== CONT  TestAccAciEPGToContract_NegativeCases
=== CONT  TestAccAciEPGToContract_Basic
=== CONT  TestAccAciL3outOspfInterfaceProfile_Negative
=== CONT  TestAccAciL3outOspfInterfaceProfile_Basic
=== CONT  TestAccAciL3outOspfInterfaceProfileDataSource_Basic
=== CONT  TestAccAciEPGToContract_Update
=== CONT  TestAccAciL3outOspfInterfaceProfile_Update
=== STEP  testing l3out_ospf_interface_profile destroy
--- PASS: TestAccAciL3outOspfInterfaceProfileDataSource_Basic (219.86s)
=== STEP  testing l3out_ospf_interface_profile destroy
--- PASS: TestAccAciL3outOspfInterfaceProfile_Update (236.02s)
=== STEP  testing EPG To Contract destroy
--- PASS: TestAccAciEPGToContractDataSource_Basic (257.44s)
=== STEP  testing EPG To Contract destroy
--- PASS: TestAccAciEPGToContract_NegativeCases (271.07s)
=== STEP  testing l3out_ospf_interface_profile destroy
--- PASS: TestAccAciL3outOspfInterfaceProfile_Negative (290.24s)
=== STEP  testing l3out_ospf_interface_profile destroy
--- PASS: TestAccAciL3outOspfInterfaceProfile_Basic (319.57s)
=== STEP  testing EPG To Contract destroy
--- PASS: TestAccAciEPGToContract_Update (494.83s)
=== STEP  testing EPG To Contract destroy
--- PASS: TestAccAciEPGToContract_Basic (550.04s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   621.317s
