### PR TITLE
Lldp interface policy

### DIFF
--- a/testacc/data_source_aci_bfdifp_test.go
+++ b/testacc/data_source_aci_bfdifp_test.go
@@ -55,7 +55,7 @@ func TestAccAciL3outBfdInterfaceProfileDataSource_Basic(t *testing.T) {
 }
 
 func CreateL3outBfdInterfaceProfileDataSourceWithoutRequired(rName string) string {
-	fmt.Println("=== STEP  Basic: Testing l3out_bfd_interface_profile data soruce creation without required attribute")
+	fmt.Println("=== STEP  Basic: Testing l3out_bfd_interface_profile data source creation without required attribute")
 	resource := fmt.Sprintf(`
 	resource "aci_tenant" "test" {
 		name 		= "%s"

--- a/testacc/data_source_aci_l3extloopbackifp_test.go
+++ b/testacc/data_source_aci_l3extloopbackifp_test.go
@@ -80,11 +80,11 @@ func CreateAccLoopBackInterfaceProfileDSConfigUpdatedResource(rName, tdn, parent
 		resource "aci_l3out_loopback_interface_profile" "test" {
 			fabric_node_dn = aci_logical_node_to_fabric_node.test.id
 			addr           = "%s"
+			%s             = "%s"
 		}
 		data "aci_l3out_loopback_interface_profile" "test" {
 			fabric_node_dn = aci_l3out_loopback_interface_profile.test.fabric_node_dn
 			addr           = aci_l3out_loopback_interface_profile.test.addr
-			%s             = "%s"
 		}
 	`, rName, rName, rName, tdn, addr, addr, key, value)
 	return resource

--- a/testacc/data_source_aci_vztaboo_test.go
+++ b/testacc/data_source_aci_vztaboo_test.go
@@ -48,7 +48,7 @@ func TestAccAciTabooContractDataSource_Basic(t *testing.T) {
 				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
 			},
 			{
-				Config: CreateAccTabooContractDataSourceUpdate(rName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Config: CreateAccTabooContractDataSourceUpdatedResource(rName, rName, "annotation", "orchestrator:terraform-testacc"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
 				),
@@ -109,8 +109,35 @@ func CreateAccTabooContractDSWithInvalidParentDn(fvTenantName, rName string) str
 	return resource
 }
 
+func CreateAccTabooContractDataSourceUpdatedResource(fvTenantName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing taboo_contract Updation with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		description = "tenant created while acceptance testing"
+	
+	}
+	
+	resource "aci_taboo_contract" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_taboo_contract" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_taboo_contract.test.name
+		depends_on = [
+			aci_taboo_contract.test
+		]
+	}
+	`, fvTenantName, rName, key, value)
+	return resource
+}
+
 func CreateAccTabooContractDataSourceUpdate(fvTenantName, rName, key, value string) string {
-	fmt.Println("=== STEP  testing taboo_contract Updation with required arguments only")
+	fmt.Println("=== STEP  testing taboo_contract Updation with random attributes")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {

--- a/testacc/resource_aci_lldpifpol_test.go
+++ b/testacc/resource_aci_lldpifpol_test.go
@@ -66,12 +66,10 @@ func TestAccAciLLDPInterfacePolicy_Basic(t *testing.T) {
 				Config:      CreateAccLLDPInterfacePolicyConfigUpdatedName(acctest.RandString(65)),
 				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
 			},
-
 			{
 				Config:      CreateAccLLDPInterfacePolicyRemovingRequiredField(),
 				ExpectError: regexp.MustCompile(`Missing required argument`),
 			},
-
 			{
 				Config: CreateAccLLDPInterfacePolicyConfigWithRequiredParams(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
@@ -93,12 +91,7 @@ func TestAccAciLLDPInterfacePolicy_MultipleCreateDelete(t *testing.T) {
 		CheckDestroy:      testAccCheckAciLLDPInterfacePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(`
-				resource "aci_lldp_interface_policy" "test" {
-					name  = "%s_${count.index}"
-					count = 5
-				}
-				`, rName),
+				Config: CreateAccLLDPInterfacePolicyConfigs(rName),
 			},
 		},
 	})
@@ -232,12 +225,23 @@ func CreateLLDPInterfacePolicyWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccLLDPInterfacePolicyConfigWithRequiredParams(rName string) string {
-	fmt.Println("=== STEP  testing lldp_interface_policy creation with required arguments only")
+	fmt.Println("=== STEP  testing lldp_interface_policy creation with updated name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_lldp_interface_policy" "test" {
 	
 		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLLDPInterfacePolicyConfigs(rName string) string {
+	fmt.Println("=== STEP  testing multiple lldp_interface_policy creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_lldp_interface_policy" "test" {
+		name  = "%s_${count.index}"
+		count = 5
 	}
 	`, rName)
 	return resource
