### PR TITLE
updated aci_l3out_loopback_interface_profile_updates

### DIFF
--- a/testacc/resource_aci_l3extloopbackifp_test.go
+++ b/testacc/resource_aci_l3extloopbackifp_test.go
@@ -143,7 +143,7 @@ func TestAccAcil3extLoopBackIfP_Negative(t *testing.T) {
 func CreateAccLoopBackInterfaceProfileRemovingRequiredField() string {
 	fmt.Println("=== STEP  Basic: testing LoopBackInterfaceProfile updation without required parameters")
 	resource := fmt.Sprintln(`
-	resource "aci_l3out_route_tag_policy" "test" {
+	resource "aci_l3out_loopback_interface_profile" "test" {
 		description = "created while acceptance testing"
 		annotation = "orchestrator:terraform_testacc"
 		name_alias = "test_l3out_route_tag_policy"
@@ -215,7 +215,7 @@ func CreateAccLoopBackInterfaceProfileWithInvalidIP(rName, tdn, parent_addr stri
 }
 
 func CreateAccLoopBackInterfaceProfileConfigWithRequiredParams(rName, tdn, parent_addr, addr string) string {
-	fmt.Printf("=== STEP  testing LoopBackInterfaceProfile creation with tdn %s and addr %s\n", tdn, addr)
+	fmt.Println("=== STEP  testing LoopBackInterfaceProfile creation with required parameters")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {
@@ -272,7 +272,7 @@ func CreateAccLoopBackInterfaceProfileConfigUpdatedAttr(rName, tdn, parent_addr,
 }
 
 func CreateAccLoopBackInterfaceProfileConfigWithInvalidParentDn(rName, addr string) string {
-	fmt.Println("=== STEP  testing LoopBackInterfaceProfile creation invalid fabric_node_dn")
+	fmt.Println("=== STEP  testing LoopBackInterfaceProfile creation with invalid fabric_node_dn")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {


### PR DESCRIPTION
=== RUN   TestAccAcil3extLoopBackIfP_Basic
=== STEP  Basic: testing LoopBackInterfaceProfile creation without  fabric_node_dn
=== STEP  Basic: testing LoopBackInterfaceProfile creation without  addr
=== STEP  testing LoopBackInterfaceProfile creation with required arguments only
=== STEP  Basic: testing l3out_route_tag_policy creation with optional parameters
=== STEP  Basic: testing LoopBackInterfaceProfile updation without required parameters
=== STEP  testing LoopBackInterfaceProfile creation with invalid ip acctest_60r3p
=== STEP  testing LoopBackInterfaceProfile creation with tdn
=== STEP  testing LoopBackInterfaceProfile creation with required arguments only
=== STEP  testing LoopBackInterfaceProfile creation with tdn
=== PAUSE TestAccAcil3extLoopBackIfP_Basic
=== CONT  TestAccAcil3extLoopBackIfP_Basic
=== STEP  testing L3out Loopback Interface Profile destroy
--- PASS: TestAccAcil3extLoopBackIfP_Basic (91.98s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   93.418s
