### PR TITLE
updated invalid parent_dn testcase in taboo_contract_modifications

### DIFF
--- a/testacc/resource_aci_vztaboo_test.go
+++ b/testacc/resource_aci_vztaboo_test.go
@@ -106,7 +106,7 @@ func TestAccAciTabooContract_Negative(t *testing.T) {
 			},
 			{
 				Config:      CreateAccTabooContractWithInValidParentDn(rName, rName),
-				ExpectError: regexp.MustCompile(`configured object (.)+ not found (.)+,`),
+				ExpectError: regexp.MustCompile(`unknown property value`),
 			},
 			{
 				Config:      CreateAccTabooContractUpdatedAttr(rName, rName, "description", acctest.RandString(129)),
@@ -309,22 +309,20 @@ func CreateAccTabooContractConfigs(rName string) string {
 	return resource
 }
 
-func CreateAccTabooContractWithInValidParentDn(fvTenantName, rName string) string {
+func CreateAccTabooContractWithInValidParentDn(rName, prName string) string {
 	fmt.Println("=== STEP  Negative Case: testing taboo_contract creation with invalid parent Dn")
 	resource := fmt.Sprintf(`
 	
-	resource "aci_tenant" "test" {
-		name 		= "%s"
-		description = "tenant created while acceptance testing"
-	
+	resource "aci_aaa_domain" "test" {
+		name        = "%s"
 	}
 	
 	resource "aci_taboo_contract" "test" {
-		tenant_dn  = "${aci_tenant.test.id}invalid"
+		tenant_dn  = aci_aaa_domain.test.id
 		name  = "%s"	
 	
 	}
-	`, fvTenantName, rName)
+	`, prName, rName)
 	return resource
 }
 


### PR DESCRIPTION
kanchi.shukla@CLW511-831 MINGW64 ~/Desktop/Bug/terraform-provider-aci (s2-dev)
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?       github.com/terraform-providers/terraform-provider-aci   [no test files]
?       github.com/terraform-providers/terraform-provider-aci/aci       [no test files]
=== RUN   TestAccAciTabooContractDataSource_Basic
=== STEP  Basic: testing Taboo Contract data source reading without giving name
=== STEP  Basic: testing Taboo Contract data source reading without giving Tenant Dn
=== STEP  testing taboo_contract creation with required arguments only
=== STEP  testing taboo_contract Updation with required arguments only
=== STEP  testing taboo_contract creation with Invalid Parent Dn
=== STEP  testing taboo_contract Updation with required arguments only
=== PAUSE TestAccAciTabooContractDataSource_Basic
=== RUN   TestProvider
--- PASS: TestProvider (0.02s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccAciTabooContract_Basic
=== STEP  Basic: testing taboo_contract creation without  tenant_dn
=== STEP  Basic: testing taboo_contract creation without  name
=== STEP  testing taboo_contract creation with required arguments only
=== STEP  Basic: testing taboo_contract creation with optional parameters
=== STEP  Basic: testing Tabboo Contract Updation with invalid name of long length
=== STEP  testing taboo_contract creation with required arguments only
=== STEP  testing taboo_contract creation with required arguments only
=== STEP  testing taboo_contract creation with required arguments only
=== PAUSE TestAccAciTabooContract_Basic
=== RUN   TestAccAciTabooContract_Negative
=== STEP  testing taboo_contract creation with required arguments only
=== STEP  Negative Case: testing taboo_contract creation with invalid parent Dn
=== STEP  testing taboo_contract attribute: description=dwtqnu7mflukwywnmuofpj0nrjzn6v6fhnq9s9lqusbo7exxzxynqx9zq4ino0wfnvhfx2qv38dgfspzfg61y67cfpmr9u8hxzwkv6bmntxxgsntfx3y9kkdspyxl8xzd
=== STEP  testing taboo_contract attribute: annotation=h4ptyewijnem0qewjr8oqtuzwp8m4qxl7til62uohcvenmt78x76jxv2pxwzwsie18f9p4244r68pzr3gjx7phkdgor6y3dz7nuw3r8e3b2rui4zo93wctb9tmoksi6zo
=== STEP  testing taboo_contract attribute: name_alias=hco1xqu1svzryl37qnegs81xf32jmokmz2ps6drz6eg9kz6p6f4mhjsqpl4owoz0
=== STEP  testing taboo_contract attribute: lidrr=acctest_71zfx
=== STEP  testing taboo_contract creation with required arguments only
=== PAUSE TestAccAciTabooContract_Negative
=== RUN   TestAccAciTabooContract_MultipleCreateDelete
=== STEP  testing taboo_contract multiple creation
=== PAUSE TestAccAciTabooContract_MultipleCreateDelete
=== CONT  TestAccAciTabooContractDataSource_Basic
=== CONT  TestAccAciTabooContract_Negative
=== CONT  TestAccAciTabooContract_MultipleCreateDelete
=== CONT  TestAccAciTabooContract_Basic
=== STEP  testing taboo_contract destroy
--- PASS: TestAccAciTabooContract_MultipleCreateDelete (21.45s)
=== STEP  testing taboo_contract destroy
--- PASS: TestAccAciTabooContractDataSource_Basic (48.21s)
=== STEP  testing taboo_contract destroy
--- PASS: TestAccAciTabooContract_Negative (66.68s)
=== STEP  testing taboo_contract destroy
--- PASS: TestAccAciTabooContract_Basic (101.31s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   103.440s