### PR TITLE
Created Resource and Data Source for aci_l3out_route_tag_policy

### DIFF
--- a/testacc/data_source_aci_l3extroutetagpol_test.go
+++ b/testacc/data_source_aci_l3extroutetagpol_test.go
@@ -1,0 +1,193 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciL3outRouteTagPolicyDataSource_Basic(t *testing.T) {
+	resourceName := "aci_l3out_route_tag_policy.test"
+	dataSourceName := "data.aci_l3out_route_tag_policy.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciL3outRouteTagPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateL3outRouteTagPolicyDSWithoutRequired(rName, rName,"tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateL3outRouteTagPolicyDSWithoutRequired(rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccL3outRouteTagPolicyConfigDataSource(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "tenant_dn", resourceName, "tenant_dn",),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tag", resourceName, "tag"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+				),
+			},
+			{
+				Config:      CreateAccL3outRouteTagPolicyDataSourceUpdate(rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			
+			{
+				Config:      CreateAccL3outRouteTagPolicyDSWithInvalidParentDn(rName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccL3outRouteTagPolicyDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccL3outRouteTagPolicyDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing l3out_hsrp_interface_group Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		
+	}
+	resource "aci_l3out_route_tag_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	
+	data "aci_l3out_route_tag_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_l3out_route_tag_policy.test.name
+		depends_on = [
+			aci_l3out_route_tag_policy.test
+		]
+	}
+
+	`,rName, rName, key, value)
+	return resource
+}
+
+func CreateL3outRouteTagPolicyDSWithoutRequired(fvTenantName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing l3out_route_tag_policy Data Source without", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		
+	}
+	resource "aci_l3out_route_tag_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	data "aci_l3out_route_tag_policy" "test" {
+	#	tenant_dn  = aci_l3out_route_tag_policy.test.tenant_dn
+		name  = aci_l3out_route_tag_policy.test.name
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_l3out_route_tag_policy" "test" {
+		tenant_dn  = aci_l3out_route_tag_policy.test.tenant_dn
+	#	name  = "aci_l3out_route_tag_policy.test.name"
+	}	`
+	}
+
+	return fmt.Sprintf(rBlock, fvTenantName, rName)
+}
+
+func CreateAccL3outRouteTagPolicyConfigDataSource(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing l3out_route_tag_policy Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3out_route_tag_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_l3out_route_tag_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_l3out_route_tag_policy.test.name
+		depends_on = [
+			aci_l3out_route_tag_policy.test
+		]
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+func CreateAccL3outRouteTagPolicyDSWithInvalidParentDn(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing l3out_route_tag_policy creation with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3out_route_tag_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_l3out_route_tag_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "${aci_l3out_route_tag_policy.test.name}_invalid"
+		depends_on = [
+			aci_l3out_route_tag_policy.test
+		]
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccL3outRouteTagPolicyDataSourceUpdate(fvTenantName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing l3out_route_tag_policy Data Source with random parameter")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_l3out_route_tag_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_l3out_route_tag_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_l3out_route_tag_policy.test.name
+		%s = "%s"
+		depends_on = [
+			aci_l3out_route_tag_policy.test
+		]
+	}
+	`, fvTenantName, rName,key,value)
+	return resource
+}

--- a/testacc/resource_aci_l3extroutetagpol_test.go
+++ b/testacc/resource_aci_l3extroutetagpol_test.go
@@ -1,0 +1,392 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciL3outRouteTagPolicy_Basic(t *testing.T) {
+	var l3out_route_tag_policy_default models.L3outRouteTagPolicy
+	var l3out_route_tag_policy_updated models.L3outRouteTagPolicy
+	resourceName := "aci_l3out_route_tag_policy.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	longrName := acctest.RandString(65)
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3outRouteTagPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateL3outRouteTagPolicyWithoutRequired(rName, rName, "tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateL3outRouteTagPolicyWithoutRequired(rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccL3outRouteTagPolicyConfig(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outRouteTagPolicyExists(resourceName, &l3out_route_tag_policy_default),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "tag", "4294967295"),
+				),
+			},
+			{
+
+				Config: CreateAccL3outRouteTagPolicyConfigWithOptionalValues(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outRouteTagPolicyExists(resourceName, &l3out_route_tag_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_l3out_route_tag_policy"),
+					resource.TestCheckResourceAttr(resourceName, "tag", "6546738"),
+					testAccCheckAciL3outRouteTagPolicyIdEqual(&l3out_route_tag_policy_default, &l3out_route_tag_policy_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+			{
+				Config:      CreateAccL3outRouteTagPolicyRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateAccL3outRouteTagPolicyConfigUpdateWithInvalidName(rName, longrName),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			{
+				Config: CreateAccL3outRouteTagPolicyConfigWithRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outRouteTagPolicyExists(resourceName, &l3out_route_tag_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciL3outRouteTagPolicyIdNotEqual(&l3out_route_tag_policy_default, &l3out_route_tag_policy_updated),
+				),
+			},
+
+			{
+				Config: CreateAccL3outRouteTagPolicyConfig(rName, rName),
+			},
+			{
+				Config: CreateAccL3outRouteTagPolicyConfigWithRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outRouteTagPolicyExists(resourceName, &l3out_route_tag_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciL3outRouteTagPolicyIdNotEqual(&l3out_route_tag_policy_default, &l3out_route_tag_policy_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciL3outRouteTagPolicy_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3outRouteTagPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccL3outRouteTagPolicyConfig(rName, rName),
+			},
+			{
+				Config:      CreateAccL3outRouteTagPolicyWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value (.)+, name dn, class l3extRouteTagPol (.)+`),
+			},
+			{
+				Config:      CreateAccL3outRouteTagPolicyUpdatedAttr(rName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccL3outRouteTagPolicyUpdatedAttr(rName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccL3outRouteTagPolicyUpdatedAttr(rName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccL3outRouteTagPolicyUpdatedAttr(rName, rName, "tag", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccL3outRouteTagPolicyUpdatedAttr(rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccL3outRouteTagPolicyConfig(rName, rName),
+			},
+		},
+	})
+}
+func TestAccAciL3outRouteTagPolicy_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3outRouteTagPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccL3outRouteTagPolicyConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func CreateAccL3outRouteTagPolicyConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  creating multiple L3outRouteTagPolicy")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name        = "%s"
+	  }
+	  resource "aci_l3out_route_tag_policy" "test" {
+			  tenant_dn      = aci_tenant.test.id
+			  name           = "%s"
+	  }
+	  resource "aci_l3out_route_tag_policy" "test1" {
+		tenant_dn      = aci_tenant.test.id
+		name           = "%s"
+	}
+	resource "aci_l3out_route_tag_policy" "test2" {
+		tenant_dn      = aci_tenant.test.id
+		name           = "%s"
+	}
+	`, rName, rName+"1", rName+"2", rName+"3")
+	return resource
+}
+func CreateAccL3outRouteTagPolicyConfigUpdateWithInvalidName(parentName, rName string) string {
+	fmt.Printf("=== STEP  Basic: testing L3outRouteTagPolicy creation with parent resource name %s and name %s\n", parentName, rName)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name  = "%s"
+	  }
+	  resource "aci_l3out_route_tag_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, parentName, rName)
+	return resource
+}
+func testAccCheckAciL3outRouteTagPolicyExists(name string, l3out_route_tag_policy *models.L3outRouteTagPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("L3out Route Tag Policy %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No L3out Route Tag Policy dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		l3out_route_tag_policyFound := models.L3outRouteTagPolicyFromContainer(cont)
+		if l3out_route_tag_policyFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("L3out Route Tag Policy %s not found", rs.Primary.ID)
+		}
+		*l3out_route_tag_policy = *l3out_route_tag_policyFound
+		return nil
+	}
+}
+
+func testAccCheckAciL3outRouteTagPolicyDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing l3out_route_tag_policy destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_l3out_route_tag_policy" {
+			cont, err := client.Get(rs.Primary.ID)
+			l3out_route_tag_policy := models.L3outRouteTagPolicyFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("L3out Route Tag Policy %s Still exists", l3out_route_tag_policy.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciL3outRouteTagPolicyIdEqual(m1, m2 *models.L3outRouteTagPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("l3out_route_tag_policy DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciL3outRouteTagPolicyIdNotEqual(m1, m2 *models.L3outRouteTagPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("l3out_route_tag_policy DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateL3outRouteTagPolicyWithoutRequired(fvTenantName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing l3out_route_tag_policy creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		
+	}
+	
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	resource "aci_l3out_route_tag_policy" "test" {
+	#	tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_l3out_route_tag_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+	#	name  = "%s"
+	}	`
+	}
+
+	return fmt.Sprintf(rBlock, fvTenantName, rName)
+}
+
+func CreateAccL3outRouteTagPolicyConfigWithRequiredParams(fvTenantName, rName string) string {
+	fmt.Printf("=== STEP  testing L3outRouteTagPolicy creation with parent resource name %s and name %s\n", fvTenantName, rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3out_route_tag_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccL3outRouteTagPolicyConfig(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing l3out_route_tag_policy creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_l3out_route_tag_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccL3outRouteTagPolicyWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing l3out_route_tag_policy creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+	resource "aci_l3out_route_tag_policy" "test" {
+		tenant_dn  = "aci_application_profile.test.id"
+		name  = "%s"
+	}
+	`, rName, rName, rName)
+	return resource
+}
+
+func CreateAccL3outRouteTagPolicyConfigWithOptionalValues(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing l3out_route_tag_policy creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3out_route_tag_policy" "test" {
+		tenant_dn  = "${aci_tenant.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_l3out_route_tag_policy"
+		tag = "6546738"
+	}
+	`, fvTenantName, rName)
+
+	return resource
+}
+
+func CreateAccL3outRouteTagPolicyRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing l3out_route_tag_policy updation without required parameters")
+	resource := fmt.Sprintln(`
+	resource "aci_l3out_route_tag_policy" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_l3out_route_tag_policy"
+		tag = "686789"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccL3outRouteTagPolicyUpdatedAttr(fvTenantName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing l3out_route_tag_policy attribute: %s=%s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3out_route_tag_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, fvTenantName, rName, attribute, value)
+	return resource
+}


### PR DESCRIPTION
kanchi.shukla@CLW511-831 MINGW64 ~/Desktop/aci_l3out_route_tag_policy/terraform-provider-aci/testacc (aci_l3out_route_tag_policy)
$ go test -v -run TestAccAciL3outRouteTagPolicy
=== RUN   TestAccAciL3outRouteTagPolicyDataSource_Basic
=== STEP  Basic: testing l3out_route_tag_policy creation without  tenant_dn
=== STEP  Basic: testing l3out_route_tag_policy creation without  name
=== STEP  testing l3out_route_tag_policy creation with required arguments only
=== STEP  testing l3out_route_tag_policy creation with required arguments only
=== STEP  testing l3out_route_tag_policy creation with Invalid Parent Dn
=== STEP  testing l3out_hsrp_interface_group Data Source with updated resource
=== PAUSE TestAccAciL3outRouteTagPolicyDataSource_Basic
=== RUN   TestAccAciL3outRouteTagPolicy_Basic
=== STEP  Basic: testing l3out_route_tag_policy creation without  tenant_dn
=== STEP  Basic: testing l3out_route_tag_policy creation without  name
=== STEP  testing l3out_route_tag_policy creation with required arguments only
=== STEP  Basic: testing l3out_route_tag_policy creation with optional parameters
=== STEP  Basic: testing l3out_route_tag_policy updation without required parameters
=== STEP  Basic: testing L3outRouteTagPolicy creation with parent resource name acctest_qhz7s and name bga31wafxpio9i84ljzclemelchbpouv22pa8dv4giwhwztauu3kpnwrza6x3ezrw
=== STEP  testing l3out_route_tag_policy creation with required arguments only
=== STEP  testing l3out_route_tag_policy creation with required arguments only
=== STEP  testing l3out_route_tag_policy creation with required arguments only
=== PAUSE TestAccAciL3outRouteTagPolicy_Basic
=== RUN   TestAccAciL3outRouteTagPolicy_Negative
=== STEP  testing l3out_route_tag_policy creation with required arguments only
=== STEP  Negative Case: testing l3out_route_tag_policy creation with invalid parent Dn
=== STEP  testing l3out_route_tag_policy attribute: description=cjmbya1tedxgz34sg272ub8ygwat462pbl1dsbi2zdjcudtv944v13vtm1nc1fg83i7y7pjgos7r8y68h3urfqmokh1jfg7et3jc2tdkb6f1tj3ty3ebtnzdgcwe0poft
=== STEP  testing l3out_route_tag_policy attribute: annotation=4krtdvr2q8icoszun88j0d28kgrcco7lzhpffb8fqgwnm4y2jti3t1h3rcpaaiv48figh24g9yylrhp9tipofugnhxk7quzo6i20rcpjnsf7xr6nf2q4u4n1q9npkr9i9
=== STEP  testing l3out_route_tag_policy attribute: name_alias=4kx28r3kfn7mvqe98kdqejopu1nfpaxh2wba966mf3fexlqxwv0yz9ktt8b3ul94
=== STEP  testing l3out_route_tag_policy attribute: tag=acctest_7g4yo
=== STEP  testing l3out_route_tag_policy attribute: atylt=acctest_7g4yo
=== STEP  testing l3out_route_tag_policy creation with required arguments only
=== PAUSE TestAccAciL3outRouteTagPolicy_Negative
=== RUN   TestAccAciL3outRouteTagPolicy_MultipleCreateDelete
=== STEP  creating multiple L3outRouteTagPolicy
=== STEP  testing l3out_route_tag_policy destroy
--- PASS: TestAccAciL3outRouteTagPolicy_MultipleCreateDelete (26.52s)
=== CONT  TestAccAciL3outRouteTagPolicyDataSource_Basic
=== CONT  TestAccAciL3outRouteTagPolicy_Negative
=== CONT  TestAccAciL3outRouteTagPolicy_Basic
=== STEP  testing l3out_route_tag_policy destroy
--- PASS: TestAccAciL3outRouteTagPolicyDataSource_Basic (59.15s)
=== STEP  testing l3out_route_tag_policy destroy
--- PASS: TestAccAciL3outRouteTagPolicy_Negative (88.65s)
=== STEP  testing l3out_route_tag_policy destroy
--- PASS: TestAccAciL3outRouteTagPolicy_Basic (129.60s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   159.146s