### PR TITLE
Added test support for hsrp interface policy and updated epg to contr…

### DIFF
--- a/aci/resource_aci_hsrpifpol.go
+++ b/aci/resource_aci_hsrpifpol.go
@@ -123,7 +123,6 @@ func resourceAciHSRPInterfacePolicyImport(d *schema.ResourceData, m interface{})
 	if err != nil {
 		return nil, err
 	}
-	fmt.Sprintf("%s", hsrpIfPol.Name)
 	d.Set("tenant_dn", GetParentDn(dn, fmt.Sprintf("/hsrpIfPol-%s", hsrpIfPol.Name)))
 	log.Printf("[DEBUG] %s: Import finished successfully", d.Id())
 

--- a/aci/resource_aci_hsrpifpol.go
+++ b/aci/resource_aci_hsrpifpol.go
@@ -115,7 +115,6 @@ func resourceAciHSRPInterfacePolicyImport(d *schema.ResourceData, m interface{})
 	dn := d.Id()
 
 	hsrpIfPol, err := getRemoteHSRPInterfacePolicy(aciClient, dn)
-
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +123,8 @@ func resourceAciHSRPInterfacePolicyImport(d *schema.ResourceData, m interface{})
 	if err != nil {
 		return nil, err
 	}
-
+	fmt.Sprintf("%s", hsrpIfPol.Name)
+	d.Set("tenant_dn", GetParentDn(dn, fmt.Sprintf("/hsrpIfPol-%s", hsrpIfPol.Name)))
 	log.Printf("[DEBUG] %s: Import finished successfully", d.Id())
 
 	return []*schema.ResourceData{schemaFilled}, nil

