### PR TITLE
Contract

### DIFF
--- a/aci/resource_aci_vzbrcp.go
+++ b/aci/resource_aci_vzbrcp.go
@@ -577,7 +577,11 @@ func setFilterEntryAttributesFromContract(vzentry *models.FilterEntry, d *schema
 	eMap["s_from_port"] = vzEntryMap["sFromPort"]
 	eMap["s_to_port"] = vzEntryMap["sToPort"]
 	eMap["stateful"] = vzEntryMap["stateful"]
-	eMap["tcp_rules"] = vzEntryMap["tcpRules"]
+	if vzEntryMap["tcpRules"] == "" {
+		eMap["tcp_rules"] = "unspecified"
+	} else {
+		eMap["tcp_rules"] = vzEntryMap["tcpRules"]
+	}
 	if v, found := constantPortMapping[vzEntryMap["dFromPort"]]; found {
 		eMap["d_from_port"] = v
 	} else {

--- a/aci/resource_aci_vzbrcp.go
+++ b/aci/resource_aci_vzbrcp.go
@@ -574,8 +574,6 @@ func setFilterEntryAttributesFromContract(vzentry *models.FilterEntry, d *schema
 	eMap["match_dscp"] = vzEntryMap["matchDscp"]
 	eMap["entry_name_alias"] = vzEntryMap["nameAlias"]
 	eMap["prot"] = vzEntryMap["prot"]
-	eMap["s_from_port"] = vzEntryMap["sFromPort"]
-	eMap["s_to_port"] = vzEntryMap["sToPort"]
 	eMap["stateful"] = vzEntryMap["stateful"]
 	if vzEntryMap["tcpRules"] == "" {
 		eMap["tcp_rules"] = "unspecified"
@@ -591,6 +589,16 @@ func setFilterEntryAttributesFromContract(vzentry *models.FilterEntry, d *schema
 		eMap["d_to_port"] = v
 	} else {
 		eMap["d_to_port"] = vzEntryMap["dToPort"]
+	}
+	if v, found := constantPortMapping[vzEntryMap["sFromPort"]]; found {
+		eMap["s_from_port"] = v
+	} else {
+		eMap["s_from_port"] = vzEntryMap["sFromPort"]
+	}
+	if v, found := constantPortMapping[vzEntryMap["sToPort"]]; found {
+		eMap["s_to_port"] = v
+	} else {
+		eMap["s_to_port"] = vzEntryMap["sToPort"]
 	}
 	return eMap, nil
 }

--- a/testacc/data_source_aci_l3extsubnet_test.go
+++ b/testacc/data_source_aci_l3extsubnet_test.go
@@ -136,7 +136,7 @@ func CreateAccL3ExtSubnetDSConfig(fvTenantName, l3extOutName, l3extInstPName, ip
 }
 
 func CreateAccL3ExtSubnetDSUpdateRandomAttr(fvTenantName, l3extOutName, l3extInstPName, ip, attribute, value string) string {
-	fmt.Printf("=== STEP  testing l3_ext_subnet data source creation with %s = %s\n", attribute, value)
+	fmt.Println("=== STEP  testing l3_ext_subnet data source with Random Attribute")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {
@@ -199,7 +199,7 @@ func CreateAccL3ExtSubnetDSWithInvalidParentDn(fvTenantName, l3extOutName, l3ext
 }
 
 func CreateAccL3ExtSubnetDSUpdate(fvTenantName, l3extOutName, l3extInstPName, ip, attribute, value string) string {
-	fmt.Printf("=== STEP  testing l3_ext_subnet data source creation with %s = %s\n", attribute, value)
+	fmt.Println("=== STEP  testing l3_ext_subnet data source with updated resources")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {

--- a/testacc/data_source_aci_vzbrcp_test.go
+++ b/testacc/data_source_aci_vzbrcp_test.go
@@ -1,0 +1,172 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciContractDataSource_Basic(t *testing.T) {
+	resourceName := "aci_contract.test"
+	dataSourceName := "data.aci_contract.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciContractDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateAccContractDSWithoutTenant(rName),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateAccContractDSWithoutName(rName),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccContractDSConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "tenant_dn", resourceName, "tenant_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "prio", resourceName, "prio"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "scope", resourceName, "scope"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "target_dscp", resourceName, "target_dscp"),
+				),
+			},
+			{
+				Config:      CreateAccContractUpdatedConfigDataSourceRandomAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccContractUpdatedConfigDataSource(rName, "description", randomValue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+				),
+			},
+			{
+				Config:      CreateAccContractDataSourceWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+		},
+	})
+}
+
+func CreateAccContractDSWithoutTenant(rName string) string {
+	fmt.Println("=== STEP  Basic: testing contract data source creation without creating tenant")
+	resource := fmt.Sprintf(`
+	data "aci_contract" "test" {
+		name = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccContractDSWithoutName(rName string) string {
+	fmt.Println("=== STEP  Basic: testing contract data source creation without name")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	data "aci_contract" "test" {
+		tenant_dn = aci_contract.test.tenant_dn
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccContractDSConfig(rName string) string {
+	fmt.Println("=== STEP  Basic: testing contract data source creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	data "aci_contract" "test" {
+		tenant_dn = aci_contract.test.tenant_dn
+		name = aci_contract.test.name
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccContractUpdatedConfigDataSourceRandomAttr(rName, key, value string) string {
+	fmt.Println("=== STEP  Basic: testing contract data source creation with random attributes")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	data "aci_contract" "test" {
+		tenant_dn = aci_contract.test.tenant_dn
+		name = aci_contract.test.name
+		%s = "%s"
+	}
+	`, rName, rName, key, value)
+	return resource
+}
+
+func CreateAccContractUpdatedConfigDataSource(rName, key, value string) string {
+	fmt.Println("=== STEP  Basic: testing contract data source with updated resource")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+		%s = "%s"
+	}
+
+	data "aci_contract" "test" {
+		tenant_dn = aci_contract.test.tenant_dn
+		name = aci_contract.test.name
+	}
+	`, rName, rName, key, value)
+	return resource
+}
+
+func CreateAccContractDataSourceWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  Basic: testing contract data source with invalid name")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	data "aci_contract" "test" {
+		tenant_dn = aci_contract.test.tenant_dn
+		name = "${aci_contract.test.name}abc"
+	}
+	`, rName, rName)
+	return resource
+}