@@ -256,7 +260,7 @@ func CreateAccLLDPInterfacePolicyConfig(rName string) string {
 }
 
 func CreateAccLLDPInterfacePolicyConfigUpdatedName(rName string) string {
-	fmt.Println("=== STEP  testing lldp_interface_policy creation with Updated name")
+	fmt.Println("=== STEP  testing lldp_interface_policy creation with longer name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_lldp_interface_policy" "test" {
@@ -286,7 +290,7 @@ func CreateAccLLDPInterfacePolicyConfigWithOptionalValues(rName string) string {
 }
 
 func CreateAccLLDPInterfacePolicyRemovingRequiredField() string {
-	fmt.Println("=== STEP  Basic: testing lldp_interface_policy creation with optional parameters")
+	fmt.Println("=== STEP  Basic: testing lldp_interface_policy update without required parameters")
 	resource := fmt.Sprintf(`
 	resource "aci_lldp_interface_policy" "test" {
 		description = "created while acceptance testing"


### PR DESCRIPTION
$ go test -v -run TestAccAciTabooContractDataSource_Basic -timeout=60m
=== RUN   TestAccAciTabooContractDataSource_Basic
=== STEP  Basic: testing Taboo Contract data source reading without giving name
=== STEP  Basic: testing Taboo Contract data source reading without giving Tenant Dn
=== STEP  testing taboo_contract creation with required arguments only
=== STEP  testing taboo_contract Updation with random attributes
=== STEP  testing taboo_contract creation with Invalid Parent Dn
=== STEP  testing taboo_contract Updation with updated resource
=== PAUSE TestAccAciTabooContractDataSource_Basic
=== CONT  TestAccAciTabooContractDataSource_Basic
=== STEP  testing taboo_contract destroy
--- PASS: TestAccAciTabooContractDataSource_Basic (32.31s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   34.919s
$ go test -v -run TestAccAcil3extLoopBackIfPDataSource_Basic -timeout=60m
=== RUN   TestAccAcil3extLoopBackIfPDataSource_Basic
=== STEP  testing LoopBackInterfaceProfile Data Source without  fabric_node_dn
=== STEP  testing LoopBackInterfaceProfile Data Source without  addr
=== STEP  testing LoopBackInterfaceProfile Data Source with required arguments only
=== STEP  testing LoopBackInterfaceProfile Data Source with random attribute
=== STEP  testing LoopBackInterfaceProfile Data Source with invalid ip
=== STEP  testing LoopBackInterfaceProfile Data Source with updated resource
=== PAUSE TestAccAcil3extLoopBackIfPDataSource_Basic
=== CONT  TestAccAcil3extLoopBackIfPDataSource_Basic
=== STEP  testing L3out Loopback Interface Profile destroy
--- PASS: TestAccAcil3extLoopBackIfPDataSource_Basic (55.88s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   58.286s
$ go test -v -run TestAccAciLLDPInterfacePolicy -timeout=60m
=== RUN   TestAccAciLLDPInterfacePolicyDataSource_Basic
=== STEP  testing lldp_interface_policy Data Source without required argument
=== STEP  testing lldp_interface_policy Data Source with required arguments only
=== STEP  testing lldp_interface_policy Data Source with random attribute
=== STEP  testing lldp_interface_policy Data Source with invalid Name
=== STEP  testing lldp_interface_policy Data Source with updated resource
=== PAUSE TestAccAciLLDPInterfacePolicyDataSource_Basic
=== RUN   TestAccAciLLDPInterfacePolicy_Basic
=== STEP  Basic: testing lldp_interface_policy creation without  name
=== STEP  testing lldp_interface_policy creation with required arguments only
=== STEP  Basic: testing lldp_interface_policy creation with optional parameters
=== STEP  testing lldp_interface_policy creation with longer name
=== STEP  Basic: testing lldp_interface_policy update without required parameters
=== STEP  testing lldp_interface_policy creation with updated name
=== PAUSE TestAccAciLLDPInterfacePolicy_Basic
=== RUN   TestAccAciLLDPInterfacePolicy_MultipleCreateDelete
=== STEP  testing multiple lldp_interface_policy creation with required arguments only
=== STEP  testing lldp_interface_policy destroy
--- PASS: TestAccAciLLDPInterfacePolicy_MultipleCreateDelete (16.04s)
=== RUN   TestAccAciLLDPInterfacePolicy_Negative
=== STEP  testing lldp_interface_policy creation with required arguments only
=== STEP  testing lldp_interface_policy attribute: description=ec11yafe2zdpso0o6lbbw2vf2w4nv0eg461m82ovvti0c3gl6amjjjfdl69vd8ogj2jyluj8q3a0qh66cdqsc9czwhhafeptijkkq6cyc6mpr147dpic02qbcbmet3xq0
=== STEP  testing lldp_interface_policy attribute: annotation=zdp9ry17bqynzaddv94di97n0eirnhbyaki2mmurf2edy7mkn6z6ay3danmnnbe41qu1rtdchvtjmwb0xh3n1u1eh9icu37cqaxqnusy8jt008e37p8wibrvpv3k083jb
=== STEP  testing lldp_interface_policy attribute: name_alias=mzy3ex4keaarhcodo14adi2pr9ilzyckugbxtkv182icfvf1m0rvvlhfun1o0rtp
=== STEP  testing lldp_interface_policy attribute: admin_rx_st=acctest_u4dwu
=== STEP  testing lldp_interface_policy attribute: admin_tx_st=acctest_u4dwu
=== STEP  testing lldp_interface_policy attribute: oxqxd=acctest_u4dwu
=== STEP  testing lldp_interface_policy creation with required arguments only
=== PAUSE TestAccAciLLDPInterfacePolicy_Negative
=== CONT  TestAccAciLLDPInterfacePolicyDataSource_Basic
=== CONT  TestAccAciLLDPInterfacePolicy_Negative
=== CONT  TestAccAciLLDPInterfacePolicy_Basic
=== STEP  testing lldp_interface_policy destroy
--- PASS: TestAccAciLLDPInterfacePolicyDataSource_Basic (27.27s)
=== STEP  testing lldp_interface_policy destroy
--- PASS: TestAccAciLLDPInterfacePolicy_Negative (33.29s)
=== STEP  testing lldp_interface_policy destroy
--- PASS: TestAccAciLLDPInterfacePolicy_Basic (36.68s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   55.288s