--- a/testacc/data_source_aci_hsrpifpol_test.go
+++ b/testacc/data_source_aci_hsrpifpol_test.go
@@ -1,0 +1,182 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciHsrpInterfacePolicyDataSource_Basic(t *testing.T) {
+	resourceName := "aci_hsrp_interface_policy.test"
+	dataSourceName := "data.aci_hsrp_interface_policy.test"
+	rName := acctest.RandString(5)
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciHsrpInterfacePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateAccHsrpInterfacePolicyDSWithoutTenant(rName),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateAccHsrpInterfacePolicyDSWithoutName(rName),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccHsrpInterfacePolicyConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tenant_dn", resourceName, "tenant_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ctrl", resourceName, "ctrl"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "reload_delay", resourceName, "reload_delay"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "delay", resourceName, "delay"),
+				),
+			},
+			{
+				Config:      CreateAccHsrpInterfacePolicyUpdatedConfigDataSourceRandomAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccHsrpInterfacePolicyUpdatedConfigDataSource(rName, "description", randomValue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+				),
+			},
+			{
+				Config:      CreateAccHsrpInterfacePolicyDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+		},
+	})
+}
+
+func CreateAccHsrpInterfacePolicyUpdatedConfigDataSourceRandomAttr(rName, attribute, value string) string {
+	fmt.Println("=== STEP  Basic: Testing Hrsp Interface Policy data source with updated resource")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_hsrp_interface_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_hsrp_interface_policy" "test" {
+		tenant_dn = aci_hsrp_interface_policy.test.tenant_dn
+		name = aci_hsrp_interface_policy.test.name
+		%s = "%s"
+	}
+	`, rName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccHsrpInterfacePolicyUpdatedConfigDataSource(rName, attribute, value string) string {
+	fmt.Println("=== STEP  Basic: Testing Hsrp Interface Policy data source with updated resource")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_hsrp_interface_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+
+	}
+
+	data "aci_hsrp_interface_policy" "test" {
+		tenant_dn = aci_hsrp_interface_policy.test.tenant_dn
+		name = aci_hsrp_interface_policy.test.name
+	}
+	`, rName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccHsrpInterfacePolicyConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  Basic: Testing Hsrp Interface Policy data source")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_hsrp_interface_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_hsrp_interface_policy" "test" {
+		tenant_dn = aci_hsrp_interface_policy.test.tenant_dn
+		name = aci_hsrp_interface_policy.test.name
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccHsrpInterfacePolicyDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  Basic: testing Hsrp Interface Policy reading with invalid name")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_hsrp_interface_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_hsrp_interface_policy" "test" {
+		tenant_dn = "${aci_hsrp_interface_policy.test.tenant_dn}abc"
+		name = aci_hsrp_interface_policy.test.name
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccHsrpInterfacePolicyDSWithoutTenant(rName string) string {
+	fmt.Println("=== STEP  Basic: testing Hsrp Interface Policy reading without giving tenant_dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_hsrp_interface_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_hsrp_interface_policy" "test" {
+		name = aci_hsrp_interface_policy.test.name
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccHsrpInterfacePolicyDSWithoutName(rName string) string {
+	fmt.Println("=== STEP  Basic: testing Hsrp Interface Policy reading without giving name")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_hsrp_interface_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_hsrp_interface_policy" "test" {
+		tenant_dn = aci_hsrp_interface_policy.test.tenant_dn
+	}
+	`, rName, rName)
+	return resource
+}

--- a/testacc/data_source_aci_ospfifp_test.go
+++ b/testacc/data_source_aci_ospfifp_test.go
@@ -257,7 +257,7 @@ func CreateAccL3outOspfInterfaceProfileDSWithoutLogicalInterfaceProfile(rName st
 }
 
 func CreateAccL3outOspfInterfaceProfileDSWithoutAuthKey(rName string) string {
-	fmt.Println("=== STEP  Basic: testing contract subject reading without giving name")
+	fmt.Println("=== STEP  Basic: testing contract subject reading without giving auth key")
 	resource := fmt.Sprintf(`
 	resource "aci_tenant" "test" {
 		name 		= "%s"

--- a/testacc/resource_aci_hsrpifpol_test.go
+++ b/testacc/resource_aci_hsrpifpol_test.go
@@ -1,0 +1,468 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciHsrpInterfacePolicy_Basic(t *testing.T) {
+	var hsrp_interface_policy_default models.HSRPInterfacePolicy
+	var hsrp_interface_policy_updated models.HSRPInterfacePolicy
+	resourceName := "aci_hsrp_interface_policy.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciHsrpInterfacePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateHsrpInterfacePolicyWithoutRequired(rName, rName, "tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateHsrpInterfacePolicyWithoutRequired(rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccHsrpInterfacePolicyConfig(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHsrpInterfacePolicyExists(resourceName, &hsrp_interface_policy_default),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "ctrl", ""),
+					resource.TestCheckResourceAttr(resourceName, "delay", "0"),
+					resource.TestCheckResourceAttr(resourceName, "reload_delay", "0"),
+				),
+			},
+			{
+				Config: CreateAccHsrpInterfacePolicyConfigWithOptionalValues(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHsrpInterfacePolicyExists(resourceName, &hsrp_interface_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_hsrp_interface_policy"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl", "bfd"),
+					resource.TestCheckResourceAttr(resourceName, "delay", "1"),
+					resource.TestCheckResourceAttr(resourceName, "reload_delay", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccHsrpInterfacePolicyConfigInvalidName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)* failed validation`),
+			},
+
+			{
+				Config: CreateAccHsrpInterfacePolicyConfigUpdatedRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHsrpInterfacePolicyExists(resourceName, &hsrp_interface_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciHsrpInterfacePolicyIdNotEqual(&hsrp_interface_policy_default, &hsrp_interface_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccHsrpInterfacePolicyConfig(rName, rName),
+			},
+			{
+				Config: CreateAccHsrpInterfacePolicyConfigUpdatedRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHsrpInterfacePolicyExists(resourceName, &hsrp_interface_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciHsrpInterfacePolicyIdNotEqual(&hsrp_interface_policy_default, &hsrp_interface_policy_updated),
+				),
+			},
+			{
+				Config:      CreateAccHsrpInterfacePolicyConfigUpdateWithoutRequiredArguments(rName, "description", acctest.RandString(5)),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccHsrpInterfacePolicyConfig(rName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciHsrpInterfacePolicy_Update(t *testing.T) {
+	var hsrp_interface_policy_default models.HSRPInterfacePolicy
+	var hsrp_interface_policy_updated models.HSRPInterfacePolicy
+	resourceName := "aci_hsrp_interface_policy.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciHsrpInterfacePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccHsrpInterfacePolicyConfig(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHsrpInterfacePolicyExists(resourceName, &hsrp_interface_policy_default),
+				),
+			},
+
+			{
+
+				Config: CreateAccHsrpInterfacePolicyUpdatedAttr(rName, rName, "ctrl", "bia"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHsrpInterfacePolicyExists(resourceName, &hsrp_interface_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "ctrl", "bia"),
+					testAccCheckAciHsrpInterfacePolicyIdEqual(&hsrp_interface_policy_default, &hsrp_interface_policy_updated),
+				),
+			},
+			{
+
+				Config: CreateAccHsrpInterfacePolicyUpdatedAttr(rName, rName, "ctrl", "bfd,bia"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHsrpInterfacePolicyExists(resourceName, &hsrp_interface_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "ctrl", "bfd,bia"),
+					testAccCheckAciHsrpInterfacePolicyIdEqual(&hsrp_interface_policy_default, &hsrp_interface_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccHsrpInterfacePolicyUpdatedAttr(rName, rName, "ctrl", ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHsrpInterfacePolicyExists(resourceName, &hsrp_interface_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "ctrl", ""),
+					testAccCheckAciHsrpInterfacePolicyIdEqual(&hsrp_interface_policy_default, &hsrp_interface_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccHsrpInterfacePolicyConfig(rName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciHsrpInterfacePolicy_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciHsrpInterfacePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccHsrpInterfacePolicyConfig(rName, rName),
+			},
+			{
+				Config:      CreateAccHsrpInterfacePolicyWithInvalidParentDn(rName, rName),
+				ExpectError: regexp.MustCompile(`configured object (.)+ not found (.)+,`),
+			},
+			{
+				Config:      CreateAccHsrpInterfacePolicyUpdatedAttr(rName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccHsrpInterfacePolicyUpdatedAttr(rName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccHsrpInterfacePolicyUpdatedAttr(rName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccHsrpInterfacePolicyUpdatedAttr(rName, rName, "ctrl", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.*)to be one of(.)*, got(.)*`),
+			},
+			{
+				Config:      CreateAccHsrpInterfacePolicyUpdatedAttr(rName, rName, "ctrl", "bfd,bfd"),
+				ExpectError: regexp.MustCompile(`unexpected duplicate values in ctrl`),
+			},
+			{
+				Config:      CreateAccHsrpInterfacePolicyUpdatedAttr(rName, rName, "delay", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccHsrpInterfacePolicyUpdatedAttr(rName, rName, "reload_delay", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccHsrpInterfacePolicyUpdatedAttr(rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named(.)*is not expected here.`),
+			},
+			{
+				Config: CreateAccHsrpInterfacePolicyConfig(rName, rName),
+			},
+		},
+	})
+}
+
+func TestAccHsrpInterfacePolicy_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciHsrpInterfacePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccAciHsrpInterfaceProfilesConfig(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciHsrpInterfacePolicyExists(name string, hsrp_interface_policy *models.HSRPInterfacePolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Hsrp Interface Policy %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Hsrp Interface Policy dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		hsrp_interface_policyFound := models.HSRPInterfacePolicyFromContainer(cont)
+		if hsrp_interface_policyFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Hsrp Interface Policy %s not found", rs.Primary.ID)
+		}
+		*hsrp_interface_policy = *hsrp_interface_policyFound
+		return nil
+	}
+}
+
+func testAccCheckAciHsrpInterfacePolicyDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing hsrp_interface_policy destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_hsrp_interface_policy" {
+			cont, err := client.Get(rs.Primary.ID)
+			hsrp_interface_policy := models.HSRPInterfacePolicyFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Hsrp Interface Policy %s Still exists", hsrp_interface_policy.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciHsrpInterfacePolicyIdEqual(m1, m2 *models.HSRPInterfacePolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("hsrp_interface_policy DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciHsrpInterfacePolicyIdNotEqual(m1, m2 *models.HSRPInterfacePolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("hsrp_interface_policy DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateAccAciHsrpInterfaceProfilesConfig(rName string) string {
+	fmt.Println("=== STEP  creating multiple Hrsp Interface Profiles")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_hsrp_interface_policy" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+		resource "aci_hsrp_interface_policy" "test1" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+		resource "aci_hsrp_interface_policy" "test2" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_hsrp_interface_policy" "test3" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	`, rName, rName, rName+"1", rName+"2", rName+"3")
+	return resource
+
+}
+func CreateHsrpInterfacePolicyWithoutRequired(fvTenantName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing hsrp_interface_policy creation without Requierd Parameters ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"	
+	}
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	resource "aci_hsrp_interface_policy" "test" {
+	#	tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		description = "created while acceptance testing"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_hsrp_interface_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+	#	name  = "%s"
+		description = "created while acceptance testing"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, rName)
+}
+
+func CreateAccHsrpInterfacePolicyConfigUpdatedRequiredParams(rName, rName2 string) string {
+	fmt.Println("=== STEP  testing hsrp_interface_policy updation using required arguements")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	}
+	
+	resource "aci_hsrp_interface_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, rName, rName2)
+	return resource
+}
+
+func CreateAccHsrpInterfacePolicyConfigUpdateWithoutRequiredArguments(rName, attribute, value string) string {
+	fmt.Println("=== STEP  testing hsrp_interface_policy updation without required arguements")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	}
+
+	resource "aci_hsrp_interface_policy" "test" {
+		%s = "%s"
+	}
+	`, rName, attribute, value)
+	return resource
+}
+
+func CreateAccHsrpInterfacePolicyConfigInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing hsrp_interface_policy creation with Invalid Name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	}
+	
+	resource "aci_hsrp_interface_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccHsrpInterfacePolicyConfig(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing hsrp_interface_policy creation with required arguements only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	}
+	
+	resource "aci_hsrp_interface_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccHsrpInterfacePolicyWithInvalidParentDn(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing hsrp_interface_policy creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	}
+	
+	resource "aci_hsrp_interface_policy" "test" {
+		tenant_dn  = "${aci_tenant.test.id}invalid"
+		name  = "%s"	
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccHsrpInterfacePolicyConfigWithOptionalValues(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing hsrp_interface_policy creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	}
+	
+	resource "aci_hsrp_interface_policy" "test" {
+		tenant_dn  = "${aci_tenant.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_hsrp_interface_policy"
+		ctrl = "bfd"
+		delay = "1"
+		reload_delay = "1"
+	}
+	`, fvTenantName, rName)
+
+	return resource
+}
+
+func CreateAccHsrpInterfacePolicyUpdatedAttr(fvTenantName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing hsrp_interface_policy attribute: %s=%s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	}
+	
+	resource "aci_hsrp_interface_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, fvTenantName, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_ospfifp_test.go
+++ b/testacc/resource_aci_ospfifp_test.go
@@ -315,7 +315,7 @@ func CreateAccL3outOspfInterfaceProfileConfigWithRequiredParams(rName, randomVal
 }
 
 func CreateAccL3outOspfInterfaceProfileUpdatedAttr(rName, attribute, value string) string {
-	fmt.Println("=== STEP  testing l3out_ospf_interface_profile creation with required arguements only")
+	fmt.Printf("=== STEP  testing l3out_ospf_interface_profile creation with : %s=%s \n", attribute, value)
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {
@@ -495,20 +495,6 @@ func CreateAccL3outOspfInterfaceProfileConfigWithOptionalValues(fvTenantName, l3
 		auth_type = "md5"
 	}
 	`, fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, randomValue)
-
-	return resource
-}
-
-func CreateAccL3outOspfInterfaceProfileRemovingRequiredField() string {
-	fmt.Println("=== STEP  Basic: testing l3out_ospf_interface_profile creation with optional parameters")
-	resource := fmt.Sprintf(`
-	resource "aci_l3out_ospf_interface_profile" "test" {
-		description = "created while acceptance testing"
-		annotation = "orchestrator:terraform_testacc"
-		name_alias = "test_l3out_ospf_interface_profile"
-		auth_key = ""auth_key_id = "2"auth_key_id = ""auth_type = "md5"
-	}
-	`)
 
 	return resource
 }

--- a/website/docs/d/epg_to_contract.html.markdown
+++ b/website/docs/d/epg_to_contract.html.markdown
@@ -30,6 +30,5 @@ data "aci_epg_to_contract" "example" {
 
 - `id` - Attribute id set to the Dn of the provider/consumer contract.
 - `annotation` - (Optional) annotation for EPg to contract relationship.
-- `description` - (Optional) annotation for EPg to contract relationship.
 - `match_t` - (Optional) Provider matching criteria.
 - `prio` - (Optional) Priority of relation object.

--- a/website/docs/r/epg_to_contract.html.markdown
+++ b/website/docs/r/epg_to_contract.html.markdown
@@ -29,7 +29,6 @@ resource "aci_epg_to_contract" "example" {
 - `contract_dn` - (Required) Distinguished name of contract to attach.
 - `contract_type` - (Required) Type of relationship. Allowed values are "consumer" and "provider".
 - `annotation` - (Optional) Annotation for EPg to contract relationship.
-- `description` - (Optional) Description for EPg to contract relationship.
 - `match_t` - (Optional) Provider matching criteria. Allowed values: "All", "AtleastOne", "AtmostOne", "None". Default value: "AtleastOne". This attribute is supported only for resources with "contract_type" with value "provider"
 - `prio` - (Optional) Priority of relation object. Allowed values: "unspecified", "level1", "level2", "level3", "level4", "level5", "level6". Default value: "unspecified".
 


### PR DESCRIPTION
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?       github.com/terraform-providers/terraform-provider-aci   [no test files]
?       github.com/terraform-providers/terraform-provider-aci/aci       [no test files]
=== RUN   TestAccAciHsrpInterfacePolicyDataSource_Basic
=== STEP  Basic: testing Hsrp Interface Policy reading without giving tenant_dn
=== STEP  Basic: testing Hsrp Interface Policy reading without giving name
=== STEP  Basic: Testing Hsrp Interface Policy data source
=== STEP  Basic: Testing Hrsp Interface Policy data source with updated resource
=== STEP  Basic: Testing Hsrp Interface Policy data source with updated resource
=== STEP  Basic: testing Hsrp Interface Policy reading with invalid name
=== PAUSE TestAccAciHsrpInterfacePolicyDataSource_Basic
=== RUN   TestProvider
--- PASS: TestProvider (0.04s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccAciHsrpInterfacePolicy_Basic
=== STEP  Basic: testing hsrp_interface_policy creation without Requierd Parameters  tenant_dn
=== STEP  Basic: testing hsrp_interface_policy creation without Requierd Parameters  name
=== STEP  testing hsrp_interface_policy creation with required arguements only
=== STEP  Basic: testing hsrp_interface_policy creation with optional parameters
=== STEP  testing hsrp_interface_policy creation with Invalid Name
=== STEP  testing hsrp_interface_policy updation using required arguements
=== STEP  testing hsrp_interface_policy creation with required arguements only
=== STEP  testing hsrp_interface_policy updation using required arguements
=== STEP  testing hsrp_interface_policy updation without required arguements
=== STEP  testing hsrp_interface_policy creation with required arguements only
=== PAUSE TestAccAciHsrpInterfacePolicy_Basic
=== RUN   TestAccAciHsrpInterfacePolicy_Update
=== STEP  testing hsrp_interface_policy creation with required arguements only
=== STEP  testing hsrp_interface_policy attribute: ctrl=bia
=== STEP  testing hsrp_interface_policy attribute: ctrl=bfd,bia
=== STEP  testing hsrp_interface_policy attribute: ctrl=
=== STEP  testing hsrp_interface_policy creation with required arguements only
=== PAUSE TestAccAciHsrpInterfacePolicy_Update
=== RUN   TestAccAciHsrpInterfacePolicy_Negative
=== STEP  testing hsrp_interface_policy creation with required arguements only
=== STEP  Negative Case: testing hsrp_interface_policy creation with invalid parent Dn
=== STEP  testing hsrp_interface_policy attribute: description=pad3nmtyrsplt1ij1yw9eryznqnuvptas8kb8oifr4qa3id489vwemlc6hj3jp86on297f4lp0yh60tp326pyx390gywsmf49oaxr4bwd2wz9iqfcaj7kt4tb7h9kzqy9
=== STEP  testing hsrp_interface_policy attribute: annotation=49y227nhp8pwcmnosamsmsfayn3anat3lz0sm7px96326i9fn4acdop9u2qqv3ay7vikmgaut3bkkcz7d6awgm4ch7mqil0npejk0yp2ddfs4lj2f9dp7lfnp9p12oq92
=== STEP  testing hsrp_interface_policy attribute: name_alias=vu2cyjcdhwda3rg3vojd9aewrasllr46r8pqj9h26dwt6eo2zkgnmttfiln6scts
=== STEP  testing hsrp_interface_policy attribute: ctrl=acctest_d9mf8
=== STEP  testing hsrp_interface_policy attribute: ctrl=bfd,bfd
=== STEP  testing hsrp_interface_policy attribute: delay=acctest_d9mf8
=== STEP  testing hsrp_interface_policy attribute: reload_delay=acctest_d9mf8
=== STEP  testing hsrp_interface_policy attribute: xrxyy=acctest_d9mf8
=== STEP  testing hsrp_interface_policy creation with required arguements only
=== PAUSE TestAccAciHsrpInterfacePolicy_Negative
=== RUN   TestAccHsrpInterfacePolicy_MultipleCreateDelete
=== STEP  creating multiple Hrsp Interface Profiles
=== STEP  testing hsrp_interface_policy destroy
--- PASS: TestAccHsrpInterfacePolicy_MultipleCreateDelete (54.96s)
=== CONT  TestAccAciHsrpInterfacePolicyDataSource_Basic
=== CONT  TestAccAciHsrpInterfacePolicy_Update
=== CONT  TestAccAciHsrpInterfacePolicy_Negative
=== CONT  TestAccAciHsrpInterfacePolicy_Basic
=== STEP  testing hsrp_interface_policy destroy
--- PASS: TestAccAciHsrpInterfacePolicyDataSource_Basic (128.00s)
=== STEP  testing hsrp_interface_policy destroy
--- PASS: TestAccAciHsrpInterfacePolicy_Negative (209.85s)
=== STEP  testing hsrp_interface_policy destroy
--- PASS: TestAccAciHsrpInterfacePolicy_Update (213.75s)
=== STEP  testing hsrp_interface_policy destroy
--- PASS: TestAccAciHsrpInterfacePolicy_Basic (265.99s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   322.238s