--- a/testacc/resource_aci_l3extsubnet_test.go
+++ b/testacc/resource_aci_l3extsubnet_test.go
@@ -680,7 +680,7 @@ func CreateAccL3ExtSubnetConfigWithOptionalValues(fvTenantName, l3extOutName, l3
 }
 
 func CreateAccL3ExtSubnetRemovingRequiredField() string {
-	fmt.Println("=== STEP  Basic: testing l3_ext_subnet creation with optional parameters")
+	fmt.Println("=== STEP  Basic: testing l3_ext_subnet updation without required parameters")
 	resource := fmt.Sprintln(`
 	resource "aci_l3_ext_subnet" "test" {
 		description = "created while acceptance testing"

--- a/testacc/resource_aci_vzbrcp_test.go
+++ b/testacc/resource_aci_vzbrcp_test.go
@@ -1,0 +1,839 @@
+package acctest
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciContract_Basic(t *testing.T) {
+	var contract_default models.Contract
+	var contract_updated models.Contract
+	resourceName := "aci_contract.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rOther := makeTestVariable(acctest.RandString(5))
+	prOther := makeTestVariable(acctest.RandString(5))
+	longrName := acctest.RandString(65)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciContractDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateAccContractWithoutTenant(rName),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateAccContractWithoutName(rName),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccContractConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_default),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "prio", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_graph_att", ""),
+					resource.TestCheckResourceAttr(resourceName, "scope", "context"),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+				),
+			},
+			{
+				Config: CreateAccContractConfigOptional(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "test_annotation"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test_description"),
+					resource.TestCheckResourceAttr(resourceName, "filter.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_alias"),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level1"),
+					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_graph_att", ""),
+					resource.TestCheckResourceAttr(resourceName, "scope", "tenant"),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "CS0"),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccContractRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccContractConfigWithFilterResources(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.annotation", ""),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.description", ""),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.apply_to_frag", "no"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.arp_opc", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_from_port", "0"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_to_port", "0"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.entry_annotation", ""),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.entry_description", ""),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.entry_name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.ether_t", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.filter_entry_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv4_t", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv6_t", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.match_dscp", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.prot", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_from_port", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_to_port", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.stateful", "no"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.tcp_rules", "unspecified"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			// {
+			// 	Config: CreateAccContractConfigWithFilterResourcesOptional(rName),
+			// 	Check: resource.ComposeTestCheckFunc(
+			// 		testAccCheckAciContractExists(resourceName, &contract_updated),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.annotation", "filter_annotation"),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.description", "filter_description"),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_name", rName),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.name_alias", "filter_name_alias"),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.apply_to_frag", "no"),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.arp_opc", "unspecified"),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_from_port", "20"),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_to_port", "20"),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.entry_annotation", ""),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.entry_description", ""),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.entry_name_alias", ""),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.ether_t", "unspecified"),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.filter_entry_name", rName),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv4_t", "unspecified"),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv6_t", "unspecified"),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.match_dscp", "unspecified"),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.prot", "unspecified"),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_from_port", "unspecified"),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_to_port", "unspecified"),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.stateful", "no"),
+			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.tcp_rules", ""),
+			// 		testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+			// 	),
+			// },
+			{
+				Config:      CreateAccContractConfigWithParentAndName(rName, longrName),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("property name of brc-%s failed validation for value '%s'", longrName, longrName)),
+			},
+			{
+				Config: CreateAccContractConfigWithParentAndName(rName, rOther),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rOther),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					testAccCheckAciContrctIdNotEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractConfig(rName),
+			},
+			{
+				Config: CreateAccContractConfigWithParentAndName(prOther, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", prOther)),
+					testAccCheckAciContrctIdNotEqual(&contract_default, &contract_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciContract_Update(t *testing.T) {
+	var contract_default models.Contract
+	var contract_updated models.Contract
+	resourceName := "aci_contract.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciContractDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccContractConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_default),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "prio", "level2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level2"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "prio", "level3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level3"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "prio", "level4"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level4"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "prio", "level5"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level5"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "prio", "level6"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level6"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "scope", "global"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "scope", "global"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "scope", "application-profile"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "scope", "application-profile"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "CS1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "CS1"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF11"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF11"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF12"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF12"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF13"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF13"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "CS2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "CS2"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF21"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF21"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF22"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF22"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF23"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF23"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "CS3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "CS3"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF31"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF31"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF32"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF32"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF33"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF33"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "CS4"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "CS4"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF41"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF41"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF42"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF42"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF43"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF43"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "CS5"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "CS5"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "VA"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "VA"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "EF"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "EF"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "CS6"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "CS6"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "CS7"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "CS7"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciContract_NegativeCases(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	longAnnotationDesc := acctest.RandString(129)
+	longNameAlias := acctest.RandString(65)
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	longrName := acctest.RandString(65)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciContractDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccContractConfig(rName),
+			},
+			{
+				Config:      CreateAccContractWithInValidTenantDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value (.)+, name dn, class vzBrCP (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttr(rName, "description", longAnnotationDesc),
+				ExpectError: regexp.MustCompile(`property descr of (.)+ failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttr(rName, "annotation", longAnnotationDesc),
+				ExpectError: regexp.MustCompile(`property annotation of (.)+ failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttr(rName, "name_alias", longNameAlias),
+				ExpectError: regexp.MustCompile(`property nameAlias of (.)+ failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttr(rName, "prio", randomValue),
+				ExpectError: regexp.MustCompile(`expected prio to be one of (.)+, got (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttr(rName, "target_dscp", randomValue),
+				ExpectError: regexp.MustCompile(`expected target_dscp to be one of (.)+, got (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttr(rName, "scope", randomValue),
+				ExpectError: regexp.MustCompile(`expected scope to be one of (.)+, got (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccContractUpdatedFilterAttr(rName, "description", longAnnotationDesc),
+				ExpectError: regexp.MustCompile(`property descr of (.)+ failed validation for value (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedFilterAttr(rName, "annotation", longAnnotationDesc),
+				ExpectError: regexp.MustCompile(`property annotation of (.)+ failed validation for value (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedFilterAttr(rName, "name_alias", longNameAlias),
+				ExpectError: regexp.MustCompile(`property nameAlias of (.)+ failed validation for value (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedFilterAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`Unsupported argument`),
+			},
+			{
+				Config:      CreateAccContractFilterWithInvalidName(rName, longrName),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("property name of flt-%s failed validation for value '%s'", longrName, longrName)),
+			},
+			{
+				Config: CreateAccContractConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccContract_RelationParameters(t *testing.T) {
+	var contract_default models.Contract
+	var contract_rel1 models.Contract
+	var contract_rel2 models.Contract
+	resourceName := "aci_contract.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	relRes1 := makeTestVariable(acctest.RandString(5))
+	relRes2 := makeTestVariable(acctest.RandString(5))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciContractDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccContractConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_default),
+					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_graph_att", ""),
+				),
+			},
+			{
+				Config: CreateAccContractRelations(rName, relRes1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_rel1),
+					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_graph_att", fmt.Sprintf("uni/tn-%s/AbsGraph-%s", rName, relRes1)),
+					testAccCheckAciContractdEqual(&contract_default, &contract_rel1),
+				),
+			},
+			{
+				Config: CreateAccContractRelations(rName, relRes2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_rel2),
+					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_graph_att", fmt.Sprintf("uni/tn-%s/AbsGraph-%s", rName, relRes2)),
+					testAccCheckAciContractdEqual(&contract_default, &contract_rel2),
+				),
+			},
+			{
+				Config: CreateAccContractConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_graph_att", ""),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccContractRelations(rName, relName string) string {
+	fmt.Printf("=== STEP  testing vrf creation with resource name %s and relation resource name %s\n", rName, relName)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_l4_l7_service_graph_template" "test"{
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_contract" "test"{
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+		relation_vz_rs_graph_att = aci_l4_l7_service_graph_template.test.id
+	}
+	`, rName, relName, rName)
+	return resource
+}
+
+func CreateAccContractFilterWithInvalidName(rName, longrName string) string {
+	fmt.Printf("=== STEP  testing contract's filter creation with name = %s\n", longrName)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test"{
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+		filter{
+			filter_name = "%s"
+		}
+	}
+
+	`, rName, rName, longrName)
+	return resource
+}
+
+func CreateAccContractUpdatedFilterAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing contract's filter with %s = %s\n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test"{
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+		filter{
+			filter_name = "%s"
+			%s = "%s"
+		}
+	}
+
+	`, rName, rName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccContractWithInValidTenantDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing contract creation with invalid tenant_dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_contract" "test"{
+		tenant_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+	`, rName, rName, rName)
+	return resource
+}
+
+func CreateAccContractUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing contract with %s = %s\n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test"{
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+		%s = "%s"
+	}
+
+	`, rName, rName, attribute, value)
+	return resource
+}
+
+// func CreateAccContractConfigWithFilterResourcesOptional(rName string) string {
+// 	fmt.Println("=== STEP  testing contract creation with optional parameters of filter resources")
+// 	resource := fmt.Sprintf(`
+// 	resource "aci_tenant" "test"{
+// 		name = "%s"
+// 	}
+
+// 	resource "aci_contract" "test" {
+// 		tenant_dn = aci_tenant.test.id
+// 		name = "%s"
+// 		filter {
+// 		  filter_name = "%s"
+// 		  annotation = "filter_annotation"
+// 		  description = "filter_description"
+// 		  name_alias = "filter_name_alias"
+// 		  filter_entry {
+// 			filter_entry_name = "%s"
+// 			apply_to_frag = "no"
+// 			arp_opc = "unspecified"
+// 			d_from_port = "ftpData"
+// 			d_to_port = "ftpData"
+// 			entry_annotation = "entry_annotation"
+// 			entry_description = "entry_description"
+// 			entry_name_alias = "entry_name_alias"
+// 			ether_t = "ipv4"
+// 			icmpv4_t = "echo-rep"
+// 			icmpv6_t = "dst-unreach"
+// 			match_dscp = "CS0"
+// 			prot = "tcp"
+// 			stateful = "yes"
+// 			tcp_rules = "est"
+// 		  }
+// 		}
+// 	}
+// 	`, rName, rName, rName, rName)
+// 	return resource
+// }
+
+func CreateAccContractConfigWithParentAndName(prName, rName string) string {
+	fmt.Printf("=== STEP  Basic: testing contract creation with tenant name %s name %s\n", prName, rName)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	`, prName, rName)
+	return resource
+}
+
+func CreateAccContractRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing contract updation without required fields")
+	resource := fmt.Sprintln(`
+	resource "aci_contract" "test" {
+		annotation = "test_annotation"
+		description = "test_description"
+		name_alias = "test_alias"
+		prio = "level1"
+		scope = "tenant"
+		target_dscp = "CS0"
+	}
+	`)
+	return resource
+}
+
+func CreateAccContractConfigWithFilterResources(rName string) string {
+	fmt.Println("=== STEP  testing contract creation with filter resources")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+		filter {
+			filter_name = "%s"
+			filter_entry {
+			  filter_entry_name = "%s"
+			}
+		}
+	}
+	`, rName, rName, rName, rName)
+	return resource
+}
+
+func CreateAccContractConfigOptional(rName string) string {
+	fmt.Println("=== STEP  testing contract creation with optional parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+		annotation = "test_annotation"
+		description = "test_description"
+		name_alias = "test_alias"
+		prio = "level1"
+		scope = "tenant"
+		target_dscp = "CS0"
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccContractConfig(rName string) string {
+	fmt.Println("=== STEP  testing contract creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccContractWithoutName(rName string) string {
+	fmt.Println("=== STEP  Basic: testing contract creation without name")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test" {
+		tenant_dn = aci_tenant.test.id
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccContractWithoutTenant(rName string) string {
+	fmt.Println("=== STEP  Basic: testing contract creation without creating tenant")
+	resource := fmt.Sprintf(`
+	resource "aci_contract" "test" {
+		name = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func testAccCheckAciContractExists(name string, contract *models.Contract) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Contract %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Contract dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		contractFound := models.ContractFromContainer(cont)
+		if contractFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Contract %s not found", rs.Primary.ID)
+		}
+		*contract = *contractFound
+		return nil
+	}
+}
+
+func testAccCheckAciContractDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing contract destroy")
+	client := testAccProvider.Meta().(*client.Client)
+
+	for _, rs := range s.RootModule().Resources {
+
+		if rs.Type == "aci_contract" {
+			cont, err := client.Get(rs.Primary.ID)
+			contract := models.ContractFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Contract %s Still exists", contract.DistinguishedName)
+			}
+
+		} else {
+			continue
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAciContrctIdNotEqual(c1, c2 *models.Contract) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if c1.DistinguishedName == c2.DistinguishedName {
+			return fmt.Errorf("Contract DNs are equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciContractdEqual(c1, c2 *models.Contract) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if c1.DistinguishedName != c2.DistinguishedName {
+			return fmt.Errorf("Contract DNs are not equal")
+		}
+		return nil
+	}
+}

--- a/testacc/resource_aci_vzbrcp_test.go
+++ b/testacc/resource_aci_vzbrcp_test.go
@@ -1,4 +1,4 @@
-package acctest
+package testacc
 
 import (
 	"fmt"
@@ -77,6 +77,14 @@ func TestAccAciContract_Basic(t *testing.T) {
 				ExpectError: regexp.MustCompile(`Missing required argument`),
 			},
 			{
+				Config:      CreateAccContractWithoutRequiredFieldFilter(rName),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateAccContractWithoutRequiredFieldFilterEntry(rName),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
 				Config: CreateAccContractConfigWithFilterResources(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciContractExists(resourceName, &contract_updated),
@@ -97,41 +105,41 @@ func TestAccAciContract_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv6_t", "unspecified"),
 					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.match_dscp", "unspecified"),
 					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.prot", "unspecified"),
-					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_from_port", "unspecified"),
-					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_to_port", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_from_port", "0"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_to_port", "0"),
 					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.stateful", "no"),
 					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.tcp_rules", "unspecified"),
 					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
 				),
 			},
-			// {
-			// 	Config: CreateAccContractConfigWithFilterResourcesOptional(rName),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		testAccCheckAciContractExists(resourceName, &contract_updated),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.annotation", "filter_annotation"),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.description", "filter_description"),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_name", rName),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.name_alias", "filter_name_alias"),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.apply_to_frag", "no"),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.arp_opc", "unspecified"),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_from_port", "20"),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_to_port", "20"),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.entry_annotation", ""),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.entry_description", ""),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.entry_name_alias", ""),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.ether_t", "unspecified"),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.filter_entry_name", rName),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv4_t", "unspecified"),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv6_t", "unspecified"),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.match_dscp", "unspecified"),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.prot", "unspecified"),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_from_port", "unspecified"),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_to_port", "unspecified"),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.stateful", "no"),
-			// 		resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.tcp_rules", ""),
-			// 		testAccCheckAciContractdEqual(&contract_default, &contract_updated),
-			// 	),
-			// },
+			{
+				Config: CreateAccContractConfigWithFilterResourcesOptional(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.annotation", "filter_annotation"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.description", "filter_description"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.name_alias", "filter_name_alias"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.apply_to_frag", "no"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.arp_opc", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_from_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_to_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.entry_annotation", "entry_annotation"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.entry_description", "entry_description"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.entry_name_alias", "entry_name_alias"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.ether_t", "ip"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.filter_entry_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv4_t", "echo-rep"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv6_t", "dst-unreach"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.match_dscp", "CS0"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.prot", "tcp"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_from_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_to_port", "443"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.stateful", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.tcp_rules", "est"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
 			{
 				Config:      CreateAccContractConfigWithParentAndName(rName, longrName),
 				ExpectError: regexp.MustCompile(fmt.Sprintf("property name of brc-%s failed validation for value '%s'", longrName, longrName)),
@@ -250,22 +258,6 @@ func TestAccAciContract_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF12"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciContractExists(resourceName, &contract_updated),
-					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF12"),
-					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
-				),
-			},
-			{
-				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF13"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciContractExists(resourceName, &contract_updated),
-					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF13"),
-					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
-				),
-			},
-			{
 				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "CS2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciContractExists(resourceName, &contract_updated),
@@ -278,94 +270,6 @@ func TestAccAciContract_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciContractExists(resourceName, &contract_updated),
 					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF21"),
-					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
-				),
-			},
-			{
-				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF22"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciContractExists(resourceName, &contract_updated),
-					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF22"),
-					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
-				),
-			},
-			{
-				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF23"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciContractExists(resourceName, &contract_updated),
-					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF23"),
-					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
-				),
-			},
-			{
-				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "CS3"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciContractExists(resourceName, &contract_updated),
-					resource.TestCheckResourceAttr(resourceName, "target_dscp", "CS3"),
-					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
-				),
-			},
-			{
-				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF31"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciContractExists(resourceName, &contract_updated),
-					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF31"),
-					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
-				),
-			},
-			{
-				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF32"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciContractExists(resourceName, &contract_updated),
-					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF32"),
-					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
-				),
-			},
-			{
-				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF33"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciContractExists(resourceName, &contract_updated),
-					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF33"),
-					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
-				),
-			},
-			{
-				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "CS4"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciContractExists(resourceName, &contract_updated),
-					resource.TestCheckResourceAttr(resourceName, "target_dscp", "CS4"),
-					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
-				),
-			},
-			{
-				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF41"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciContractExists(resourceName, &contract_updated),
-					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF41"),
-					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
-				),
-			},
-			{
-				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF42"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciContractExists(resourceName, &contract_updated),
-					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF42"),
-					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
-				),
-			},
-			{
-				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "AF43"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciContractExists(resourceName, &contract_updated),
-					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF43"),
-					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
-				),
-			},
-			{
-				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "CS5"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciContractExists(resourceName, &contract_updated),
-					resource.TestCheckResourceAttr(resourceName, "target_dscp", "CS5"),
 					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
 				),
 			},
@@ -386,18 +290,401 @@ func TestAccAciContract_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "CS6"),
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "ether_t", "ip"),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "apply_to_frag", "yes"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciContractExists(resourceName, &contract_updated),
-					resource.TestCheckResourceAttr(resourceName, "target_dscp", "CS6"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.apply_to_frag", "yes"),
 					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
 				),
 			},
 			{
-				Config: CreateAccContractUpdatedAttr(rName, "target_dscp", "CS7"),
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "apply_to_frag", "no"),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "ether_t", "arp"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciContractExists(resourceName, &contract_updated),
-					resource.TestCheckResourceAttr(resourceName, "target_dscp", "CS7"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.ether_t", "arp"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "arp_opc", "req"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.arp_opc", "req"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "arp_opc", "reply"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.arp_opc", "reply"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "arp_opc", "reply"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.arp_opc", "reply"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "arp_opc", "unspecified"),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "ether_t", "ipv4"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.ether_t", "ipv4"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "ether_t", "trill"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.ether_t", "trill"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "ether_t", "mpls_ucast"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.ether_t", "mpls_ucast"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "ether_t", "mac_security"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.ether_t", "mac_security"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "ether_t", "fcoe"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.ether_t", "fcoe"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "ether_t", "ipv6"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.ether_t", "ipv6"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "icmpv4_t", "dst-unreach"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv4_t", "dst-unreach"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "icmpv4_t", "echo"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv4_t", "echo"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "icmpv4_t", "time-exceeded"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv4_t", "time-exceeded"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "icmpv4_t", "src-quench"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv4_t", "src-quench"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "icmpv6_t", "time-exceeded"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv6_t", "time-exceeded"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "icmpv6_t", "echo-req"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv6_t", "echo-req"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "icmpv6_t", "echo-rep"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv6_t", "echo-rep"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "icmpv6_t", "nbr-solicit"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv6_t", "nbr-solicit"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "icmpv6_t", "nbr-advert"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv6_t", "nbr-advert"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "icmpv6_t", "redirect"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.icmpv6_t", "redirect"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "match_dscp", "CS1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.match_dscp", "CS1"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "match_dscp", "AF11"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.match_dscp", "AF11"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "match_dscp", "CS2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.match_dscp", "CS2"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "match_dscp", "AF21"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.match_dscp", "AF21"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "match_dscp", "VA"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.match_dscp", "VA"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "match_dscp", "EF"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.match_dscp", "EF"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "prot", "icmp"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.prot", "icmp"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "prot", "igmp"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.prot", "igmp"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "prot", "egp"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.prot", "egp"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "prot", "igp"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.prot", "igp"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "prot", "icmpv6"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.prot", "icmpv6"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "prot", "eigrp"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.prot", "eigrp"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "prot", "ospfigp"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.prot", "ospfigp"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "prot", "pim"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.prot", "pim"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "prot", "l2tp"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.prot", "l2tp"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "prot", "tcp"),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "tcp_rules", "syn"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.tcp_rules", "syn"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "tcp_rules", "ack"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.tcp_rules", "ack"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "tcp_rules", "fin"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.tcp_rules", "fin"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "tcp_rules", "rst"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.tcp_rules", "rst"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntryForPortAttr(rName, "ftpData"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.prot", "udp"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_from_port", "20"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_to_port", "20"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_from_port", "20"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_to_port", "20"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntryForPortAttr(rName, "smtp"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_from_port", "25"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_to_port", "25"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_from_port", "25"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_to_port", "25"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntryForPortAttr(rName, "dns"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_from_port", "53"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_to_port", "53"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_from_port", "53"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_to_port", "53"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntryForPortAttr(rName, "http"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_from_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_to_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_from_port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_to_port", "80"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntryForPortAttr(rName, "pop3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_from_port", "110"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_to_port", "110"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_from_port", "110"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_to_port", "110"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntryForPortAttr(rName, "rtsp"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_from_port", "554"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_to_port", "554"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_from_port", "554"),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_to_port", "554"),
 					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
 				),
 			},
@@ -473,76 +760,161 @@ func TestAccAciContract_NegativeCases(t *testing.T) {
 				ExpectError: regexp.MustCompile(fmt.Sprintf("property name of flt-%s failed validation for value '%s'", longrName, longrName)),
 			},
 			{
+				Config:      CreateAccContractFilterEntryWithInvalidName(rName, longrName),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("property name of e-%s failed validation for value '%s'", longrName, longrName)),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "entry_annotation", longAnnotationDesc),
+				ExpectError: regexp.MustCompile(`property annotation of (.)+ failed validation for value (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "entry_description", longAnnotationDesc),
+				ExpectError: regexp.MustCompile(`property descr of (.)+ failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "entry_name_alias", longNameAlias),
+				ExpectError: regexp.MustCompile(`property nameAlias of (.)+ failed validation for value (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "apply_to_frag", randomValue),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "arp_opc", randomValue),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "ether_t", randomValue),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "icmpv4_t", randomValue),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "icmpv6_t", randomValue),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "match_dscp", randomValue),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "prot", randomValue),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "stateful", randomValue),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "tcp_rules", randomValue),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got (.)+`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`Unsupported argument`),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "ether_t", "ip"),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "prot", "tcp"),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "d_from_port", "65536"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "d_to_port", "65536"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "s_from_port", "65536"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "s_to_port", "65536"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "arp_opc", "req"),
+				ExpectError: regexp.MustCompile(`ArpOpcode cannot be combined with non arp Ethertype`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "arp_opc", "reply"),
+				ExpectError: regexp.MustCompile(`ArpOpcode cannot be combined with non arp Ethertype`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "apply_to_frag", "yes"),
+				ExpectError: regexp.MustCompile(`non-IP Ethertype cannot be combined with other l4 properties`),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "prot", "unspecified"),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "d_from_port", "http"),
+				ExpectError: regexp.MustCompile(`non-IP Ethertype cannot be combined with other l4 properties`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "d_to_port", "http"),
+				ExpectError: regexp.MustCompile(`non-IP Ethertype cannot be combined with other l4 properties`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "s_from_port", "http"),
+				ExpectError: regexp.MustCompile(`non-IP Ethertype cannot be combined with other l4 properties`),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "s_to_port", "http"),
+				ExpectError: regexp.MustCompile(`non-IP Ethertype cannot be combined with other l4 properties`),
+			},
+			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "ether_t", "unspecified"),
+			},
+			{
+				Config:      CreateAccContractUpdatedAttrFilterEntry(rName, "tcp_rules", "est"),
+				ExpectError: regexp.MustCompile(`non-IP Ethertype cannot be combined with other l4 properties`),
+			},
+			{
 				Config: CreateAccContractConfig(rName),
 			},
 		},
 	})
 }
 
-func TestAccContract_RelationParameters(t *testing.T) {
-	var contract_default models.Contract
-	var contract_rel1 models.Contract
-	var contract_rel2 models.Contract
-	resourceName := "aci_contract.test"
+func TestAccAciContract_MultipleCreateDestroy(t *testing.T) {
 	rName := makeTestVariable(acctest.RandString(5))
-	relRes1 := makeTestVariable(acctest.RandString(5))
-	relRes2 := makeTestVariable(acctest.RandString(5))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAciContractDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: CreateAccContractConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciContractExists(resourceName, &contract_default),
-					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_graph_att", ""),
-				),
-			},
-			{
-				Config: CreateAccContractRelations(rName, relRes1),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciContractExists(resourceName, &contract_rel1),
-					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_graph_att", fmt.Sprintf("uni/tn-%s/AbsGraph-%s", rName, relRes1)),
-					testAccCheckAciContractdEqual(&contract_default, &contract_rel1),
-				),
-			},
-			{
-				Config: CreateAccContractRelations(rName, relRes2),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciContractExists(resourceName, &contract_rel2),
-					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_graph_att", fmt.Sprintf("uni/tn-%s/AbsGraph-%s", rName, relRes2)),
-					testAccCheckAciContractdEqual(&contract_default, &contract_rel2),
-				),
-			},
-			{
-				Config: CreateAccContractConfig(rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "relation_vz_rs_graph_att", ""),
-				),
+				Config: CreateAccContractConfigMultiple(rName),
 			},
 		},
 	})
 }
 
-func CreateAccContractRelations(rName, relName string) string {
-	fmt.Printf("=== STEP  testing vrf creation with resource name %s and relation resource name %s\n", rName, relName)
+func CreateAccContractFilterEntryWithInvalidName(rName, longrName string) string {
+	fmt.Printf("=== STEP  testing contract's filter_entry creation with name = %s\n", longrName)
 	resource := fmt.Sprintf(`
