### PR TITLE
Added bgpprotp, fabrichifpol and fcifpol

### DIFF
--- a/aci/resource_aci_bfdifp.go
+++ b/aci/resource_aci_bfdifp.go
@@ -61,8 +61,8 @@ func resourceAciBFDInterfaceProfile() *schema.Resource {
 			},
 
 			"relation_bfd_rs_if_pol": &schema.Schema{
-				Type:     schema.TypeString,
-				
+				Type: schema.TypeString,
+
 				Optional: true,
 			},
 		}),

--- a/aci/resource_aci_fvaepg.go
+++ b/aci/resource_aci_fvaepg.go
@@ -140,12 +140,12 @@ func resourceAciApplicationEPG() *schema.Resource {
 			},
 
 			"relation_fv_rs_bd": &schema.Schema{
-				Type:     schema.TypeString,
-	
+				Type: schema.TypeString,
+
 				Optional: true,
 			},
 			"relation_fv_rs_cust_qos_pol": &schema.Schema{
-				Type:     schema.TypeString,
+				Type: schema.TypeString,
 
 				Optional: true,
 			},

--- a/aci/resource_aci_fvap.go
+++ b/aci/resource_aci_fvap.go
@@ -60,8 +60,8 @@ func resourceAciApplicationProfile() *schema.Resource {
 			},
 
 			"relation_fv_rs_ap_mon_pol": &schema.Schema{
-				Type:     schema.TypeString,
-	
+				Type: schema.TypeString,
+
 				Optional: true,
 			},
 		}),

--- a/aci/resource_aci_fvctx.go
+++ b/aci/resource_aci_fvctx.go
@@ -91,12 +91,12 @@ func resourceAciVRF() *schema.Resource {
 			},
 
 			"relation_fv_rs_ospf_ctx_pol": &schema.Schema{
-				Type:     schema.TypeString,
-	
+				Type: schema.TypeString,
+
 				Optional: true,
 			},
 			"relation_fv_rs_vrf_validation_pol": &schema.Schema{
-				Type:     schema.TypeString,
+				Type: schema.TypeString,
 
 				Optional: true,
 			},
@@ -141,12 +141,12 @@ func resourceAciVRF() *schema.Resource {
 				},
 			},
 			"relation_fv_rs_ctx_to_ep_ret": &schema.Schema{
-				Type:     schema.TypeString,
+				Type: schema.TypeString,
 
 				Optional: true,
 			},
 			"relation_fv_rs_bgp_ctx_pol": &schema.Schema{
-				Type:     schema.TypeString,
+				Type: schema.TypeString,
 
 				Optional: true,
 			},
@@ -156,7 +156,7 @@ func resourceAciVRF() *schema.Resource {
 				Optional: true,
 			},
 			"relation_fv_rs_ctx_to_ext_route_tag_pol": &schema.Schema{
-				Type:     schema.TypeString,
+				Type: schema.TypeString,
 
 				Optional: true,
 			},

--- a/aci/resource_aci_fvtenant.go
+++ b/aci/resource_aci_fvtenant.go
@@ -45,8 +45,8 @@ func resourceAciTenant() *schema.Resource {
 				Set:      schema.HashString,
 			},
 			"relation_fv_rs_tenant_mon_pol": &schema.Schema{
-				Type:     schema.TypeString,
-			
+				Type: schema.TypeString,
+
 				Optional: true,
 			},
 		}),

