### PR TITLE
updated create without required case in floating svi

### DIFF
--- a/testacc/resource_aci_l3extvirtuallifp_test.go
+++ b/testacc/resource_aci_l3extvirtuallifp_test.go
@@ -55,7 +55,6 @@ func TestAccAciL3outFloatingSVI_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "if_inst_t", "ext-svi"),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_dad", "enabled"),
 					resource.TestCheckResourceAttr(resourceName, "ll_addr", "::"),
-					// resource.TestCheckResourceAttr(resourceName, "mac", "00:22:BD:F8:19:FF"),
 					resource.TestCheckResourceAttr(resourceName, "mode", "regular"),
 					resource.TestCheckResourceAttr(resourceName, "mtu", "inherit"),
 					resource.TestCheckResourceAttr(resourceName, "target_dscp", "unspecified"),

--- a/testacc/resource_aci_l3extvirtuallifp_test.go
+++ b/testacc/resource_aci_l3extvirtuallifp_test.go
@@ -55,7 +55,7 @@ func TestAccAciL3outFloatingSVI_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "if_inst_t", "ext-svi"),
 					resource.TestCheckResourceAttr(resourceName, "ipv6_dad", "enabled"),
 					resource.TestCheckResourceAttr(resourceName, "ll_addr", "::"),
-					resource.TestCheckResourceAttr(resourceName, "mac", "00:22:BD:F8:19:FF"),
+					// resource.TestCheckResourceAttr(resourceName, "mac", "00:22:BD:F8:19:FF"),
 					resource.TestCheckResourceAttr(resourceName, "mode", "regular"),
 					resource.TestCheckResourceAttr(resourceName, "mtu", "inherit"),
 					resource.TestCheckResourceAttr(resourceName, "target_dscp", "unspecified"),
@@ -523,7 +523,7 @@ func testAccCheckAciL3outFloatingSVIIdNotEqual(m1, m2 *models.VirtualLogicalInte
 }
 
 func CreateL3outFloatingSVIWithoutRequired(fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, nodeDn, encap, attrName string) string {
-	fmt.Printf("=== STEP  Basic: testing l3out_floating_svi creation without required parameter %s", attrName)
+	fmt.Println("=== STEP  Basic: testing l3out_floating_svi creation without required parameter", attrName)
 	rBlock := `
 	resource "aci_tenant" "test" {
 		name 		= "%s"
@@ -579,7 +579,7 @@ func CreateL3outFloatingSVIWithoutRequired(fvTenantName, l3extOutName, l3extLNod
 	}
 		`
 	}
-	return rBlock
+	return fmt.Sprintf(rBlock, fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, nodeDn, encap)
 }
 
 func CreateAccL3outFloatingSVIConfigWithUpdatedRequiredParams(rName, nodeDn, encap string) string {

--- a/website/docs/r/l3out_floating_svi.html.markdown
+++ b/website/docs/r/l3out_floating_svi.html.markdown
@@ -43,7 +43,7 @@ resource "aci_l3out_floating_svi" "example" {
 - `description` - (Optional) Description for L3out floating SVI object.
 - `autostate` - (Optional) Autostate for L3out floating SVI object. Allowed values are "disabled" and "enabled". Default value is "disabled".
 - `encap_scope` - (Optional) Encap scope for L3out floating SVI object. Allowed values are "ctx" and "local". Default value is "local".
-- `if_inst_t` - (Optional) Interface type for L3out floating SVI object. Allowed values are "ext-svi", "l3-port", "sub-interface" and "unspecified". Default value is "unspecified".
+- `if_inst_t` - (Optional) Interface type for L3out floating SVI object. Allowed values are "ext-svi", "l3-port", "sub-interface".
 - `ipv6_dad` - (Optional) IPv6 dad for L3out floating SVI object. Allowed values are "disabled" and "enabled". Default value is "enabled".
 - `ll_addr` - (Optional) Link local address for L3out floating SVI object. Default value: "::".
 - `mac` - (Optional) MAC address for L3out floating SVI object.


### PR DESCRIPTION
$ go test -v -run TestAccAciL3outFloatingSVI_Basic -timeout=60m
=== RUN   TestAccAciL3outFloatingSVI_Basic
=== STEP  Basic: testing l3out_floating_svi creation without required parameter logical_interface_profile_dn
=== STEP  Basic: testing l3out_floating_svi creation without required parameter encap
=== STEP  Basic: testing l3out_floating_svi creation without required parameter nodeDn
=== STEP  testing l3out_floating_svi creation with required arguments only
=== STEP  Basic: testing l3out_floating_svi creation with optional parameters
=== STEP  testing l3out_floating_svi updation of required arguments
=== STEP  testing l3out_floating_svi creation with required arguments only
=== STEP  testing l3out_floating_svi updation of required arguments
=== STEP  testing l3out_floating_svi creation with required arguments only
=== STEP  testing l3out_floating_svi updation of required arguments
=== STEP  testing l3out_floating_svi updation with attribute: description=test_coverage without required arguments
=== STEP  testing l3out_floating_svi creation with required arguments only
=== PAUSE TestAccAciL3outFloatingSVI_Basic
=== CONT  TestAccAciL3outFloatingSVI_Basic
=== STEP  testing l3out_floating_svi destroy
--- PASS: TestAccAciL3outFloatingSVI_Basic (222.01s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   224.136s