-	resource "aci_tenant" "test" {
-		name = "%s"
-	}
-
-	resource "aci_l4_l7_service_graph_template" "test"{
-		tenant_dn = aci_tenant.test.id
+	resource "aci_tenant" "test"{
 		name = "%s"
 	}
 
 	resource "aci_contract" "test"{
 		tenant_dn = aci_tenant.test.id
 		name = "%s"
-		relation_vz_rs_graph_att = aci_l4_l7_service_graph_template.test.id
+		filter{
+			filter_name = "%s"
+			filter_entry{
+				filter_entry_name = "%s"
+			}
+		}
 	}
-	`, rName, relName, rName)
+
+	`, rName, rName, rName, longrName)
 	return resource
 }
 
@@ -605,6 +977,56 @@ func CreateAccContractWithInValidTenantDn(rName string) string {
 	return resource
 }
 
+func CreateAccContractUpdatedAttrFilterEntryForPortAttr(rName, value string) string {
+	fmt.Printf("=== STEP  testing contract by updating filter_entry ports %s\n", value)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test"{
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+		filter {
+			filter_name = "%s"
+			filter_entry {
+				filter_entry_name = "%s"
+				prot = "udp"
+				d_from_port = "%s"
+				d_to_port = "%s"
+				s_from_port = "%s"
+				s_to_port = "%s"
+			}
+		}
+	}
+
+	`, rName, rName, rName, rName, value, value, value, value)
+	return resource
+}
+
+func CreateAccContractUpdatedAttrFilterEntry(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing contract by updating filter_entry attribute with %s = %s\n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test"{
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+		filter {
+			filter_name = "%s"
+			filter_entry {
+				filter_entry_name = "%s"
+				%s = "%s"
+			}
+		}
+	}
+
+	`, rName, rName, rName, rName, attribute, value)
+	return resource
+}
+
 func CreateAccContractUpdatedAttr(rName, attribute, value string) string {
 	fmt.Printf("=== STEP  testing contract with %s = %s\n", attribute, value)
 	resource := fmt.Sprintf(`
@@ -622,43 +1044,45 @@ func CreateAccContractUpdatedAttr(rName, attribute, value string) string {
 	return resource
 }
 
-// func CreateAccContractConfigWithFilterResourcesOptional(rName string) string {
-// 	fmt.Println("=== STEP  testing contract creation with optional parameters of filter resources")
-// 	resource := fmt.Sprintf(`
-// 	resource "aci_tenant" "test"{
-// 		name = "%s"
-// 	}
+func CreateAccContractConfigWithFilterResourcesOptional(rName string) string {
+	fmt.Println("=== STEP  testing contract creation with optional parameters of filter resources")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
 
-// 	resource "aci_contract" "test" {
-// 		tenant_dn = aci_tenant.test.id
-// 		name = "%s"
-// 		filter {
-// 		  filter_name = "%s"
-// 		  annotation = "filter_annotation"
-// 		  description = "filter_description"
-// 		  name_alias = "filter_name_alias"
-// 		  filter_entry {
-// 			filter_entry_name = "%s"
-// 			apply_to_frag = "no"
-// 			arp_opc = "unspecified"
-// 			d_from_port = "ftpData"
-// 			d_to_port = "ftpData"
-// 			entry_annotation = "entry_annotation"
-// 			entry_description = "entry_description"
-// 			entry_name_alias = "entry_name_alias"
-// 			ether_t = "ipv4"
-// 			icmpv4_t = "echo-rep"
-// 			icmpv6_t = "dst-unreach"
-// 			match_dscp = "CS0"
-// 			prot = "tcp"
-// 			stateful = "yes"
-// 			tcp_rules = "est"
-// 		  }
-// 		}
-// 	}
-// 	`, rName, rName, rName, rName)
-// 	return resource
-// }
+	resource "aci_contract" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+		filter {
+		  filter_name = "%s"
+		  annotation = "filter_annotation"
+		  description = "filter_description"
+		  name_alias = "filter_name_alias"
+		  filter_entry {
+			filter_entry_name = "%s"
+			apply_to_frag = "no"
+			arp_opc = "unspecified"
+			d_from_port = "https"
+			d_to_port = "https"
+			entry_annotation = "entry_annotation"
+			entry_description = "entry_description"
+			entry_name_alias = "entry_name_alias"
+			ether_t = "ip"
+			icmpv4_t = "echo-rep"
+			icmpv6_t = "dst-unreach"
+			match_dscp = "CS0"
+			prot = "tcp"
+			s_from_port = "https"
+			s_to_port = "https"
+			stateful = "yes"
+			tcp_rules = "est"
+		  }
+		}
+	}
+	`, rName, rName, rName, rName)
+	return resource
+}
 
 func CreateAccContractConfigWithParentAndName(prName, rName string) string {
 	fmt.Printf("=== STEP  Basic: testing contract creation with tenant name %s name %s\n", prName, rName)
@@ -744,6 +1168,66 @@ func CreateAccContractConfig(rName string) string {
 		name = "%s"
 	}
 	`, rName, rName)
+	return resource
+}
+
+func CreateAccContractConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple contract creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test1" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_contract" "test2" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_contract" "test3" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	`, rName, rName+"1", rName+"2", rName+"3")
+	return resource
+}
+
+func CreateAccContractWithoutRequiredFieldFilterEntry(rName string) string {
+	fmt.Println("=== STEP  Basic: testing contract's filter_entry without required parameter")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test" {
+		tenant_dn = aci_tenant.test.id
+		filter{
+			filter_name = "%s"
+			filter_entry{
+
+			}
+		}
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccContractWithoutRequiredFieldFilter(rName string) string {
+	fmt.Println("=== STEP  Basic: testing contract's filter without required parameter")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_contract" "test" {
+		tenant_dn = aci_tenant.test.id
+		filter{}
+	}
+	`, rName)
 	return resource
 }
 

--- a/testacc/resource_aci_vzbrcp_test.go
+++ b/testacc/resource_aci_vzbrcp_test.go
@@ -328,14 +328,6 @@ func TestAccAciContract_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "arp_opc", "reply"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciContractExists(resourceName, &contract_updated),
-					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.arp_opc", "reply"),
-					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
-				),
-			},
-			{
 				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "arp_opc", "unspecified"),
 			},
 			{
@@ -587,6 +579,14 @@ func TestAccAciContract_Update(t *testing.T) {
 				),
 			},
 			{
+				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "prot", "udp"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciContractExists(resourceName, &contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.prot", "udp"),
+					testAccCheckAciContractdEqual(&contract_default, &contract_updated),
+				),
+			},
+			{
 				Config: CreateAccContractUpdatedAttrFilterEntry(rName, "prot", "tcp"),
 			},
 			{
@@ -625,7 +625,6 @@ func TestAccAciContract_Update(t *testing.T) {
 				Config: CreateAccContractUpdatedAttrFilterEntryForPortAttr(rName, "ftpData"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciContractExists(resourceName, &contract_updated),
-					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.prot", "udp"),
 					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_from_port", "20"),
 					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.d_to_port", "20"),
 					resource.TestCheckResourceAttr(resourceName, "filter.0.filter_entry.0.s_from_port", "20"),
@@ -938,7 +937,7 @@ func CreateAccContractFilterWithInvalidName(rName, longrName string) string {
 }
 
 func CreateAccContractUpdatedFilterAttr(rName, attribute, value string) string {
-	fmt.Printf("=== STEP  testing contract's filter with %s = %s\n", attribute, value)
+	fmt.Printf("=== STEP  testing contract's filter updation with %s = %s\n", attribute, value)
 	resource := fmt.Sprintf(`
 	resource "aci_tenant" "test"{
 		name = "%s"
@@ -991,7 +990,7 @@ func CreateAccContractUpdatedAttrFilterEntryForPortAttr(rName, value string) str
 			filter_name = "%s"
 			filter_entry {
 				filter_entry_name = "%s"
-				prot = "udp"
+				prot = "tcp"
 				d_from_port = "%s"
 				d_to_port = "%s"
 				s_from_port = "%s"
@@ -1005,7 +1004,7 @@ func CreateAccContractUpdatedAttrFilterEntryForPortAttr(rName, value string) str
 }
 
 func CreateAccContractUpdatedAttrFilterEntry(rName, attribute, value string) string {
-	fmt.Printf("=== STEP  testing contract by updating filter_entry attribute with %s = %s\n", attribute, value)
+	fmt.Printf("=== STEP  testing contract by updating filter_entry's attribute with %s = %s\n", attribute, value)
 	resource := fmt.Sprintf(`
 	resource "aci_tenant" "test"{
 		name = "%s"
@@ -1028,7 +1027,7 @@ func CreateAccContractUpdatedAttrFilterEntry(rName, attribute, value string) str
 }
 
 func CreateAccContractUpdatedAttr(rName, attribute, value string) string {
-	fmt.Printf("=== STEP  testing contract with %s = %s\n", attribute, value)
+	fmt.Printf("=== STEP  testing contract updation with %s = %s\n", attribute, value)
 	resource := fmt.Sprintf(`
 	resource "aci_tenant" "test"{
 		name = "%s"
@@ -1103,7 +1102,7 @@ func CreateAccContractRemovingRequiredField() string {
 	fmt.Println("=== STEP  Basic: testing contract updation without required fields")
 	resource := fmt.Sprintln(`
 	resource "aci_contract" "test" {
-		annotation = "test_annotation"
+		annotation = "tag"
 		description = "test_description"
 		name_alias = "test_alias"
 		prio = "level1"

--- a/website/docs/r/l3_ext_subnet.html.markdown
+++ b/website/docs/r/l3_ext_subnet.html.markdown
@@ -39,8 +39,6 @@ Manages ACI l3 extension subnet
 
 ```
 
-## Argument Reference
-
 ## Argument Reference ##
 * `external_network_instance_profile_dn` - (Required) Distinguished name of parent ExternalNetworkInstanceProfile object.
 * `ip` - (Required) ip of Object l3 extension subnet.


### PR DESCRIPTION
$ make fmt && make testacc
gofmt -w $(find . -name '*.go' |grep -v vendor)
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?       github.com/terraform-providers/terraform-provider-aci   [no test files]
?       github.com/terraform-providers/terraform-provider-aci/aci       [no test files]
=== RUN   TestAccAciContractDataSource_Basic
=== STEP  Basic: testing contract data source creation without creating tenant
=== STEP  Basic: testing contract data source creation without name
=== STEP  Basic: testing contract data source creation with required arguments only
=== STEP  Basic: testing contract data source creation with random attributes
=== STEP  Basic: testing contract data source with updated resource
=== STEP  Basic: testing contract data source with invalid name
=== STEP  testing contract destroy
--- PASS: TestAccAciContractDataSource_Basic (43.24s)
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccAciContract_Basic
=== STEP  Basic: testing contract creation without creating tenant
=== STEP  Basic: testing contract creation without name
=== STEP  testing contract creation with required arguments only
=== STEP  testing contract creation with optional parameters
=== STEP  Basic: testing contract updation without required fields
=== STEP  Basic: testing contract's filter without required parameter
=== STEP  Basic: testing contract's filter_entry without required parameter
=== STEP  testing contract creation with filter resources
=== STEP  testing contract creation with optional parameters of filter resources
=== STEP  Basic: testing contract creation with tenant name acctest_su0gz name 4kexoc0fmia3wpx12ptjqrv03yuk3bk2pvje8j6hr7zzx1fi7ci9vbyrg6znx0h2s
=== STEP  Basic: testing contract creation with tenant name acctest_su0gz name acctest_xt6qj
=== STEP  testing contract creation with required arguments only
=== STEP  Basic: testing contract creation with tenant name acctest_dyduk name acctest_su0gz
=== STEP  testing contract destroy
--- PASS: TestAccAciContract_Basic (102.06s)
=== RUN   TestAccAciContract_Update
=== STEP  testing contract creation with required arguments only
=== STEP  testing contract updation with prio = level2
=== STEP  testing contract updation with prio = level3
=== STEP  testing contract updation with prio = level4
=== STEP  testing contract updation with prio = level5
=== STEP  testing contract updation with prio = level6
=== STEP  testing contract updation with scope = global
=== STEP  testing contract updation with scope = application-profile
=== STEP  testing contract updation with target_dscp = CS1
=== STEP  testing contract updation with target_dscp = AF11
=== STEP  testing contract updation with target_dscp = CS2
=== STEP  testing contract updation with target_dscp = AF21
=== STEP  testing contract updation with target_dscp = VA
=== STEP  testing contract updation with target_dscp = EF
=== STEP  testing contract by updating filter_entry's attribute with ether_t = ip
=== STEP  testing contract by updating filter_entry's attribute with apply_to_frag = yes
=== STEP  testing contract by updating filter_entry's attribute with apply_to_frag = no
=== STEP  testing contract by updating filter_entry's attribute with ether_t = arp
=== STEP  testing contract by updating filter_entry's attribute with arp_opc = req
=== STEP  testing contract by updating filter_entry's attribute with arp_opc = reply
=== STEP  testing contract by updating filter_entry's attribute with arp_opc = unspecified
=== STEP  testing contract by updating filter_entry's attribute with ether_t = ipv4
=== STEP  testing contract by updating filter_entry's attribute with ether_t = trill
=== STEP  testing contract by updating filter_entry's attribute with ether_t = mpls_ucast
=== STEP  testing contract by updating filter_entry's attribute with ether_t = mac_security
=== STEP  testing contract by updating filter_entry's attribute with ether_t = fcoe
=== STEP  testing contract by updating filter_entry's attribute with ether_t = ipv6
=== STEP  testing contract by updating filter_entry's attribute with icmpv4_t = dst-unreach
=== STEP  testing contract by updating filter_entry's attribute with icmpv4_t = echo
=== STEP  testing contract by updating filter_entry's attribute with icmpv4_t = time-exceeded
=== STEP  testing contract by updating filter_entry's attribute with icmpv4_t = src-quench
=== STEP  testing contract by updating filter_entry's attribute with icmpv6_t = time-exceeded
=== STEP  testing contract by updating filter_entry's attribute with icmpv6_t = echo-req
=== STEP  testing contract by updating filter_entry's attribute with icmpv6_t = echo-rep
=== STEP  testing contract by updating filter_entry's attribute with icmpv6_t = nbr-solicit
=== STEP  testing contract by updating filter_entry's attribute with icmpv6_t = nbr-advert
=== STEP  testing contract by updating filter_entry's attribute with icmpv6_t = redirect
=== STEP  testing contract by updating filter_entry's attribute with match_dscp = CS1
=== STEP  testing contract by updating filter_entry's attribute with match_dscp = AF11
=== STEP  testing contract by updating filter_entry's attribute with match_dscp = CS2
=== STEP  testing contract by updating filter_entry's attribute with match_dscp = AF21
=== STEP  testing contract by updating filter_entry's attribute with match_dscp = VA
=== STEP  testing contract by updating filter_entry's attribute with match_dscp = EF
=== STEP  testing contract by updating filter_entry's attribute with prot = icmp
=== STEP  testing contract by updating filter_entry's attribute with prot = igmp
=== STEP  testing contract by updating filter_entry's attribute with prot = egp
=== STEP  testing contract by updating filter_entry's attribute with prot = igp
=== STEP  testing contract by updating filter_entry's attribute with prot = icmpv6
=== STEP  testing contract by updating filter_entry's attribute with prot = eigrp
=== STEP  testing contract by updating filter_entry's attribute with prot = ospfigp
=== STEP  testing contract by updating filter_entry's attribute with prot = pim
=== STEP  testing contract by updating filter_entry's attribute with prot = l2tp
=== STEP  testing contract by updating filter_entry's attribute with prot = udp
=== STEP  testing contract by updating filter_entry's attribute with prot = tcp
=== STEP  testing contract by updating filter_entry's attribute with tcp_rules = syn
=== STEP  testing contract by updating filter_entry's attribute with tcp_rules = ack
=== STEP  testing contract by updating filter_entry's attribute with tcp_rules = fin
=== STEP  testing contract by updating filter_entry's attribute with tcp_rules = rst
=== STEP  testing contract by updating filter_entry ports ftpData
=== STEP  testing contract by updating filter_entry ports smtp
=== STEP  testing contract by updating filter_entry ports dns
=== STEP  testing contract by updating filter_entry ports http
=== STEP  testing contract by updating filter_entry ports pop3
=== STEP  testing contract by updating filter_entry ports rtsp
=== PAUSE TestAccAciContract_Update
=== RUN   TestAccAciContract_NegativeCases
=== STEP  testing contract creation with required arguments only
=== STEP  Negative Case: testing contract creation with invalid tenant_dn
=== STEP  testing contract updation with description = yfjdwmj2pnx06zqbyzp14rl9l9e4m7pkyq1gblwchtampdjbtmoxc9o2zolsch8vjevpi4vao9y8znxxf6s41qwxv19lhexpiilg0tag4v884di0wa7e36r9313r66bco
=== STEP  testing contract updation with annotation = yfjdwmj2pnx06zqbyzp14rl9l9e4m7pkyq1gblwchtampdjbtmoxc9o2zolsch8vjevpi4vao9y8znxxf6s41qwxv19lhexpiilg0tag4v884di0wa7e36r9313r66bco
=== STEP  testing contract updation with name_alias = 8m8wpfd2g4c3qotihe23k6fuizwxfiem1w9cpeugwyqttgrl81rjjdjbg0rmggjpr
=== STEP  testing contract updation with prio = 9fnzq
=== STEP  testing contract updation with target_dscp = 9fnzq
=== STEP  testing contract updation with scope = 9fnzq
=== STEP  testing contract updation with bixix = 9fnzq
=== STEP  testing contract's filter updation with description = yfjdwmj2pnx06zqbyzp14rl9l9e4m7pkyq1gblwchtampdjbtmoxc9o2zolsch8vjevpi4vao9y8znxxf6s41qwxv19lhexpiilg0tag4v884di0wa7e36r9313r66bco
=== STEP  testing contract's filter updation with annotation = yfjdwmj2pnx06zqbyzp14rl9l9e4m7pkyq1gblwchtampdjbtmoxc9o2zolsch8vjevpi4vao9y8znxxf6s41qwxv19lhexpiilg0tag4v884di0wa7e36r9313r66bco
=== STEP  testing contract's filter updation with name_alias = 8m8wpfd2g4c3qotihe23k6fuizwxfiem1w9cpeugwyqttgrl81rjjdjbg0rmggjpr
=== STEP  testing contract's filter updation with bixix = 9fnzq
=== STEP  testing contract's filter creation with name = qjmzhg8kssn6s9zgchbzk4age8j7s9csqhfmb2446i7li88kd6v2s3r66iw4csc3l
=== STEP  testing contract's filter_entry creation with name = qjmzhg8kssn6s9zgchbzk4age8j7s9csqhfmb2446i7li88kd6v2s3r66iw4csc3l
=== STEP  testing contract by updating filter_entry's attribute with entry_annotation = yfjdwmj2pnx06zqbyzp14rl9l9e4m7pkyq1gblwchtampdjbtmoxc9o2zolsch8vjevpi4vao9y8znxxf6s41qwxv19lhexpiilg0tag4v884di0wa7e36r9313r66bco
=== STEP  testing contract by updating filter_entry's attribute with entry_description = yfjdwmj2pnx06zqbyzp14rl9l9e4m7pkyq1gblwchtampdjbtmoxc9o2zolsch8vjevpi4vao9y8znxxf6s41qwxv19lhexpiilg0tag4v884di0wa7e36r9313r66bco
=== STEP  testing contract by updating filter_entry's attribute with entry_name_alias = 8m8wpfd2g4c3qotihe23k6fuizwxfiem1w9cpeugwyqttgrl81rjjdjbg0rmggjpr
=== STEP  testing contract by updating filter_entry's attribute with apply_to_frag = 9fnzq
=== STEP  testing contract by updating filter_entry's attribute with arp_opc = 9fnzq
=== STEP  testing contract by updating filter_entry's attribute with ether_t = 9fnzq
=== STEP  testing contract by updating filter_entry's attribute with icmpv4_t = 9fnzq
=== STEP  testing contract by updating filter_entry's attribute with icmpv6_t = 9fnzq
=== STEP  testing contract by updating filter_entry's attribute with match_dscp = 9fnzq
=== STEP  testing contract by updating filter_entry's attribute with prot = 9fnzq
=== STEP  testing contract by updating filter_entry's attribute with stateful = 9fnzq
=== STEP  testing contract by updating filter_entry's attribute with tcp_rules = 9fnzq
=== STEP  testing contract by updating filter_entry's attribute with bixix = 9fnzq
=== STEP  testing contract by updating filter_entry's attribute with ether_t = ip
=== STEP  testing contract by updating filter_entry's attribute with prot = tcp
=== STEP  testing contract by updating filter_entry's attribute with d_from_port = 65536
=== STEP  testing contract by updating filter_entry's attribute with d_to_port = 65536
=== STEP  testing contract by updating filter_entry's attribute with s_from_port = 65536
=== STEP  testing contract by updating filter_entry's attribute with s_to_port = 65536
=== STEP  testing contract by updating filter_entry's attribute with arp_opc = req
=== STEP  testing contract by updating filter_entry's attribute with arp_opc = reply
=== STEP  testing contract by updating filter_entry's attribute with apply_to_frag = yes
=== STEP  testing contract by updating filter_entry's attribute with prot = unspecified
=== STEP  testing contract by updating filter_entry's attribute with d_from_port = http
=== STEP  testing contract by updating filter_entry's attribute with d_to_port = http
=== STEP  testing contract by updating filter_entry's attribute with s_from_port = http
=== STEP  testing contract by updating filter_entry's attribute with s_to_port = http
=== STEP  testing contract by updating filter_entry's attribute with ether_t = unspecified
=== STEP  testing contract by updating filter_entry's attribute with tcp_rules = est
=== STEP  testing contract creation with required arguments only
=== PAUSE TestAccAciContract_NegativeCases
=== RUN   TestAccAciContract_MultipleCreateDestroy
=== STEP  testing multiple contract creation with required arguments only
=== STEP  testing contract destroy
--- PASS: TestAccAciContract_MultipleCreateDestroy (14.02s)
=== CONT  TestAccAciContract_Update
=== CONT  TestAccAciContract_NegativeCases
=== STEP  testing contract destroy
--- PASS: TestAccAciContract_NegativeCases (241.43s)
=== STEP  testing contract destroy
--- PASS: TestAccAciContract_Update (832.81s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   992.866s