--- a/aci/resource_aci_l3extinstp.go
+++ b/aci/resource_aci_l3extinstp.go
@@ -39,9 +39,9 @@ func resourceAciExternalNetworkInstanceProfile() *schema.Resource {
 			},
 
 			"exception_tag": &schema.Schema{
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 
 			"flood_on_encap": &schema.Schema{
@@ -157,7 +157,7 @@ func resourceAciExternalNetworkInstanceProfile() *schema.Resource {
 				Set:      schema.HashString,
 			},
 			"relation_fv_rs_cust_qos_pol": &schema.Schema{
-				Type:     schema.TypeString,
+				Type: schema.TypeString,
 
 				Optional: true,
 			},

--- a/aci/resource_aci_l3extlifp.go
+++ b/aci/resource_aci_l3extlifp.go
@@ -73,27 +73,27 @@ func resourceAciLogicalInterfaceProfile() *schema.Resource {
 			},
 
 			"relation_l3ext_rs_egress_qos_dpp_pol": &schema.Schema{
-				Type:     schema.TypeString,
+				Type: schema.TypeString,
 
 				Optional: true,
 			},
 			"relation_l3ext_rs_ingress_qos_dpp_pol": &schema.Schema{
-				Type:     schema.TypeString,
+				Type: schema.TypeString,
 
 				Optional: true,
 			},
 			"relation_l3ext_rs_l_if_p_cust_qos_pol": &schema.Schema{
-				Type:     schema.TypeString,
+				Type: schema.TypeString,
 
 				Optional: true,
 			},
 			"relation_l3ext_rs_arp_if_pol": &schema.Schema{
-				Type:     schema.TypeString,
+				Type: schema.TypeString,
 
 				Optional: true,
 			},
 			"relation_l3ext_rs_nd_if_pol": &schema.Schema{
-				Type:     schema.TypeString,
+				Type: schema.TypeString,
 
 				Optional: true,
 			},

--- a/aci/resource_aci_l3extout.go
+++ b/aci/resource_aci_l3extout.go
@@ -108,7 +108,7 @@ func resourceAciL3Outside() *schema.Resource {
 				},
 			},
 			"relation_l3ext_rs_ectx": &schema.Schema{
-				Type:     schema.TypeString,
+				Type: schema.TypeString,
 
 				Optional: true,
 			},

--- a/testacc/data_source_aci_bgpprotp_test.go
+++ b/testacc/data_source_aci_bgpprotp_test.go
@@ -1,0 +1,233 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciL3outBGPProtocolProfileDataSource_Basic(t *testing.T) {
+	resourceName := "aci_l3out_bgp_protocol_profile.test"
+	dataSourceName := "data.aci_l3out_bgp_protocol_profile.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3outBGPProtocolProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateL3outBGPProtocolProfileDSWithoutRequired(rName, rName, rName, "logical_node_profile_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccL3outBGPProtocolProfileConfigDataSource(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "logical_node_profile_dn", resourceName, "logical_node_profile_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+				),
+			},
+			{
+				Config:      CreateAccL3outBGPProtocolProfileDataSourceUpdateRandomAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccL3outBGPProtocolProfileDSWithInvalidParentDn(rName, rName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccL3outBGPProtocolProfileDataSourceUpdate(rName, rName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateL3outBGPProtocolProfileDSWithoutRequired(fvTenantName, l3extOutName, l3extLNodePName, attribute string) string {
+	fmt.Println("=== STEP  testing l3out_bgp_protocol_profile data source without required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_l3out_bgp_protocol_profile" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+	}
+
+	data "aci_l3out_bgp_protocol_profile" "test" {
+		depends_on = [
+			aci_l3out_bgp_protocol_profile.test
+		]
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName)
+	return resource
+}
+
+func CreateAccL3outBGPProtocolProfileConfigDataSource(fvTenantName, l3extOutName, l3extLNodePName string) string {
+	fmt.Println("=== STEP  testing l3out_bgp_protocol_profile data source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_l3out_bgp_protocol_profile" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+	}
+
+	data "aci_l3out_bgp_protocol_profile" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		depends_on = [
+			aci_l3out_bgp_protocol_profile.test
+		]
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName)
+	return resource
+}
+func CreateAccL3outBGPProtocolProfileDSWithInvalidParentDn(fvTenantName, l3extOutName, l3extLNodePName string) string {
+	fmt.Println("=== STEP  testing l3out_bgp_protocol_profile data source with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_l3out_bgp_protocol_profile" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+	}
+
+	data "aci_l3out_bgp_protocol_profile" "test" {
+		logical_node_profile_dn  = "${aci_logical_node_profile.test.id}invalid"
+		depends_on = [
+			aci_l3out_bgp_protocol_profile.test
+		]
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName)
+	return resource
+}
+
+func CreateAccL3outBGPProtocolProfileDataSourceUpdate(fvTenantName, l3extOutName, l3extLNodePName, key, value string) string {
+	fmt.Println("=== STEP  testing l3out_bgp_protocol_profile data source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_l3out_bgp_protocol_profile" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		%s = "%s"
+
+	}
+
+	data "aci_l3out_bgp_protocol_profile" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		depends_on = [
+			aci_l3out_bgp_protocol_profile.test
+		]
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, key, value)
+	return resource
+}
+
+func CreateAccL3outBGPProtocolProfileDataSourceUpdateRandomAttr(rName, key, value string) string {
+	fmt.Println("=== STEP  testing L3out BGP Protocol Profile data source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_l3out_bgp_protocol_profile" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+	}
+
+	data "aci_l3out_bgp_protocol_profile" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		%s = "%s"
+		depends_on = [
+			aci_l3out_bgp_protocol_profile.test
+		]
+	}
+	`, rName, rName, rName, key, value)
+	return resource
+}

--- a/testacc/resource_aci_bgpprotp_test.go
+++ b/testacc/resource_aci_bgpprotp_test.go
@@ -1,0 +1,458 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciL3outBGPProtocolProfile_Basic(t *testing.T) {
+	var l3out_bgp_protocol_profile_default models.L3outBGPProtocolProfile
+	var l3out_bgp_protocol_profile_updated models.L3outBGPProtocolProfile
+	resourceName := "aci_l3out_bgp_protocol_profile.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	randomValue := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3outBGPProtocolProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateL3outBGPProtocolProfileWithoutRequired(rName, rName, rName, "logical_node_profile_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccL3outBGPProtocolProfileConfig(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outBGPProtocolProfileExists(resourceName, &l3out_bgp_protocol_profile_default),
+					resource.TestCheckResourceAttr(resourceName, "logical_node_profile_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s", rName, rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_bgp_rs_bgp_node_ctx_pol", ""),
+				),
+			},
+			{
+				Config: CreateAccL3outBGPProtocolProfileConfigWithOptionalValues(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outBGPProtocolProfileExists(resourceName, &l3out_bgp_protocol_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "logical_node_profile_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s", rName, rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_l3out_bgp_protocol_profile"),
+					resource.TestCheckResourceAttr(resourceName, "relation_bgp_rs_bgp_node_ctx_pol", ""),
+					testAccCheckAciL3outBGPProtocolProfileIdEqual(&l3out_bgp_protocol_profile_default, &l3out_bgp_protocol_profile_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: CreateAccL3outBGPProtocolProfileConfigWithUpdatedRequiredParams(rName, rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outBGPProtocolProfileExists(resourceName, &l3out_bgp_protocol_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "logical_node_profile_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s", rName, rName, rNameUpdated)),
+					testAccCheckAciL3outBGPProtocolProfileIdNotEqual(&l3out_bgp_protocol_profile_default, &l3out_bgp_protocol_profile_updated),
+				),
+			},
+			{
+				Config:      CreateAccL3outBGPProtocolProfileConfigUpdateWithoutRequiredParams(rName, rName, rName, "annotation", randomValue),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccL3outBGPProtocolProfileConfig(rName, rName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciL3outBGPProtocolProfile_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3outBGPProtocolProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccL3outBGPProtocolProfileConfig(rName, rName, rName),
+			},
+			{
+				Config:      CreateAccL3outBGPProtocolProfileWithInValidParentDn(rName, rName, rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccL3outBGPProtocolProfileUpdatedAttr(rName, rName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccL3outBGPProtocolProfileUpdatedAttr(rName, rName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccL3outBGPProtocolProfileUpdatedAttr(rName, rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named(.)*is not expected here.`),
+			},
+			{
+				Config: CreateAccL3outBGPProtocolProfileConfig(rName, rName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciL3outBGPProtocolProfile_RelationParameters(t *testing.T) {
+	var l3out_bgp_protocol_profile_default models.L3outBGPProtocolProfile
+	var l3out_bgp_protocol_profile_rel models.L3outBGPProtocolProfile
+	resourceName := "aci_l3out_bgp_protocol_profile.test"
+	rName := acctest.RandString(5)
+	randomName1 := acctest.RandString(5)
+	randomName2 := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3outBGPProtocolProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccL3outBGPProtocolProfileConfig(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outBGPProtocolProfileExists(resourceName, &l3out_bgp_protocol_profile_default),
+					resource.TestCheckResourceAttr(resourceName, "relation_bgp_rs_bgp_node_ctx_pol", ""),
+				),
+			},
+			{
+				Config: CreateAccL3outBGPProtocolProfileRelConfig(rName, randomName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outBGPProtocolProfileExists(resourceName, &l3out_bgp_protocol_profile_rel),
+					resource.TestCheckResourceAttr(resourceName, "relation_bgp_rs_bgp_node_ctx_pol", fmt.Sprintf("uni/tn-%s/bgpCtxP-%s", rName, randomName1)),
+					testAccCheckAciL3outBGPProtocolProfileIdEqual(&l3out_bgp_protocol_profile_default, &l3out_bgp_protocol_profile_rel),
+				),
+			},
+			{
+				Config: CreateAccL3outBGPProtocolProfileRelConfig(rName, randomName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outBGPProtocolProfileExists(resourceName, &l3out_bgp_protocol_profile_rel),
+					resource.TestCheckResourceAttr(resourceName, "relation_bgp_rs_bgp_node_ctx_pol", fmt.Sprintf("uni/tn-%s/bgpCtxP-%s", rName, randomName2)),
+					testAccCheckAciL3outBGPProtocolProfileIdEqual(&l3out_bgp_protocol_profile_default, &l3out_bgp_protocol_profile_rel),
+				),
+			},
+			{
+				Config: CreateAccL3outBGPProtocolProfileConfig(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outBGPProtocolProfileExists(resourceName, &l3out_bgp_protocol_profile_default),
+					resource.TestCheckResourceAttr(resourceName, "relation_bgp_rs_bgp_node_ctx_pol", ""),
+				),
+			},
+		},
+	})
+}
+func testAccCheckAciL3outBGPProtocolProfileExists(name string, l3out_bgp_protocol_profile *models.L3outBGPProtocolProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("L3out BGP Protocol Profile %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No L3out BGP Protocol Profile dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		l3out_bgp_protocol_profileFound := models.L3outBGPProtocolProfileFromContainer(cont)
+		if l3out_bgp_protocol_profileFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("L3out BGP Protocol Profile %s not found", rs.Primary.ID)
+		}
+		*l3out_bgp_protocol_profile = *l3out_bgp_protocol_profileFound
+		return nil
+	}
+}
+
+func testAccCheckAciL3outBGPProtocolProfileDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing l3out_bgp_protocol_profile destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_l3out_bgp_protocol_profile" {
+			cont, err := client.Get(rs.Primary.ID)
+			l3out_bgp_protocol_profile := models.L3outBGPProtocolProfileFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("L3out BGP Protocol Profile %s Still exists", l3out_bgp_protocol_profile.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciL3outBGPProtocolProfileIdEqual(m1, m2 *models.L3outBGPProtocolProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("l3out_bgp_protocol_profile DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciL3outBGPProtocolProfileIdNotEqual(m1, m2 *models.L3outBGPProtocolProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("l3out_bgp_protocol_profile DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateL3outBGPProtocolProfileWithoutRequired(fvTenantName, l3extOutName, l3extLNodePName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing l3out_bgp_protocol_profile creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	`
+	switch attrName {
+	case "logical_node_profile_dn":
+		rBlock += `
+	resource "aci_l3out_bgp_protocol_profile" "test" {
+	#	logical_node_profile_dn  = aci_logical_node_profile.test.id
+	}
+		`
+
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, l3extOutName, l3extLNodePName)
+}
+
+func CreateAccL3outBGPProtocolProfileConfigWithUpdatedRequiredParams(fvTenantName, l3extOutName, l3extLNodePName string) string {
+	fmt.Println("=== STEP  testing l3out_bgp_protocol_profile creation with updated required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_l3out_bgp_protocol_profile" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName)
+	return resource
+}
+
+func CreateAccL3outBGPProtocolProfileConfig(fvTenantName, l3extOutName, l3extLNodePName string) string {
+	fmt.Println("=== STEP  testing l3out_bgp_protocol_profile creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_l3out_bgp_protocol_profile" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName)
+	return resource
+}
+
+func CreateAccL3outBGPProtocolProfileRelConfig(rName, relName string) string {
+	fmt.Println("=== STEP  testing l3out_bgp_protocol_profile relation parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_bgp_timers" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_l3out_bgp_protocol_profile" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		relation_bgp_rs_bgp_node_ctx_pol = aci_bgp_timers.test.id
+	}
+	`, rName, rName, rName, relName)
+	return resource
+}
+
+func CreateAccL3outBGPProtocolProfileWithInValidParentDn(fvTenantName, l3extOutName, l3extLNodePName string) string {
+	fmt.Println("=== STEP  Negative Case: testing l3out_bgp_protocol_profile creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_l3out_bgp_protocol_profile" "test" {
+		logical_node_profile_dn  = aci_l3_outside.test.id	
+	}
+	`, fvTenantName, l3extOutName)
+	return resource
+}
+
+func CreateAccL3outBGPProtocolProfileConfigWithOptionalValues(fvTenantName, l3extOutName, l3extLNodePName string) string {
+	fmt.Println("=== STEP  Basic: testing l3out_bgp_protocol_profile creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_l3out_bgp_protocol_profile" "test" {
+		logical_node_profile_dn  = "${aci_logical_node_profile.test.id}"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_l3out_bgp_protocol_profile"	
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName)
+
+	return resource
+}
+
+func CreateAccL3outBGPProtocolProfileConfigUpdateWithoutRequiredParams(fvTenantName, l3extOutName, l3extLNodePName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing l3out_bgp_protocol_profile attribute: %s=%s without required arguments \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_l3out_bgp_protocol_profile" "test" {
+		%s = "%s"
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, attribute, value)
+	return resource
+}
+
+func CreateAccL3outBGPProtocolProfileUpdatedAttr(fvTenantName, l3extOutName, l3extLNodePName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing l3out_bgp_protocol_profile attribute: %s=%s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		description = "l3_outside created while acceptance testing"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		description = "logical_node_profile created while acceptance testing"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_l3out_bgp_protocol_profile" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		%s = "%s"
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_fabrichifpol_test.go
+++ b/testacc/resource_aci_fabrichifpol_test.go
@@ -12,28 +12,28 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccAciFabricIFPol_Basic(t *testing.T) {
-	var fabric_if_pol_default models.LinkLevelPolicy
-	var fabric_if_pol_updated models.LinkLevelPolicy
+func TestAccAciFabricIfPolicy_Basic(t *testing.T) {
+	var fabric_if_policy_default models.LinkLevelPolicy
+	var fabric_if_policy_updated models.LinkLevelPolicy
 	resourceName := "aci_fabric_if_pol.test"
 	rName := makeTestVariable(acctest.RandString(5))
 	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	randomValue := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
-		CheckDestroy:      testAccCheckAciFabricIFPolDestroy,
+		CheckDestroy:      testAccCheckAciFabricIfPolicyDestroy,
 		Steps: []resource.TestStep{
 
 			{
-				Config:      CreateFabricIFPolWithoutRequired(rName, "name"),
+				Config:      CreateFabricIfPolicyWithoutName(rName, "name"),
 				ExpectError: regexp.MustCompile(`Missing required argument`),
 			},
 			{
-				Config: CreateAccFabricIFPolConfig(rName),
+				Config: CreateAccFabricIfPolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_default),
-
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_default),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
@@ -45,21 +45,17 @@ func TestAccAciFabricIFPol_Basic(t *testing.T) {
 				),
 			},
 			{
-				// in this step all optional attribute expect realational attribute are given for the same resource and then compared
-				Config: CreateAccFabricIFPolConfigWithOptionalValues(rName), // configuration to update optional filelds
+				Config: CreateAccFabricIfPolicyConfigWithOptionalValues(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_updated),
-
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
 					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
 					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_fabric_if_pol"),
 					resource.TestCheckResourceAttr(resourceName, "auto_neg", "off"),
-					resource.TestCheckResourceAttr(resourceName, "fec_mode", "auto-fec"),
-					resource.TestCheckResourceAttr(resourceName, "link_debounce", "2"),
-					resource.TestCheckResourceAttr(resourceName, "speed", "100G"),
-
-					testAccCheckAciFabricIFPolIdEqual(&fabric_if_pol_default, &fabric_if_pol_updated),
+					resource.TestCheckResourceAttr(resourceName, "fec_mode", "cl91-rs-fec"),
+					resource.TestCheckResourceAttr(resourceName, "link_debounce", "0"),
+					resource.TestCheckResourceAttr(resourceName, "speed", "unknown"),
 				),
 			},
 			{
@@ -68,238 +64,260 @@ func TestAccAciFabricIFPol_Basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:      CreateAccFabricIFPolConfigUpdatedName(acctest.RandString(65)),
-				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+				Config:      CreateAccFabricIfPolicyConfig(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)* failed validation`),
 			},
-
 			{
-				Config:      CreateAccFabricIFPolRemovingRequiredField(),
+				Config: CreateAccFabricIfPolicyConfigWithUpdatedRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciFabricIfPolicyIdNotEqual(&fabric_if_policy_default, &fabric_if_policy_updated),
+				),
+			},
+			{
+				Config:      CreateAccFabricIfPolicyConfigUpdateWithoutName("description", randomValue),
 				ExpectError: regexp.MustCompile(`Missing required argument`),
 			},
-
 			{
-				Config: CreateAccFabricIFPolConfigWithRequiredParams(rNameUpdated),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_updated),
-
-					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
-					testAccCheckAciFabricIFPolIdNotEqual(&fabric_if_pol_default, &fabric_if_pol_updated),
-				),
+				Config: CreateAccFabricIfPolicyConfig(rName),
 			},
 		},
 	})
 }
 
