### PR TITLE
fixed floating svi and hsrp interface profile

### DIFF
--- a/aci/resource_aci_hsrpifpol.go
+++ b/aci/resource_aci_hsrpifpol.go
@@ -44,6 +44,7 @@ func resourceAciHSRPInterfacePolicy() *schema.Resource {
 			"ctrl": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{

--- a/testacc/data_source_aci_hsrpifpol_test.go
+++ b/testacc/data_source_aci_hsrpifpol_test.go
@@ -60,7 +60,7 @@ func TestAccAciHsrpInterfacePolicyDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccHsrpInterfacePolicyUpdatedConfigDataSourceRandomAttr(rName, attribute, value string) string {
-	fmt.Println("=== STEP  Basic: Testing Hrsp Interface Policy data source with updated resource")
+	fmt.Println("=== STEP  Basic: Testing Hrsp Interface Policy data source with random attribute")
 	resource := fmt.Sprintf(`
 	resource "aci_tenant" "test" {
 		name = "%s"

--- a/testacc/resource_aci_hsrpifpol_test.go
+++ b/testacc/resource_aci_hsrpifpol_test.go
@@ -139,7 +139,14 @@ func TestAccAciHsrpInterfacePolicy_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: CreateAccHsrpInterfacePolicyUpdatedAttrList(rName, rName, "ctrl", StringListtoString([]string{"bia"})),
+				Config: CreateAccHsrpInterfacePolicyUpdatedAttrList(rName, rName, "ctrl", StringListtoString([]string{"bfd", "bia"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHsrpInterfacePolicyExists(resourceName, &hsrp_interface_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.0", "bfd"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.1", "bia"),
+					testAccCheckAciHsrpInterfacePolicyIdEqual(&hsrp_interface_policy_default, &hsrp_interface_policy_updated),
+				),
 			},
 			{
 				Config: CreateAccHsrpInterfacePolicyUpdatedAttr(rName, rName, "delay", "5000"),
@@ -158,7 +165,7 @@ func TestAccAciHsrpInterfacePolicy_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: CreateAccHsrpInterfacePolicyUpdatedAttr(rName, rName, "reload_delay", "000"),
+				Config: CreateAccHsrpInterfacePolicyUpdatedAttr(rName, rName, "reload_delay", "5000"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciHsrpInterfacePolicyExists(resourceName, &hsrp_interface_policy_updated),
 					resource.TestCheckResourceAttr(resourceName, "reload_delay", "5000"),


### PR DESCRIPTION
$ go test -v -run TestAccAciHsrpInterfacePolicy_Update -timeout=60m
=== RUN   TestAccAciHsrpInterfacePolicy_Update
=== STEP  testing hsrp_interface_policy creation with required arguments only
=== STEP  testing hsrp_interface_policy attribute: ctrl=["bia"]
=== STEP  testing hsrp_interface_policy attribute: ctrl=["bia","bfd"]
=== STEP  testing hsrp_interface_policy attribute: ctrl=["bfd","bia"]
=== STEP  testing hsrp_interface_policy attribute: delay=5000
=== STEP  testing hsrp_interface_policy attribute: delay=10000
=== STEP  testing hsrp_interface_policy attribute: reload_delay=5000
=== STEP  testing hsrp_interface_policy attribute: reload_delay=10000
=== PAUSE TestAccAciHsrpInterfacePolicy_Update
=== CONT  TestAccAciHsrpInterfacePolicy_Update
=== STEP  testing hsrp_interface_policy destroy
--- PASS: TestAccAciHsrpInterfacePolicy_Update (100.72s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   103.246s
$ go test -v -run TestAccAciL3outFloatingSVIDataSource_Basic -timeout=60m
=== RUN   TestAccAciL3outFloatingSVIDataSource_Basic
=== STEP  testing l3out_floating_svi creation data source without logical_interface_profile_dn
=== STEP  testing l3out_floating_svi data source without encap
=== STEP  testing l3out_floating_svi data source without node_dn
=== STEP  testing l3out_floating_svi data source with required arguments only
=== STEP  testing l3out_floating_svi data source with random arguments
=== STEP  testing l3out_floating_svi data source with Invalid Parent Dn
=== STEP  testing l3out_floating_svi data source with updated resource
=== PAUSE TestAccAciL3outFloatingSVIDataSource_Basic
=== CONT  TestAccAciL3outFloatingSVIDataSource_Basic
=== STEP  testing l3out_floating_svi destroy
--- PASS: TestAccAciL3outFloatingSVIDataSource_Basic (76.74s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   79.285s
$ go test -v -run TestAccAciHsrpInterfacePolicyDataSource_Basic -timeout=60m
=== RUN   TestAccAciHsrpInterfacePolicyDataSource_Basic
=== STEP  Basic: testing Hsrp Interface Policy reading without giving tenant_dn
=== STEP  Basic: testing Hsrp Interface Policy reading without giving name
=== STEP  Basic: Testing Hsrp Interface Policy data source
=== STEP  Basic: Testing Hrsp Interface Policy data source with random attribute
=== STEP  Basic: Testing Hsrp Interface Policy data source with updated resource
=== STEP  Basic: testing Hsrp Interface Policy reading with invalid name
=== PAUSE TestAccAciHsrpInterfacePolicyDataSource_Basic
=== CONT  TestAccAciHsrpInterfacePolicyDataSource_Basic
=== STEP  testing hsrp_interface_policy destroy
--- PASS: TestAccAciHsrpInterfacePolicyDataSource_Basic (39.29s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   41.800s
