### PR TITLE
Taboo contract

### DIFF
--- a/testacc/data_source_aci_vztaboo_test.go
+++ b/testacc/data_source_aci_vztaboo_test.go
@@ -1,0 +1,184 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciTabooContractDataSource_Basic(t *testing.T) {
+	resourceName := "aci_taboo_contract.test"
+	dataSourceName := "data.aci_taboo_contract.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciTabooContractDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateTabooContractDSWithoutName(rName),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateTabooContractDSWithoutTenantdn(rName),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccTabooContractConfigDataSource(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "tenant_dn", resourceName, "tenant_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+				),
+			},
+			{
+				Config:      CreateAccTabooContractDataSourceUpdate(rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccTabooContractDSWithInvalidParentDn(rName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccTabooContractDataSourceUpdate(rName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccTabooContractConfigDataSource(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing taboo_contract creation with required arguements only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_taboo_contract" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_taboo_contract" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_taboo_contract.test.name
+		depends_on = [
+			aci_taboo_contract.test
+		]
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+func CreateAccTabooContractDSWithInvalidParentDn(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing taboo_contract creation with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_taboo_contract" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_taboo_contract" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "${aci_taboo_contract.test.name}_invalid"
+		depends_on = [
+			aci_taboo_contract.test
+		]
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccTabooContractDataSourceUpdate(fvTenantName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing taboo_contract creation with required arguements only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_taboo_contract" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_taboo_contract" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_taboo_contract.test.name
+		%s = "%s"
+		depends_on = [
+			aci_taboo_contract.test
+		]
+	}
+	`, fvTenantName, rName, key, value)
+	return resource
+}
+
+func CreateTabooContractDSWithoutName(rName string) string {
+	fmt.Println("=== STEP  Basic: testing Taboo Contract data source reading without giving name")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_taboo_contract" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_taboo_contract" "test" {
+		tenant_dn  = aci_tenant.test.id
+		depends_on = [
+			aci_taboo_contract.test
+		]
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateTabooContractDSWithoutTenantdn(rName string) string {
+	fmt.Println("=== STEP  Basic: testing Taboo Contract data source reading without giving name")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_taboo_contract" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_taboo_contract" "test" {
+		name  = aci_taboo_contract.test.name
+		depends_on = [
+			aci_taboo_contract.test
+		]
+	}
+	`, rName, rName)
+	return resource
+}

--- a/testacc/data_source_aci_vztaboo_test.go
+++ b/testacc/data_source_aci_vztaboo_test.go
@@ -58,7 +58,7 @@ func TestAccAciTabooContractDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccTabooContractConfigDataSource(fvTenantName, rName string) string {
-	fmt.Println("=== STEP  testing taboo_contract creation with required arguements only")
+	fmt.Println("=== STEP  testing taboo_contract creation with required arguments only")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {
@@ -98,8 +98,8 @@ func CreateAccTabooContractDSWithInvalidParentDn(fvTenantName, rName string) str
 	}
 
 	data "aci_taboo_contract" "test" {
-		tenant_dn  = aci_tenant.test.id
-		name  = "${aci_taboo_contract.test.name}_invalid"
+		tenant_dn  = "${aci_tenant.test.id}_invalid"
+		name  = aci_taboo_contract.test.name
 		depends_on = [
 			aci_taboo_contract.test
 		]
@@ -109,7 +109,7 @@ func CreateAccTabooContractDSWithInvalidParentDn(fvTenantName, rName string) str
 }
 
 func CreateAccTabooContractDataSourceUpdate(fvTenantName, rName, key, value string) string {
-	fmt.Println("=== STEP  testing taboo_contract creation with required arguements only")
+	fmt.Println("=== STEP  testing taboo_contract Updation with required arguments only")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {
@@ -160,7 +160,7 @@ func CreateTabooContractDSWithoutName(rName string) string {
 }
 
 func CreateTabooContractDSWithoutTenantdn(rName string) string {
-	fmt.Println("=== STEP  Basic: testing Taboo Contract data source reading without giving name")
+	fmt.Println("=== STEP  Basic: testing Taboo Contract data source reading without giving Tenant Dn")
 	resource := fmt.Sprintf(`
 	resource "aci_tenant" "test" {
 		name 		= "%s"

--- a/testacc/resource_aci_vztaboo_test.go
+++ b/testacc/resource_aci_vztaboo_test.go
@@ -1,0 +1,431 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciTabooContract_Basic(t *testing.T) {
+	var taboo_contract_default models.TabooContract
+	var taboo_contract_updated models.TabooContract
+	resourceName := "aci_taboo_contract.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciTabooContractDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateTabooContractWithoutRequired(rName, rName, "tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateTabooContractWithoutRequired(rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccTabooContractConfig(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTabooContractExists(resourceName, &taboo_contract_default),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+				),
+			},
+			{
+				// in this step all optional attribute expect realational attribute are given for the same resource and then compared
+				Config: CreateAccTabooContractConfigWithOptionalValues(rName, rName), // configuration to update optional filelds
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTabooContractExists(resourceName, &taboo_contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_taboo_contract"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccTabooContractConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config: CreateAccTabooContractConfigWithRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTabooContractExists(resourceName, &taboo_contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciTabooContractIdNotEqual(&taboo_contract_default, &taboo_contract_updated),
+				),
+			},
+			{
+				Config: CreateAccTabooContractConfig(rName, rName),
+			},
+			{
+				Config: CreateAccTabooContractConfigWithRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTabooContractExists(resourceName, &taboo_contract_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciTabooContractIdNotEqual(&taboo_contract_default, &taboo_contract_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciTabooContract_Update(t *testing.T) {
+	var taboo_contract_default models.TabooContract
+	//var taboo_contract_updated models.TabooContract
+	resourceName := "aci_taboo_contract.test"
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciTabooContractDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccTabooContractConfig(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTabooContractExists(resourceName, &taboo_contract_default),
+				),
+			},
+
+			{
+				Config: CreateAccTabooContractConfig(rName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciTabooContract_Negative(t *testing.T) {
+	//var taboo_contract_default models.TabooContract
+	//var taboo_contract_updated models.TabooContract
+	//resourceName := "aci_taboo_contract.test"
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciTabooContractDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccTabooContractConfig(rName, rName),
+			},
+			{
+				Config:      CreateAccTabooContractWithInValidParentDn(rName, rName),
+				ExpectError: regexp.MustCompile(`configured object (.)+ not found (.)+,`),
+			},
+			{
+				Config:      CreateAccTabooContractUpdatedAttr(rName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccTabooContractUpdatedAttr(rName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccTabooContractUpdatedAttr(rName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccTabooContractUpdatedAttr(rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named(.)+is not expected here.`),
+			},
+			{
+				Config: CreateAccTabooContractConfig(rName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciTabooContract_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciTabooContractDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config: CreateAccTabooContractConfig(rName, rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciTabooContractExists(name string, taboo_contract *models.TabooContract) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Taboo Contract %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Taboo Contract dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		taboo_contractFound := models.TabooContractFromContainer(cont)
+		if taboo_contractFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Taboo Contract %s not found", rs.Primary.ID)
+		}
+		*taboo_contract = *taboo_contractFound
+		return nil
+	}
+}
+
+func testAccCheckAciTabooContractDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing taboo_contract destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_taboo_contract" {
+			cont, err := client.Get(rs.Primary.ID)
+			taboo_contract := models.TabooContractFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Taboo Contract %s Still exists", taboo_contract.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciTabooContractIdEqual(m1, m2 *models.TabooContract) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("taboo_contract DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciTabooContractIdNotEqual(m1, m2 *models.TabooContract) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("taboo_contract DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateTabooContractWithoutRequired(fvTenantName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing taboo_contract creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+		
+	}
+	
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	resource "aci_taboo_contract" "test" {
+#		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_taboo_contract" "test" {
+		tenant_dn  = aci_tenant.test.id
+#		name = "%s"
+
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, rName)
+}
+
+func CreateAccTabooContractConfigWithRequiredParams(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing taboo_contract creation with required arguements only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_taboo_contract" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccTabooContractConfig(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing taboo_contract creation with required arguements only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_taboo_contract" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccTabooContractConfigs(rName string) string {
+	fmt.Println("=== STEP  testing taboo_contract multiple creation")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_taboo_contract" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+
+	}
+	resource "aci_taboo_contract" "test1" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+
+	}
+	resource "aci_taboo_contract" "test2" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+
+	}
+	`, rName, rName, rName+"1", rName+"2")
+	return resource
+}
+
+func CreateAccTabooContractWithInValidParentDn(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing taboo_contract creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_taboo_contract" "test" {
+		tenant_dn  = "${aci_tenant.test.id}invalid"
+		name  = "%s"	
+	
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccTabooContractConfigWithOptionalValues(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing taboo_contract creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_taboo_contract" "test" {
+		tenant_dn  = "${aci_tenant.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_taboo_contract"
+		
+	}
+	`, fvTenantName, rName)
+
+	return resource
+}
+
+func CreateAccTabooContractRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing taboo_contract creation with optional parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_taboo_contract" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_taboo_contract"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccTabooContractConfigUpdatedName(longerName string) string {
+	fmt.Println("=== STEP  Basic: testing Tabboo Contract creation with invalid name with long length")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "aci_tenant"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_taboo_contract" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, longerName)
+	return resource
+}
+
+func CreateAccTabooContractUpdatedAttr(fvTenantName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing taboo_contract attribute: %s=%s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_taboo_contract" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+
+	}
+	`, fvTenantName, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_vztaboo_test.go
+++ b/testacc/resource_aci_vztaboo_test.go
@@ -44,8 +44,8 @@ func TestAccAciTabooContract_Basic(t *testing.T) {
 				),
 			},
 			{
-				// in this step all optional attribute expect realational attribute are given for the same resource and then compared
-				Config: CreateAccTabooContractConfigWithOptionalValues(rName, rName), // configuration to update optional filelds
+
+				Config: CreateAccTabooContractConfigWithOptionalValues(rName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciTabooContractExists(resourceName, &taboo_contract_updated),
 					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
@@ -61,7 +61,7 @@ func TestAccAciTabooContract_Basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:      CreateAccTabooContractConfigUpdatedName(acctest.RandString(65)),
+				Config:      CreateAccTabooContractConfigUpdatedName(rName, acctest.RandString(65)),
 				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
 			},
 
@@ -90,35 +90,7 @@ func TestAccAciTabooContract_Basic(t *testing.T) {
 	})
 }
 
-func TestAccAciTabooContract_Update(t *testing.T) {
-	var taboo_contract_default models.TabooContract
-	//var taboo_contract_updated models.TabooContract
-	resourceName := "aci_taboo_contract.test"
-	rName := makeTestVariable(acctest.RandString(5))
-
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviders,
-		CheckDestroy:      testAccCheckAciTabooContractDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: CreateAccTabooContractConfig(rName, rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciTabooContractExists(resourceName, &taboo_contract_default),
-				),
-			},
-
-			{
-				Config: CreateAccTabooContractConfig(rName, rName),
-			},
-		},
-	})
-}
-
 func TestAccAciTabooContract_Negative(t *testing.T) {
-	//var taboo_contract_default models.TabooContract
-	//var taboo_contract_updated models.TabooContract
-	//resourceName := "aci_taboo_contract.test"
 	rName := makeTestVariable(acctest.RandString(5))
 
 	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
@@ -170,7 +142,7 @@ func TestAccAciTabooContract_MultipleCreateDelete(t *testing.T) {
 		Steps: []resource.TestStep{
 
 			{
-				Config: CreateAccTabooContractConfig(rName, rName),
+				Config: CreateAccTabooContractConfigs(rName),
 			},
 		},
 	})
@@ -272,7 +244,7 @@ func CreateTabooContractWithoutRequired(fvTenantName, rName, attrName string) st
 }
 
 func CreateAccTabooContractConfigWithRequiredParams(fvTenantName, rName string) string {
-	fmt.Println("=== STEP  testing taboo_contract creation with required arguements only")
+	fmt.Println("=== STEP  testing taboo_contract creation with required arguments only")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {
@@ -290,7 +262,7 @@ func CreateAccTabooContractConfigWithRequiredParams(fvTenantName, rName string) 
 }
 
 func CreateAccTabooContractConfig(fvTenantName, rName string) string {
-	fmt.Println("=== STEP  testing taboo_contract creation with required arguements only")
+	fmt.Println("=== STEP  testing taboo_contract creation with required arguments only")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {
@@ -393,11 +365,11 @@ func CreateAccTabooContractRemovingRequiredField() string {
 	return resource
 }
 
-func CreateAccTabooContractConfigUpdatedName(longerName string) string {
-	fmt.Println("=== STEP  Basic: testing Tabboo Contract creation with invalid name with long length")
+func CreateAccTabooContractConfigUpdatedName(rName, longerName string) string {
+	fmt.Println("=== STEP  Basic: testing Tabboo Contract Updation with invalid name of long length")
 	resource := fmt.Sprintf(`
 	resource "aci_tenant" "test" {
-		name 		= "aci_tenant"
+		name 		= "%s"
 		description = "tenant created while acceptance testing"
 	
 	}
@@ -406,7 +378,7 @@ func CreateAccTabooContractConfigUpdatedName(longerName string) string {
 		tenant_dn  = aci_tenant.test.id
 		name  = "%s"
 	}
-	`, longerName)
+	`, rName, longerName)
 	return resource
 }
 


### PR DESCRIPTION
=== RUN   TestAccAciTabooContractDataSource_Basic
=== STEP  Basic: testing Taboo Contract data source reading without giving name
=== STEP  Basic: testing Taboo Contract data source reading without giving Tenant Dn
=== STEP  testing taboo_contract creation with required arguments only
=== STEP  testing taboo_contract Updation with required arguments only
=== STEP  testing taboo_contract creation with Invalid Parent Dn
=== STEP  testing taboo_contract Updation with required arguments only
=== PAUSE TestAccAciTabooContractDataSource_Basic
=== RUN   TestAccAciTabooContract_Basic
=== STEP  Basic: testing taboo_contract creation without  tenant_dn
=== STEP  Basic: testing taboo_contract creation without  name
=== STEP  testing taboo_contract creation with required arguments only
=== STEP  Basic: testing taboo_contract creation with optional parameters
=== STEP  Basic: testing Tabboo Contract Updation with invalid name of long length
=== STEP  testing taboo_contract creation with required arguments only
=== STEP  testing taboo_contract creation with required arguments only
=== STEP  testing taboo_contract creation with required arguments only
=== PAUSE TestAccAciTabooContract_Basic
=== RUN   TestAccAciTabooContract_Negative
=== STEP  testing taboo_contract creation with required arguments only
=== STEP  Negative Case: testing taboo_contract creation with invalid parent Dn
=== STEP  testing taboo_contract attribute: description=klsyfhjpty7t2v0d4xgyoheabcm0e632vbszlql3vnixsty88miju1l61wc9nr087xbxmxtgdwbhyneji2v0cezeklzrdioo3um4ds7hwuh9zv4w499adbh2poylakvkg
=== STEP  testing taboo_contract attribute: annotation=l69ys0tftfezlv4ijr6mxl0eelxs3c2dimoddhccezjelke33ch1opck4yusx2rzzeqhhye0pqgcowzza6rwq64m7u6ijj716optiivkjbyhwgz34vywo2csfj6sxjyjo
=== STEP  testing taboo_contract attribute: name_alias=bb6ypz3e0ma8ekbxt3rg70sg2k7ci0qv3qat0h7hi8c1v2dud326q0rag76keh43
=== STEP  testing taboo_contract attribute: kpqpv=acctest_tz0go
=== STEP  testing taboo_contract creation with required arguments only
=== PAUSE TestAccAciTabooContract_Negative
=== RUN   TestAccAciTabooContract_MultipleCreateDelete
=== STEP  testing taboo_contract multiple creation
=== PAUSE TestAccAciTabooContract_MultipleCreateDelete
=== CONT  TestAccAciTabooContractDataSource_Basic
=== CONT  TestAccAciTabooContract_Negative
=== CONT  TestAccAciTabooContract_Basic
=== CONT  TestAccAciTabooContract_MultipleCreateDelete
=== STEP  testing taboo_contract destroy
--- PASS: TestAccAciTabooContract_MultipleCreateDelete (54.65s)
=== STEP  testing taboo_contract destroy
--- PASS: TestAccAciTabooContractDataSource_Basic (116.62s)
=== STEP  testing taboo_contract destroy
--- PASS: TestAccAciTabooContract_Negative (158.95s)
=== STEP  testing taboo_contract destroy
--- PASS: TestAccAciTabooContract_Basic (246.02s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   247.676s