-func TestAccAciFabricIFPol_Update(t *testing.T) {
-	var fabric_if_pol_default models.LinkLevelPolicy
-	var fabric_if_pol_updated models.LinkLevelPolicy
+func TestAccAciFabricIfPolicy_Update(t *testing.T) {
+	var fabric_if_policy_default models.LinkLevelPolicy
+	var fabric_if_policy_updated models.LinkLevelPolicy
 	resourceName := "aci_fabric_if_pol.test"
 	rName := makeTestVariable(acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
-		CheckDestroy:      testAccCheckAciFabricIFPolDestroy,
+		CheckDestroy:      testAccCheckAciFabricIfPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: CreateAccFabricIFPolConfig(rName),
+				Config: CreateAccFabricIfPolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_default),
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_default),
 				),
 			},
-
 			{
-				Config: CreateAccFabricIFPolUpdatedAttr(rName, "fec_mode", "cl74-fc-fec"),
+				Config: CreateAccFabricIfPolicyUpdatedAttr(rName, "fec_mode", "cl74-fc-fec"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
 					resource.TestCheckResourceAttr(resourceName, "fec_mode", "cl74-fc-fec"),
-					testAccCheckAciFabricIFPolIdEqual(&fabric_if_pol_default, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyIdEqual(&fabric_if_policy_default, &fabric_if_policy_updated),
 				),
 			},
 			{
-				Config: CreateAccFabricIFPolUpdatedAttr(rName, "fec_mode", "cl91-rs-fec"),
+				Config: CreateAccFabricIfPolicyUpdatedAttr(rName, "fec_mode", "cons16-rs-fec"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_updated),
-					resource.TestCheckResourceAttr(resourceName, "fec_mode", "cl91-rs-fec"),
-					testAccCheckAciFabricIFPolIdEqual(&fabric_if_pol_default, &fabric_if_pol_updated),
-				),
-			},
-			{
-				Config: CreateAccFabricIFPolUpdatedAttr(rName, "fec_mode", "cons16-rs-fec"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
 					resource.TestCheckResourceAttr(resourceName, "fec_mode", "cons16-rs-fec"),
-					testAccCheckAciFabricIFPolIdEqual(&fabric_if_pol_default, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyIdEqual(&fabric_if_policy_default, &fabric_if_policy_updated),
 				),
 			},
 			{
-				Config: CreateAccFabricIFPolUpdatedAttr(rName, "fec_mode", "disable-fec"),
+				Config: CreateAccFabricIfPolicyUpdatedAttr(rName, "fec_mode", "disable-fec"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
 					resource.TestCheckResourceAttr(resourceName, "fec_mode", "disable-fec"),
-					testAccCheckAciFabricIFPolIdEqual(&fabric_if_pol_default, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyIdEqual(&fabric_if_policy_default, &fabric_if_policy_updated),
 				),
 			},
 			{
-				Config: CreateAccFabricIFPolUpdatedAttr(rName, "fec_mode", "ieee-rs-fec"),
+				Config: CreateAccFabricIfPolicyUpdatedAttr(rName, "fec_mode", "ieee-rs-fec"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
 					resource.TestCheckResourceAttr(resourceName, "fec_mode", "ieee-rs-fec"),
-					testAccCheckAciFabricIFPolIdEqual(&fabric_if_pol_default, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyIdEqual(&fabric_if_policy_default, &fabric_if_policy_updated),
 				),
 			},
 			{
-				Config: CreateAccFabricIFPolUpdatedAttr(rName, "fec_mode", "kp-fec"),
+				Config: CreateAccFabricIfPolicyUpdatedAttr(rName, "fec_mode", "kp-fec"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
 					resource.TestCheckResourceAttr(resourceName, "fec_mode", "kp-fec"),
-					testAccCheckAciFabricIFPolIdEqual(&fabric_if_pol_default, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyIdEqual(&fabric_if_policy_default, &fabric_if_policy_updated),
 				),
 			},
 			{
-				Config: CreateAccFabricIFPolUpdatedAttr(rName, "speed", "100M"),
+				Config: CreateAccFabricIfPolicyUpdatedAttr(rName, "speed", "100M"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
 					resource.TestCheckResourceAttr(resourceName, "speed", "100M"),
-					testAccCheckAciFabricIFPolIdEqual(&fabric_if_pol_default, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyIdEqual(&fabric_if_policy_default, &fabric_if_policy_updated),
 				),
 			},
 			{
-				Config: CreateAccFabricIFPolUpdatedAttr(rName, "speed", "10G"),
+				Config: CreateAccFabricIfPolicyUpdatedAttr(rName, "speed", "1G"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_updated),
-					resource.TestCheckResourceAttr(resourceName, "speed", "10G"),
-					testAccCheckAciFabricIFPolIdEqual(&fabric_if_pol_default, &fabric_if_pol_updated),
-				),
-			},
-			{
-				Config: CreateAccFabricIFPolUpdatedAttr(rName, "speed", "1G"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
 					resource.TestCheckResourceAttr(resourceName, "speed", "1G"),
-					testAccCheckAciFabricIFPolIdEqual(&fabric_if_pol_default, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyIdEqual(&fabric_if_policy_default, &fabric_if_policy_updated),
 				),
 			},
 			{
-				Config: CreateAccFabricIFPolUpdatedAttr(rName, "speed", "200G"),
+				Config: CreateAccFabricIfPolicyUpdatedAttr(rName, "speed", "10G"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_updated),
-					resource.TestCheckResourceAttr(resourceName, "speed", "200G"),
-					testAccCheckAciFabricIFPolIdEqual(&fabric_if_pol_default, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "speed", "10G"),
+					testAccCheckAciFabricIfPolicyIdEqual(&fabric_if_policy_default, &fabric_if_policy_updated),
 				),
 			},
 			{
-				Config: CreateAccFabricIFPolUpdatedAttr(rName, "speed", "25G"),
+				Config: CreateAccFabricIfPolicyUpdatedAttr(rName, "speed", "25G"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
 					resource.TestCheckResourceAttr(resourceName, "speed", "25G"),
-					testAccCheckAciFabricIFPolIdEqual(&fabric_if_pol_default, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyIdEqual(&fabric_if_policy_default, &fabric_if_policy_updated),
 				),
 			},
 			{
-				Config: CreateAccFabricIFPolUpdatedAttr(rName, "speed", "400G"),
+				Config: CreateAccFabricIfPolicyUpdatedAttr(rName, "speed", "40G"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_updated),
-					resource.TestCheckResourceAttr(resourceName, "speed", "400G"),
-					testAccCheckAciFabricIFPolIdEqual(&fabric_if_pol_default, &fabric_if_pol_updated),
-				),
-			},
-			{
-				Config: CreateAccFabricIFPolUpdatedAttr(rName, "speed", "40G"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
 					resource.TestCheckResourceAttr(resourceName, "speed", "40G"),
-					testAccCheckAciFabricIFPolIdEqual(&fabric_if_pol_default, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyIdEqual(&fabric_if_policy_default, &fabric_if_policy_updated),
 				),
 			},
 			{
-				Config: CreateAccFabricIFPolUpdatedAttr(rName, "speed", "50G"),
+				Config: CreateAccFabricIfPolicyUpdatedAttr(rName, "speed", "50G"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
 					resource.TestCheckResourceAttr(resourceName, "speed", "50G"),
-					testAccCheckAciFabricIFPolIdEqual(&fabric_if_pol_default, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyIdEqual(&fabric_if_policy_default, &fabric_if_policy_updated),
 				),
 			},
 			{
-				Config: CreateAccFabricIFPolUpdatedAttr(rName, "speed", "unknown"),
+				Config: CreateAccFabricIfPolicyUpdatedAttr(rName, "speed", "100G"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciFabricIFPolExists(resourceName, &fabric_if_pol_updated),
-					resource.TestCheckResourceAttr(resourceName, "speed", "unknown"),
-					testAccCheckAciFabricIFPolIdEqual(&fabric_if_pol_default, &fabric_if_pol_updated),
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "speed", "100G"),
+					testAccCheckAciFabricIfPolicyIdEqual(&fabric_if_policy_default, &fabric_if_policy_updated),
 				),
 			},
 			{
-				Config: CreateAccFabricIFPolConfig(rName),
+				Config: CreateAccFabricIfPolicyUpdatedAttr(rName, "speed", "200G"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "speed", "200G"),
+					testAccCheckAciFabricIfPolicyIdEqual(&fabric_if_policy_default, &fabric_if_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccFabricIfPolicyUpdatedAttr(rName, "speed", "400G"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "speed", "400G"),
+					testAccCheckAciFabricIfPolicyIdEqual(&fabric_if_policy_default, &fabric_if_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccFabricIfPolicyUpdatedAttr(rName, "link_debounce", "5000"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "link_debounce", "5000"),
+					testAccCheckAciFabricIfPolicyIdEqual(&fabric_if_policy_default, &fabric_if_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccFabricIfPolicyUpdatedAttr(rName, "link_debounce", "2999"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricIfPolicyExists(resourceName, &fabric_if_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "link_debounce", "2999"),
+					testAccCheckAciFabricIfPolicyIdEqual(&fabric_if_policy_default, &fabric_if_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccFabricIfPolicyConfig(rName),
 			},
 		},
 	})
 }
 
-func TestAccAciFabricIFPol_Negative(t *testing.T) {
+func TestAccAciFabricIfPolicy_Negative(t *testing.T) {
 	rName := makeTestVariable(acctest.RandString(5))
-
 	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
 	randomValue := makeTestVariable(acctest.RandString(5))
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
-		CheckDestroy:      testAccCheckAciFabricIFPolDestroy,
+		CheckDestroy:      testAccCheckAciFabricIfPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: CreateAccFabricIFPolConfig(rName),
+				Config: CreateAccFabricIfPolicyConfig(rName),
 			},
-
 			{
-				Config:      CreateAccFabricIFPolUpdatedAttr(rName, "description", acctest.RandString(129)),
+				Config:      CreateAccFabricIfPolicyUpdatedAttr(rName, "description", acctest.RandString(129)),
 				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
 			},
 			{
-				Config:      CreateAccFabricIFPolUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				Config:      CreateAccFabricIfPolicyUpdatedAttr(rName, "annotation", acctest.RandString(129)),
 				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
 			},
 			{
-				Config:      CreateAccFabricIFPolUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				Config:      CreateAccFabricIfPolicyUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
 				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
 			},
 			{
-				Config:      CreateAccFabricIFPolUpdatedAttr(rName, "auto_neg", randomValue),
-				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+				Config:      CreateAccFabricIfPolicyUpdatedAttr(rName, "auto_neg", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)*to be one of(.)*, got(.)*`),
 			},
 			{
-				Config:      CreateAccFabricIFPolUpdatedAttr(rName, "fec_mode", randomValue),
-				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+				Config:      CreateAccFabricIfPolicyUpdatedAttr(rName, "fec_mode", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)*to be one of(.)*, got(.)*`),
 			},
 			{
-				Config:      CreateAccFabricIFPolUpdatedAttr(rName, "link_debounce", randomValue),
+				Config:      CreateAccFabricIfPolicyUpdatedAttr(rName, "link_debounce", "10000"),
+				ExpectError: regexp.MustCompile(`Property linkDebounce of (.)* is out of range`),
+			},
+			{
+				Config:      CreateAccFabricIfPolicyUpdatedAttr(rName, "link_debounce", randomValue),
 				ExpectError: regexp.MustCompile(`unknown property value`),
 			},
 			{
-				Config:      CreateAccFabricIFPolUpdatedAttr(rName, "speed", randomValue),
-				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
-			},
-
-			{
-				Config:      CreateAccFabricIFPolUpdatedAttr(rName, randomParameter, randomValue),
-				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+				Config:      CreateAccFabricIfPolicyUpdatedAttr(rName, "speed", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)*to be one of(.)*, got(.)*`),
 			},
 			{
-				Config: CreateAccFabricIFPolConfig(rName),
+				Config:      CreateAccFabricIfPolicyUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named(.)*is not expected here.`),
+			},
+			{
+				Config: CreateAccFabricIfPolicyConfig(rName),
 			},
 		},
 	})
 }
 
-func testAccCheckAciFabricIFPolExists(name string, fabric_if_pol *models.LinkLevelPolicy) resource.TestCheckFunc {
+func TestAccAciFabricIfPolicy_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFabricIfPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccFabricIfPoliciesConfig(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciFabricIfPolicyExists(name string, fabric_if_pol *models.LinkLevelPolicy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 
 		if !ok {
-			return fmt.Errorf("Fabric IF Pol %s not found", name)
+			return fmt.Errorf("Fabric If Policy %s not found", name)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No Fabric IF Pol dn was set")
+			return fmt.Errorf("No Fabric If Policy dn was set")
 		}
 
 		client := testAccProvider.Meta().(*client.Client)
@@ -311,14 +329,14 @@ func testAccCheckAciFabricIFPolExists(name string, fabric_if_pol *models.LinkLev
 
 		fabric_if_polFound := models.LinkLevelPolicyFromContainer(cont)
 		if fabric_if_polFound.DistinguishedName != rs.Primary.ID {
-			return fmt.Errorf("Fabric IF Pol %s not found", rs.Primary.ID)
+			return fmt.Errorf("Fabric If Policy %s not found", rs.Primary.ID)
 		}
 		*fabric_if_pol = *fabric_if_polFound
 		return nil
 	}
 }
 
-func testAccCheckAciFabricIFPolDestroy(s *terraform.State) error {
+func testAccCheckAciFabricIfPolicyDestroy(s *terraform.State) error {
 	fmt.Println("=== STEP  testing fabric_if_pol destroy")
 	client := testAccProvider.Meta().(*client.Client)
 	for _, rs := range s.RootModule().Resources {
@@ -326,7 +344,7 @@ func testAccCheckAciFabricIFPolDestroy(s *terraform.State) error {
 			cont, err := client.Get(rs.Primary.ID)
 			fabric_if_pol := models.LinkLevelPolicyFromContainer(cont)
 			if err == nil {
-				return fmt.Errorf("Fabric IF Pol %s Still exists", fabric_if_pol.DistinguishedName)
+				return fmt.Errorf("Fabric If Policy %s Still exists", fabric_if_pol.DistinguishedName)
 			}
 		} else {
 			continue
@@ -335,7 +353,7 @@ func testAccCheckAciFabricIFPolDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAciFabricIFPolIdEqual(m1, m2 *models.LinkLevelPolicy) resource.TestCheckFunc {
+func testAccCheckAciFabricIfPolicyIdEqual(m1, m2 *models.LinkLevelPolicy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if m1.DistinguishedName != m2.DistinguishedName {
 			return fmt.Errorf("fabric_if_pol DNs are not equal")
@@ -344,7 +362,7 @@ func testAccCheckAciFabricIFPolIdEqual(m1, m2 *models.LinkLevelPolicy) resource.
 	}
 }
 
-func testAccCheckAciFabricIFPolIdNotEqual(m1, m2 *models.LinkLevelPolicy) resource.TestCheckFunc {
+func testAccCheckAciFabricIfPolicyIdNotEqual(m1, m2 *models.LinkLevelPolicy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if m1.DistinguishedName == m2.DistinguishedName {
 			return fmt.Errorf("fabric_if_pol DNs are equal")
@@ -353,98 +371,105 @@ func testAccCheckAciFabricIFPolIdNotEqual(m1, m2 *models.LinkLevelPolicy) resour
 	}
 }
 
-func CreateFabricIFPolWithoutRequired(rName, attrName string) string {
-	fmt.Println("=== STEP  Basic: testing fabric_if_pol creation without ", attrName)
-	rBlock := ``
+func CreateFabricIfPolicyWithoutName(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing fabric_if_pol creation without Name", attrName)
+	rBlock := `
+	
+	`
 	switch attrName {
 	case "name":
 		rBlock += `
 	resource "aci_fabric_if_pol" "test" {
 	#	name  = "%s"
-		description = "created while acceptance testing"
 	}
 		`
 	}
 	return fmt.Sprintf(rBlock, rName)
 }
 
-func CreateAccFabricIFPolConfigWithRequiredParams(rName string) string {
-	fmt.Println("=== STEP  testing fabric_if_pol creation with required arguments only")
-	resource := fmt.Sprintf(`
-	
-	resource "aci_fabric_if_pol" "test" {
-		name  = "%s"
-	}
-	`, rName)
-	return resource
-}
-
-func CreateAccFabricIFPolConfig(rName string) string {
-	fmt.Println("=== STEP  testing fabric_if_pol creation with required arguments only")
-	resource := fmt.Sprintf(`
-	
-	resource "aci_fabric_if_pol" "test" {
-		name  = "%s"
-	}
-	`, rName)
-	return resource
-}
-
-func CreateAccFabricIFPolConfigUpdatedName(rName string) string {
-	fmt.Println("=== STEP  testing fabric_if_pol creation with Updated Name")
-	resource := fmt.Sprintf(`
-	
-	resource "aci_fabric_if_pol" "test" {
-		name  = "%s"
-	}
-	`, rName)
-	return resource
-}
-
-func CreateAccFabricIFPolConfigWithOptionalValues(rName string) string {
-	fmt.Println("=== STEP  Basic: testing fabric_if_pol creation with optional parameters")
-	resource := fmt.Sprintf(`
-	
-	resource "aci_fabric_if_pol" "test" {
-		name  = "%s"
-		description = "created while acceptance testing"
-		annotation = "orchestrator:terraform_testacc"
-		name_alias = "test_fabric_if_pol"
-		auto_neg = "off"
-		fec_mode = "auto-fec"
-		link_debounce = "2"
-		speed = "100G"
-	}
-	`, rName)
-
-	return resource
-}
-
-func CreateAccFabricIFPolRemovingRequiredField() string {
-	fmt.Println("=== STEP  Basic: testing fabric_if_pol creation with optional parameters")
-	resource := `
-	resource "aci_fabric_if_pol" "test" {
-		description = "created while acceptance testing"
-		annotation = "orchestrator:terraform_testacc"
-		name_alias = "test_fabric_if_pol"
-		auto_neg = "off"
-		fec_mode = "auto-fec"
-		link_debounce = "1"
-		speed = "100G"
-	}
-	`
-
-	return resource
-}
-
-func CreateAccFabricIFPolUpdatedAttr(rName, attribute, value string) string {
-	fmt.Printf("=== STEP  testing fabric_if_pol attribute: %s=%s \n", attribute, value)
+func CreateAccFabricIfPolicyConfigWithUpdatedRequiredParams(rName string) string {
+	fmt.Println("=== STEP  testing fabric_if_pol creation with updated required arguments")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_fabric_if_pol" "test" {	
 		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccFabricIfPoliciesConfig(rName string) string {
+	fmt.Println("=== STEP  testing fabric_if_pol multiple creation")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_fabric_if_pol" "test" {
+		name  = "%s"
+	}
+
+	resource "aci_fabric_if_pol" "test1" {
+		name  = "%s"
+	}
+
+	resource "aci_fabric_if_pol" "test2" {
+		name  = "%s"
+	}
+
+	resource "aci_fabric_if_pol" "test3" {
+		name  = "%s"
+	}
+	`, rName, rName+"1", rName+"2", rName+"3")
+	return resource
+}
+
+func CreateAccFabricIfPolicyConfig(rName string) string {
+	fmt.Println("=== STEP  testing fabric_if_pol creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_fabric_if_pol" "test" {
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+func CreateAccFabricIfPolicyConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing fabric_if_pol creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_fabric_if_pol" "test" {
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_fabric_if_pol"
+		auto_neg = "off"
+		fec_mode = "cl91-rs-fec"
+		link_debounce = "0"
+		speed = "unknown"
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccFabricIfPolicyUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing fabric_if_pol attribute: %s=%s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_fabric_if_pol" "test" {
+	
+		name  = "%s"
 		%s = "%s"
 	}
 	`, rName, attribute, value)
+	return resource
+}
+
+func CreateAccFabricIfPolicyConfigUpdateWithoutName(attribute, value string) string {
+	fmt.Printf("=== STEP  testing fabric_if_pol attribute: %s=%s without name\n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_fabric_if_pol" "test" {
+		%s = "%s"
+	}
+	`, attribute, value)
 	return resource
 }


### PR DESCRIPTION
$ make fmt && make testacc
gofmt -w $(find . -name '*.go' |grep -v vendor)
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?       github.com/terraform-providers/terraform-provider-aci   [no test files]
?       github.com/terraform-providers/terraform-provider-aci/aci       [no test files]
=== RUN   TestAccAciL3outBGPProtocolProfileDataSource_Basic
=== STEP  testing l3out_bgp_protocol_profile data source without required arguments only
=== STEP  testing l3out_bgp_protocol_profile data source with required arguments only
=== STEP  testing L3out BGP Protocol Profile data source with random attribute
=== STEP  testing l3out_bgp_protocol_profile data source with Invalid Parent Dn
=== STEP  testing l3out_bgp_protocol_profile data source with updated resource
=== PAUSE TestAccAciL3outBGPProtocolProfileDataSource_Basic
=== RUN   TestAccAciFabricIfPolicyDataSource_Basic
=== STEP  testing fabric_if_pol data source without required arguments
=== STEP  testing fabric_if_pol data source with required arguments only
=== STEP  testing fabric_if_pol data source with random attribute
=== STEP  testing fabric_if_pol data source with Invalid Name
=== STEP  testing fabric_if_pol data source with updated resource
=== PAUSE TestAccAciFabricIfPolicyDataSource_Basic
=== RUN   TestAccAciInterfaceFcPolicy_Basic
=== STEP  testing interface_fc_policy data source without name
=== STEP  testing interface_fc_policy data source with required arguments only
=== STEP  testing interface_fc_policy data source updation with random attribute
=== STEP  testing interface_fc_policy data source with Invalid Name
=== STEP  testing interface_fc_policy data source with updated resource
=== PAUSE TestAccAciInterfaceFcPolicy_Basic
=== RUN   TestProvider
--- PASS: TestProvider (0.04s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccAciL3outBGPProtocolProfile_Basic
=== STEP  Basic: testing l3out_bgp_protocol_profile creation without  logical_node_profile_dn
=== STEP  testing l3out_bgp_protocol_profile creation with required arguments only
=== STEP  Basic: testing l3out_bgp_protocol_profile creation with optional parameters
=== STEP  testing l3out_bgp_protocol_profile creation with updated required arguments only
=== STEP  testing l3out_bgp_protocol_profile attribute: annotation=t08ce without required arguments
=== STEP  testing l3out_bgp_protocol_profile creation with required arguments only
=== PAUSE TestAccAciL3outBGPProtocolProfile_Basic
=== RUN   TestAccAciL3outBGPProtocolProfile_Negative
=== STEP  testing l3out_bgp_protocol_profile creation with required arguments only
=== STEP  Negative Case: testing l3out_bgp_protocol_profile creation with invalid parent Dn
=== STEP  testing l3out_bgp_protocol_profile attribute: annotation=ekurmxuilc69se0hkpaohz0seqfbbubhrbfc29ocjj41ie4jtpdzsja2sxcapkugcnrrec4ll7vnwyrsqqnoz799n97zymzo60tvw6gw2b1arsw8tvkteuw33apylzop9
=== STEP  testing l3out_bgp_protocol_profile attribute: name_alias=csyhg2ijgrlqyim4lyjf6cwyiqjudhvmjq4w39aaz421iwz4p14k67nhusecg4p1
=== STEP  testing l3out_bgp_protocol_profile attribute: gblog=acctest_b4pyi
=== STEP  testing l3out_bgp_protocol_profile creation with required arguments only
=== PAUSE TestAccAciL3outBGPProtocolProfile_Negative
=== RUN   TestAccAciL3outBGPProtocolProfile_RelationParameters
=== STEP  testing l3out_bgp_protocol_profile creation with required arguments only
=== STEP  testing l3out_bgp_protocol_profile relation parameters
=== STEP  testing l3out_bgp_protocol_profile relation parameters
=== STEP  testing l3out_bgp_protocol_profile creation with required arguments only
=== PAUSE TestAccAciL3outBGPProtocolProfile_RelationParameters
=== RUN   TestAccAciFabricIfPolicy_Basic
=== STEP  Basic: testing fabric_if_pol creation without Name name
=== STEP  testing fabric_if_pol creation with required arguments only
=== STEP  Basic: testing fabric_if_pol creation with optional parameters
=== STEP  testing fabric_if_pol creation with required arguments only
=== STEP  testing fabric_if_pol creation with updated required arguments
=== STEP  testing fabric_if_pol attribute: description=wcb97 without name
=== STEP  testing fabric_if_pol creation with required arguments only
=== PAUSE TestAccAciFabricIfPolicy_Basic
=== RUN   TestAccAciFabricIfPolicy_Update
=== STEP  testing fabric_if_pol creation with required arguments only
=== STEP  testing fabric_if_pol attribute: fec_mode=cl74-fc-fec
=== STEP  testing fabric_if_pol attribute: fec_mode=cons16-rs-fec
=== STEP  testing fabric_if_pol attribute: fec_mode=disable-fec
=== STEP  testing fabric_if_pol attribute: fec_mode=ieee-rs-fec
=== STEP  testing fabric_if_pol attribute: fec_mode=kp-fec
=== STEP  testing fabric_if_pol attribute: speed=100M
=== STEP  testing fabric_if_pol attribute: speed=1G
=== STEP  testing fabric_if_pol attribute: speed=10G
=== STEP  testing fabric_if_pol attribute: speed=25G
=== STEP  testing fabric_if_pol attribute: speed=40G
=== STEP  testing fabric_if_pol attribute: speed=50G
=== STEP  testing fabric_if_pol attribute: speed=100G
=== STEP  testing fabric_if_pol attribute: speed=200G
=== STEP  testing fabric_if_pol attribute: speed=400G
=== STEP  testing fabric_if_pol attribute: link_debounce=5000
=== STEP  testing fabric_if_pol attribute: link_debounce=2999
=== STEP  testing fabric_if_pol creation with required arguments only
=== PAUSE TestAccAciFabricIfPolicy_Update
=== RUN   TestAccAciFabricIfPolicy_Negative
=== STEP  testing fabric_if_pol creation with required arguments only
=== STEP  testing fabric_if_pol attribute: description=v70cpqlfcy9g3fpbsfjnhf0slxtrjk4nu88kkm8v3ps1jtgl0swvsw8uitppidkcq63x8lg7fobcjikusb9hfsi2vtypjxfjh76rjr12uixprx3mdhfk2x4yw4v4qxauw
=== STEP  testing fabric_if_pol attribute: annotation=zj8n2aa99bjdrc071vkhf7uzwt7ztxhqn9z8pg23t0ellebq1dkdlrelh2ujbu7txuw31k8x2vweia4679khdftale4tywlt2jwpu9htttnuevahwqa316qxz1s62n3yz
=== STEP  testing fabric_if_pol attribute: name_alias=33h018gyj6ydakm641h7r6jn0drv3x99t63oh89n6x23eioghjzsyrcux2uk90c4
=== STEP  testing fabric_if_pol attribute: auto_neg=acctest_nx47w
=== STEP  testing fabric_if_pol attribute: fec_mode=acctest_nx47w
=== STEP  testing fabric_if_pol attribute: link_debounce=10000
=== STEP  testing fabric_if_pol attribute: link_debounce=acctest_nx47w
=== STEP  testing fabric_if_pol attribute: speed=acctest_nx47w
=== STEP  testing fabric_if_pol attribute: daoni=acctest_nx47w
=== STEP  testing fabric_if_pol creation with required arguments only
=== PAUSE TestAccAciFabricIfPolicy_Negative
=== RUN   TestAccAciFabricIfPolicy_MultipleCreateDelete
=== STEP  testing fabric_if_pol multiple creation
=== STEP  testing fabric_if_pol destroy
--- PASS: TestAccAciFabricIfPolicy_MultipleCreateDelete (44.50s)
=== RUN   TestAccAciInterfaceFcPolicyDataSource_Basic
=== STEP  Basic: testing interface_fc_policy creation without Name  name
=== STEP  testing interface_fc_policy creation with required arguments only
=== STEP  Basic: testing interface_fc_policy creation with optional parameters
=== STEP  testing interface_fc_policy creation with required arguments only
=== STEP  testing interface_fc_policy updation of required arguments
=== STEP  testing interface_fc_policy attribute: description=ikp8g without name
=== STEP  testing interface_fc_policy creation with required arguments only
=== PAUSE TestAccAciInterfaceFcPolicyDataSource_Basic
=== RUN   TestAccAciInterfaceFcPolicy_Update
=== STEP  testing interface_fc_policy creation with required arguments only
=== STEP  testing interface_fc_policy attribute: automaxspeed=2G
=== STEP  testing interface_fc_policy attribute: automaxspeed=4G
=== STEP  testing interface_fc_policy attribute: automaxspeed=8G
=== STEP  testing interface_fc_policy attribute: speed=32G
=== STEP  testing interface_fc_policy attribute: speed=4G
=== STEP  testing interface_fc_policy attribute: speed=8G
=== STEP  testing interface_fc_policy attribute: speed=16G
=== STEP  testing interface_fc_policy attribute: trunk_mode=trunk-on
=== STEP  testing interface_fc_policy attribute: trunk_mode=un-init
=== STEP  testing interface_fc_policy attribute: rx_bb_credit=16
=== STEP  testing interface_fc_policy attribute: rx_bb_credit=64
=== STEP  testing interface_fc_policy creation with required arguments only
=== PAUSE TestAccAciInterfaceFcPolicy_Update
=== RUN   TestAccAciInterfaceFcPolicy_Negative
=== STEP  testing interface_fc_policy creation with required arguments only
=== STEP  testing interface_fc_policy attribute: description=tlivi0jwji2e9rp68qm8wk4124tvptsfg4d7i0tb7zbuptlsqojew12xgiziuz4d68toe1gtbdlobd36fomizcxg133h828sa4frhi18h8yb37omrfjrbcxhh7pa7av48
=== STEP  testing interface_fc_policy attribute: annotation=urbhz9knoszqj7n7m8unhrgudrn0iirxf0btrjf4mx144lb1f1bea2kz7kx6dnssdj04xp70x9dtzaymzbrdukzi8z3ctbhmz1usojazguw9e4g37jdd7w3x0gpkjvmtg
=== STEP  testing interface_fc_policy attribute: name_alias=sx7ik1fxj12fm6ltr42swe6dbvyhfi09xzn3pgu30vvwg0w46x79a3o0cc7ov89l
=== STEP  testing interface_fc_policy attribute: automaxspeed=acctest_gjlqc
=== STEP  testing interface_fc_policy attribute: fill_pattern=acctest_gjlqc
=== STEP  testing interface_fc_policy attribute: port_mode=acctest_gjlqc
=== STEP  testing interface_fc_policy attribute: rx_bb_credit=acctest_gjlqc
=== STEP  testing interface_fc_policy attribute: rx_bb_credit=65
=== STEP  testing interface_fc_policy attribute: speed=acctest_gjlqc
=== STEP  testing interface_fc_policy attribute: trunk_mode=acctest_gjlqc
=== STEP  testing interface_fc_policy attribute: ekiek=acctest_gjlqc
=== STEP  testing interface_fc_policy creation with required arguments only
=== PAUSE TestAccAciInterfaceFcPolicy_Negative
=== RUN   TestAccAciInterfaceFcPolicy_MultipleCreateDelete
=== STEP  testing Multiple interface_fc_policy creation with required arguments only
=== STEP  testing interface_fc_policy destroy
--- PASS: TestAccAciInterfaceFcPolicy_MultipleCreateDelete (31.29s)
=== CONT  TestAccAciL3outBGPProtocolProfileDataSource_Basic
=== CONT  TestAccAciFabricIfPolicy_Basic
=== CONT  TestAccAciL3outBGPProtocolProfile_RelationParameters
=== CONT  TestAccAciL3outBGPProtocolProfile_Negative
=== CONT  TestAccAciInterfaceFcPolicy_Update
=== CONT  TestAccAciL3outBGPProtocolProfile_Basic
=== CONT  TestAccAciInterfaceFcPolicyDataSource_Basic
=== CONT  TestAccAciInterfaceFcPolicy_Negative
=== STEP  testing l3out_bgp_protocol_profile destroy
--- PASS: TestAccAciL3outBGPProtocolProfileDataSource_Basic (126.70s)
=== CONT  TestAccAciInterfaceFcPolicy_Basic
=== STEP  testing l3out_bgp_protocol_profile destroy
--- PASS: TestAccAciL3outBGPProtocolProfile_Negative (171.38s)
=== CONT  TestAccAciFabricIfPolicy_Negative
=== STEP  testing interface_fc_policy destroy
=== STEP  testing interface_fc_policy destroy
--- PASS: TestAccAciInterfaceFcPolicy_Negative (192.98s)
=== CONT  TestAccAciFabricIfPolicyDataSource_Basic
--- PASS: TestAccAciInterfaceFcPolicyDataSource_Basic (195.76s)
=== CONT  TestAccAciFabricIfPolicy_Update
=== STEP  testing fabric_if_pol destroy
--- PASS: TestAccAciFabricIfPolicy_Basic (204.69s)
=== STEP  testing l3out_bgp_protocol_profile destroy
--- PASS: TestAccAciL3outBGPProtocolProfile_RelationParameters (215.48s)
=== STEP  testing interface_fc_policy destroy
=== STEP  testing l3out_bgp_protocol_profile destroy
--- PASS: TestAccAciL3outBGPProtocolProfile_Basic (227.56s)
--- PASS: TestAccAciInterfaceFcPolicy_Basic (101.70s)
=== STEP  testing fabric_if_pol destroy
--- PASS: TestAccAciFabricIfPolicyDataSource_Basic (212.35s)
=== STEP  testing fabric_if_pol destroy
--- PASS: TestAccAciFabricIfPolicy_Negative (290.70s)
=== STEP  testing interface_fc_policy destroy
--- PASS: TestAccAciInterfaceFcPolicy_Update (595.98s)
=== STEP  testing fabric_if_pol destroy
--- PASS: TestAccAciFabricIfPolicy_Update (752.73s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   1025.786s