### PR TITLE
Bgp route control profile

### DIFF
--- a/aci/resource_aci_rtctrlprofile.go
+++ b/aci/resource_aci_rtctrlprofile.go
@@ -106,6 +106,7 @@ func resourceAciRouteControlProfileImport(d *schema.ResourceData, m interface{})
 	if err != nil {
 		return nil, err
 	}
+	d.Set("parent_dn", GetParentDn(dn, fmt.Sprintf("/prof-%s", rtctrlProfile.Name)))
 	log.Printf("[DEBUG] %s: Import finished successfully", d.Id())
 
 	return []*schema.ResourceData{schemaFilled}, nil

--- a/testacc/data_source_aci_rtctrlprofile_test.go
+++ b/testacc/data_source_aci_rtctrlprofile_test.go
@@ -1,0 +1,211 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciBgpRouteControlProfileDS_Basic(t *testing.T) {
+	resourceName := "aci_bgp_route_control_profile.test"
+	dataSourceName := "data.aci_bgp_route_control_profile.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciBgpRouteControlProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateBgpRouteControlProfileDSWithoutRequired(rName, rName, "parent_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateBgpRouteControlProfileDSWithoutRequired(rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccBgpRouteControlProfileDSConfig(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "parent_dn", resourceName, "parent_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "route_control_profile_type", resourceName, "route_control_profile_type"),
+				),
+			},
+			{
+				Config: CreateAccBgpRouteControlProfileDSConfigL3Outside(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "parent_dn", resourceName, "parent_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "route_control_profile_type", resourceName, "route_control_profile_type"),
+				),
+			},
+			{
+				Config:      CreateAccBgpRouteControlProfileDSUpdateRandomAttr(rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccBgpRouteControlProfileDSWithInvalidParentDn(rName, rName),
+				ExpectError: regexp.MustCompile(`Object may not exists`),
+			},
+			{
+				Config: CreateAccBgpRouteControlProfileDSUpdate(rName, rName, "description", randomValue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+				),
+			},
+		},
+	})
+}
+
+func CreateBgpRouteControlProfileDSWithoutRequired(fvTenantName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: Creating bgp_route_control_profile Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		
+	}
+	resource "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_tenant.test.id
+		name  = "%s"
+		description = "created while acceptance testing"
+	}
+	
+	`
+	switch attrName {
+	case "parent_dn":
+		rBlock += `
+	data "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_tenant.test.id
+		# name  = aci_bgp_route_control_profile.test.name
+		depends_on = [aci_bgp_route_control_profile.test]
+	}
+	`
+	case "name":
+		rBlock += `
+	data "aci_bgp_route_control_profile" "test" {
+		#parent_dn  = aci_tenant.test.id
+		name  = aci_bgp_route_control_profile.test.name
+		depends_on = [aci_bgp_route_control_profile.test]
+	}
+	`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, rName)
+}
+
+func CreateAccBgpRouteControlProfileDSUpdateRandomAttr(fvTenantName, rName, attribute, value string) string {
+	fmt.Println("=== STEP  Testing bgp_route_control_profile Data Source update with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	resource "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	data "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_tenant.test.id
+		name  = aci_bgp_route_control_profile.test.name 
+		%s = "%s"
+		depends_on = [aci_bgp_route_control_profile.test]
+	}
+	`, fvTenantName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccBgpRouteControlProfileDSConfig(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  Testing bgp_route_control_profile Data Source creation with required arguements only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	resource "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	data "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_tenant.test.id
+		name  = aci_bgp_route_control_profile.test.name 
+		depends_on = [aci_bgp_route_control_profile.test]
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccBgpRouteControlProfileDSConfigL3Outside(ParentName, rName string) string {
+	fmt.Println("=== STEP  Testing bgp_route_control_profile Data Source creation when parent is l3outside")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	resource "aci_l3_outside" "test" {
+        tenant_dn      = aci_tenant.test.id
+        name           = "%s"
+	}
+	
+	resource "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_l3_outside.test.id
+		name  = "%s"
+	}
+	data "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_l3_outside.test.id
+		name  = aci_bgp_route_control_profile.test.name 
+		depends_on = [aci_bgp_route_control_profile.test]
+	}
+	`, ParentName, ParentName, rName)
+	return resource
+}
+
+func CreateAccBgpRouteControlProfileDSWithInvalidParentDn(ParentName, rName string) string {
+	fmt.Println("=== STEP  Testing bgp_route_control_profile Data Source creation with invalid parent_dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	resource "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	data "aci_bgp_route_control_profile" "test" {
+		parent_dn  = "${aci_tenant.test.id}xyz"
+		name  = aci_bgp_route_control_profile.test.name 
+		depends_on = [aci_bgp_route_control_profile.test]
+	}
+	`, ParentName, rName)
+	return resource
+}
+
+func CreateAccBgpRouteControlProfileDSUpdate(fvTenantName, rName, attribute, value string) string {
+	fmt.Println("=== STEP  Testing bgp_route_control_profile Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	resource "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	data "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_tenant.test.id
+		name  = aci_bgp_route_control_profile.test.name 
+		depends_on = [aci_bgp_route_control_profile.test]
+	}
+	`, fvTenantName, rName, attribute, value)
+	return resource
+}

--- a/testacc/data_source_aci_rtctrlprofile_test.go
+++ b/testacc/data_source_aci_rtctrlprofile_test.go
@@ -40,17 +40,6 @@ func TestAccAciBgpRouteControlProfileDS_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: CreateAccBgpRouteControlProfileDSConfigL3Outside(rName, rName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(dataSourceName, "parent_dn", resourceName, "parent_dn"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "route_control_profile_type", resourceName, "route_control_profile_type"),
-				),
-			},
-			{
 				Config:      CreateAccBgpRouteControlProfileDSUpdateRandomAttr(rName, rName, randomParameter, randomValue),
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
 			},

--- a/testacc/resource_aci_rtctrlprofile_test.go
+++ b/testacc/resource_aci_rtctrlprofile_test.go
@@ -1,0 +1,445 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciBgpRouteControlProfile_Basic(t *testing.T) {
+	var bgp_route_control_profile_default models.RouteControlProfile
+	var bgp_route_control_profile_updated models.RouteControlProfile
+	resourceName := "aci_bgp_route_control_profile.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciBgpRouteControlProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateBgpRouteControlProfileWithoutRequired(rName, rName, "parent_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateBgpRouteControlProfileWithoutRequired(rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccBgpRouteControlProfileConfig(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciBgpRouteControlProfileExists(resourceName, &bgp_route_control_profile_default),
+					resource.TestCheckResourceAttr(resourceName, "parent_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "route_control_profile_type", "combinable"),
+				),
+			},
+			{
+				Config: CreateAccBgpRouteControlProfileConfigWithOptionalValues(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciBgpRouteControlProfileExists(resourceName, &bgp_route_control_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "parent_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_route_control_profile"),
+					resource.TestCheckResourceAttr(resourceName, "route_control_profile_type", "global"),
+					testAccCheckAciBgpRouteControlProfileIdEqual(&bgp_route_control_profile_default, &bgp_route_control_profile_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccBgpRouteControlProfileConfigUpdatedName(rName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config: CreateAccBgpRouteControlProfileConfigWithRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciBgpRouteControlProfileExists(resourceName, &bgp_route_control_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "parent_dn", fmt.Sprintf("uni/tn-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciBgpRouteControlProfileIdNotEqual(&bgp_route_control_profile_default, &bgp_route_control_profile_updated),
+				),
+			},
+			{
+				Config: CreateAccBgpRouteControlProfileConfig(rName, rName),
+			},
+			{
+				Config: CreateAccBgpRouteControlProfileConfigWithRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciBgpRouteControlProfileExists(resourceName, &bgp_route_control_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "parent_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciBgpRouteControlProfileIdNotEqual(&bgp_route_control_profile_default, &bgp_route_control_profile_updated),
+				),
+			},
+			{
+				Config:      CreateAccBgpRouteControlProfileUpdateWithoutRequiredAttr(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccBgpRouteControlProfileConfigL3Outside(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciBgpRouteControlProfileExists(resourceName, &bgp_route_control_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "parent_dn", fmt.Sprintf("uni/tn-%s/out-%s", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "route_control_profile_type", "combinable"),
+					testAccCheckAciBgpRouteControlProfileIdNotEqual(&bgp_route_control_profile_default, &bgp_route_control_profile_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciBgpRouteControlProfile_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciBgpRouteControlProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccBgpRouteControlProfileConfig(rName, rName),
+			},
+			{
+				Config:      CreateAccBgpRouteControlProfileWithInValidParentDn(rName, rName),
+				ExpectError: regexp.MustCompile(`configured object (.)+ not found (.)+,`),
+			},
+			{
+				Config:      CreateAccBgpRouteControlProfileUpdatedAttr(rName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccBgpRouteControlProfileUpdatedAttr(rName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccBgpRouteControlProfileUpdatedAttr(rName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccBgpRouteControlProfileUpdatedAttr(rName, rName, "route_control_profile_type", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+to be one of(.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccBgpRouteControlProfileUpdatedAttr(rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named(.)+is not expected here.`),
+			},
+			{
+				Config: CreateAccBgpRouteControlProfileConfig(rName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciBgpRouteControlProfile_Multiple(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAciBgpRouteControlProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccBgpRouteControlProfileConfigs(rName, rName),
+			},
+		},
+	})
+}
+
+func CreateAccBgpRouteControlProfileConfigs(fvTenantName, rName string) string {
+	fmt.Println("=== STEP Testing Multiple route_control_profile creation")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	resource "aci_bgp_route_control_profile" "test1" {
+		parent_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	resource "aci_bgp_route_control_profile" "test2" {
+		parent_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName, rName+"1", rName+"2")
+	return resource
+}
+
+func testAccCheckAciBgpRouteControlProfileExists(name string, bgp_route_control_profile *models.RouteControlProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Bgp Route Control Profile %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Bgp Route Control Profile dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		bgp_route_control_profileFound := models.RouteControlProfileFromContainer(cont)
+		if bgp_route_control_profileFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Bgp Route Control Profile %s not found", rs.Primary.ID)
+		}
+		*bgp_route_control_profile = *bgp_route_control_profileFound
+		return nil
+	}
+}
+
+func testAccCheckAciBgpRouteControlProfileDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  Testing bgp_route_control_profile destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_bgp_route_control_profile" {
+			cont, err := client.Get(rs.Primary.ID)
+			bgp_route_control_profile := models.RouteControlProfileFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Bgp Route Control Profile %s Still exists", bgp_route_control_profile.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciBgpRouteControlProfileIdEqual(m1, m2 *models.RouteControlProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("bgp_route_control_profile DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciBgpRouteControlProfileIdNotEqual(m1, m2 *models.RouteControlProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("bgp_route_control_profile DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateBgpRouteControlProfileWithoutRequired(fvTenantName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: Testing bgp_route_control_profile creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		
+	}
+	
+	`
+	switch attrName {
+	case "parent_dn":
+		rBlock += `
+	resource "aci_bgp_route_control_profile" "test" {
+	#	parent_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_tenant.test.id
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, rName)
+}
+
+func CreateAccBgpRouteControlProfileConfigWithRequiredParams(ParentName, rName string) string {
+	fmt.Printf("=== STEP  Testing bgp_route_control_profile creation with tenant name = %s and bgp_route_control_profile name = %s\n", ParentName, rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, ParentName, rName)
+	return resource
+}
+
+func CreateAccBgpRouteControlProfileConfigL3Outside(ParentName, rName string) string {
+	fmt.Println("=== STEP  Testing bgp_route_control_profile creation when parent is l3outside")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	resource "aci_l3_outside" "test" {
+        tenant_dn      = aci_tenant.test.id
+        name           = "%s"
+	}
+	
+	resource "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_l3_outside.test.id
+		name  = "%s"
+	}
+	`, ParentName, ParentName, rName)
+	return resource
+}
+
+func CreateAccBgpRouteControlProfileConfig(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  Testing bgp_route_control_profile creation with required arguements only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccBgpRouteControlProfileConfigUpdatedName(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  Testing bgp_route_control_profile creation with Invalid Long Name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccBgpRouteControlProfileWithInValidParentDn(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  Negative Case: Testing bgp_route_control_profile creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_bgp_route_control_profile" "test" {
+		parent_dn  = "${aci_tenant.test.id}invalid"
+		name  = "%s" 
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccBgpRouteControlProfileConfigWithOptionalValues(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  Basic: Testing bgp_route_control_profile creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_bgp_route_control_profile" "test" {
+		parent_dn  = "${aci_tenant.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_route_control_profile"
+		route_control_profile_type = "global"
+	}
+	`, fvTenantName, rName)
+
+	return resource
+}
+
+func CreateAccBgpRouteControlProfileUpdateWithoutRequiredAttr() string {
+	fmt.Println("=== STEP  Basic: Testing bgp_route_control_profile updation without required attributes")
+	resource := fmt.Sprintln(`
+	resource "aci_bgp_route_control_profile" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_route_control_profile"
+		route_control_profile_type = "global"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccBgpRouteControlProfileRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: Testing bgp_route_control_profile creation with optional parameters")
+	resource := fmt.Sprintln(`
+	resource "aci_bgp_route_control_profile" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_route_control_profile"
+		route_control_profile_type = "global"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccBgpRouteControlProfileUpdatedAttr(fvTenantName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  Testing bgp_route_control_profile attribute: %s=%s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_bgp_route_control_profile" "test" {
+		parent_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, fvTenantName, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_rtctrlprofile_test.go
+++ b/testacc/resource_aci_rtctrlprofile_test.go
@@ -124,7 +124,7 @@ func TestAccAciBgpRouteControlProfile_Negative(t *testing.T) {
 			},
 			{
 				Config:      CreateAccBgpRouteControlProfileWithInValidParentDn(rName, rName),
-				ExpectError: regexp.MustCompile(`configured object (.)+ not found (.)+,`),
+				ExpectError: regexp.MustCompile(`unknown property value (.)+, name dn, class rtctrlProfile (.)+`),
 			},
 			{
 				Config:      CreateAccBgpRouteControlProfileUpdatedAttr(rName, rName, "description", acctest.RandString(129)),
@@ -360,20 +360,23 @@ func CreateAccBgpRouteControlProfileConfigUpdatedName(fvTenantName, rName string
 	return resource
 }
 
-func CreateAccBgpRouteControlProfileWithInValidParentDn(fvTenantName, rName string) string {
+func CreateAccBgpRouteControlProfileWithInValidParentDn(ParentName, rName string) string {
 	fmt.Println("=== STEP  Negative Case: Testing bgp_route_control_profile creation with invalid parent Dn")
 	resource := fmt.Sprintf(`
-	
 	resource "aci_tenant" "test" {
 		name 		= "%s"
 	
 	}
+	resource "aci_application_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name       = "%s"
+	}
 	
 	resource "aci_bgp_route_control_profile" "test" {
-		parent_dn  = "${aci_tenant.test.id}invalid"
+		parent_dn  = aci_application_profile.test.id
 		name  = "%s" 
 	}
-	`, fvTenantName, rName)
+	`, ParentName, ParentName, rName)
 	return resource
 }
 


### PR DESCRIPTION
go test -v -run TestAccAciBgpRouteControl -timeout=60m
=== RUN   TestAccAciBgpRouteControlProfileDS_Basic
=== STEP  Basic: Creating bgp_route_control_profile Data Source without  parent_dn
=== STEP  Basic: Creating bgp_route_control_profile Data Source without  name
=== STEP  Testing bgp_route_control_profile Data Source creation with required arguements only
=== STEP  Testing bgp_route_control_profile Data Source update with random attribute
=== STEP  Testing bgp_route_control_profile Data Source creation with invalid parent_dn
=== STEP  Testing bgp_route_control_profile Data Source with updated resource
=== PAUSE TestAccAciBgpRouteControlProfileDS_Basic
=== RUN   TestAccAciBgpRouteControlProfile_Basic
=== STEP  Basic: Testing bgp_route_control_profile creation without  parent_dn
=== STEP  Basic: Testing bgp_route_control_profile creation without  name
=== STEP  Testing bgp_route_control_profile creation with required arguements only
=== STEP  Basic: Testing bgp_route_control_profile creation with optional parameters
=== STEP  Testing bgp_route_control_profile creation with Invalid Long Name
=== STEP  Testing bgp_route_control_profile creation with tenant name = acctest_nu1jc and bgp_route_control_profile name = acctest_m0q0l     
=== STEP  Testing bgp_route_control_profile creation with required arguements only
=== STEP  Testing bgp_route_control_profile creation with tenant name = acctest_m0q0l and bgp_route_control_profile name = acctest_nu1jc     
=== STEP  Basic: Testing bgp_route_control_profile updation without required attributes
=== STEP  Testing bgp_route_control_profile creation when parent is l3outside
=== PAUSE TestAccAciBgpRouteControlProfile_Basic
=== RUN   TestAccAciBgpRouteControlProfile_Negative
=== STEP  Testing bgp_route_control_profile creation with required arguements only
=== STEP  Negative Case: Testing bgp_route_control_profile creation with invalid parent Dn
=== STEP  Testing bgp_route_control_profile attribute: description=suwgqhgf9k883k0h8jhlbqjjrst18vrgph43scb3mmndebbzqmdxchbj47w720wkzs9tyqg3kzg3u83egsj3imnasz8siq31pkygqcw8blvoacb191tyyyzngj4eikwev
=== STEP  Testing bgp_route_control_profile attribute: annotation=nvo7it29r0eao7zmvkn7fxkhv4rru6annejdzbgfvqb8pvr1rueuwn077pb2gmw6kpwfc2p2urftgt4y9pijguoifdukregqp1ndmf3xjau8dry19aws1t0ipmmffaxdc
=== STEP  Testing bgp_route_control_profile attribute: name_alias=m7shojnkbxdi64ue36es9e0fitcof9mj0qil98eclcaod0k8cgo8cvbjccadkcxa
=== STEP  Testing bgp_route_control_profile attribute: route_control_profile_type=acctest_qwg6q
=== STEP  Testing bgp_route_control_profile attribute: rlobq=acctest_qwg6q
=== STEP  Testing bgp_route_control_profile creation with required arguements only
=== PAUSE TestAccAciBgpRouteControlProfile_Negative
=== RUN   TestAccAciBgpRouteControlProfile_Multiple
=== STEP Testing Multiple route_control_profile creation
=== PAUSE TestAccAciBgpRouteControlProfile_Multiple
=== CONT  TestAccAciBgpRouteControlProfileDS_Basic
=== CONT  TestAccAciBgpRouteControlProfile_Negative
=== CONT  TestAccAciBgpRouteControlProfile_Basic
=== CONT  TestAccAciBgpRouteControlProfile_Multiple
=== STEP  Testing bgp_route_control_profile destroy
--- PASS: TestAccAciBgpRouteControlProfile_Multiple (37.51s)
=== STEP  Testing bgp_route_control_profile destroy
--- PASS: TestAccAciBgpRouteControlProfileDS_Basic (77.32s)
=== STEP  Testing bgp_route_control_profile destroy
--- PASS: TestAccAciBgpRouteControlProfile_Negative (123.00s)
=== STEP  Testing bgp_route_control_profile destroy
--- PASS: TestAccAciBgpRouteControlProfile_Basic (198.71s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   200.381s