### PR TITLE
Ospf timers

### DIFF
--- a/testacc/data_source_aci_bgppeerpfxpol_test.go
+++ b/testacc/data_source_aci_bgppeerpfxpol_test.go
@@ -1,0 +1,187 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciBGPPeerPrefixDataSource_Basic(t *testing.T) {
+	resourceName := "aci_bgp_peer_prefix.test"
+	dataSourceName := "data.aci_bgp_peer_prefix.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciBGPPeerPrefixDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateBGPPeerPrefixDSWithoutRequired(rName, rName, "tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateBGPPeerPrefixDSWithoutRequired(rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccBGPPeerPrefixConfigDataSource(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "tenant_dn", resourceName, "tenant_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "action", resourceName, "action"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "max_pfx", resourceName, "max_pfx"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "restart_time", resourceName, "restart_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "thresh", resourceName, "thresh"),
+				),
+			},
+			{
+				Config:      CreateAccBGPPeerPrefixDataSourceUpdate(rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccBGPPeerPrefixDSWithInvalidParentDn(rName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccBGPPeerPrefixDataSourceUpdatedResource(rName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccBGPPeerPrefixConfigDataSource(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing bgp_peer_prefix Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_bgp_peer_prefix" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_bgp_peer_prefix" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_bgp_peer_prefix.test.name
+		depends_on = [ aci_bgp_peer_prefix.test ]
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateBGPPeerPrefixDSWithoutRequired(fvTenantName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing bgp_peer_prefix creation without ", attrName)
+	rBlock := `
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_bgp_peer_prefix" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	data "aci_bgp_peer_prefix" "test" {
+	#	tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		depends_on = [ aci_bgp_peer_prefix.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_bgp_peer_prefix" "test" {
+		tenant_dn  = aci_tenant.test.id
+	#	name  = "%s"
+		depends_on = [ aci_bgp_peer_prefix.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, rName)
+}
+
+func CreateAccBGPPeerPrefixDSWithInvalidParentDn(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing bgp_peer_prefix Data Source with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_bgp_peer_prefix" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_bgp_peer_prefix" "test" {
+		tenant_dn  = "${aci_tenant.test.id}_invalid"
+		name  = aci_bgp_peer_prefix.test.name
+		depends_on = [ aci_bgp_peer_prefix.test ]
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccBGPPeerPrefixDataSourceUpdate(fvTenantName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing bgp_peer_prefix Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_bgp_peer_prefix" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_bgp_peer_prefix" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_bgp_peer_prefix.test.name
+		%s = "%s"
+		depends_on = [ aci_bgp_peer_prefix.test ]
+	}
+	`, fvTenantName, rName, key, value)
+	return resource
+}
+
+func CreateAccBGPPeerPrefixDataSourceUpdatedResource(fvTenantName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing bgp_peer_prefix Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_bgp_peer_prefix" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_bgp_peer_prefix" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_bgp_peer_prefix.test.name
+		depends_on = [ aci_bgp_peer_prefix.test ]
+	}
+	`, fvTenantName, rName, key, value)
+	return resource
+}

--- a/testacc/resource_aci_bgppeerpfxpol_test.go
+++ b/testacc/resource_aci_bgppeerpfxpol_test.go
@@ -1,0 +1,447 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciBGPPeerPrefix_Basic(t *testing.T) {
+	var bgp_peer_prefix_default models.BGPPeerPrefixPolicy
+	var bgp_peer_prefix_updated models.BGPPeerPrefixPolicy
+	resourceName := "aci_bgp_peer_prefix.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciBGPPeerPrefixDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateBGPPeerPrefixWithoutRequired(fvTenantName, rName, "tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateBGPPeerPrefixWithoutRequired(fvTenantName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccBGPPeerPrefixConfig(fvTenantName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciBGPPeerPrefixExists(resourceName, &bgp_peer_prefix_default),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", fvTenantName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "action", "reject"),
+					resource.TestCheckResourceAttr(resourceName, "max_pfx", "20000"),
+					resource.TestCheckResourceAttr(resourceName, "restart_time", "infinite"),
+					resource.TestCheckResourceAttr(resourceName, "thresh", "75"),
+				),
+			},
+			{
+				Config: CreateAccBGPPeerPrefixConfigWithOptionalValues(fvTenantName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciBGPPeerPrefixExists(resourceName, &bgp_peer_prefix_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", fvTenantName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_bgp_peer_prefix"),
+					resource.TestCheckResourceAttr(resourceName, "action", "log"),
+					resource.TestCheckResourceAttr(resourceName, "max_pfx", "2"),
+					resource.TestCheckResourceAttr(resourceName, "restart_time", "2"),
+					resource.TestCheckResourceAttr(resourceName, "thresh", "2"),
+					testAccCheckAciBGPPeerPrefixIdEqual(&bgp_peer_prefix_default, &bgp_peer_prefix_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccBGPPeerPrefixConfig(fvTenantName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			{
+				Config:      CreateAccBGPPeerPrefixUpdateWithoutRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccBGPPeerPrefixConfigWithUpdatedRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciBGPPeerPrefixExists(resourceName, &bgp_peer_prefix_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciBGPPeerPrefixIdNotEqual(&bgp_peer_prefix_default, &bgp_peer_prefix_updated),
+				),
+			},
+			{
+				Config: CreateAccBGPPeerPrefixConfig(fvTenantName, rName),
+			},
+			{
+				Config: CreateAccBGPPeerPrefixConfigWithUpdatedRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciBGPPeerPrefixExists(resourceName, &bgp_peer_prefix_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciBGPPeerPrefixIdNotEqual(&bgp_peer_prefix_default, &bgp_peer_prefix_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciBGPPeerPrefix_Update(t *testing.T) {
+	var bgp_peer_prefix_default models.BGPPeerPrefixPolicy
+	var bgp_peer_prefix_updated models.BGPPeerPrefixPolicy
+	resourceName := "aci_bgp_peer_prefix.test"
+	rName := makeTestVariable(acctest.RandString(5))
+
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciBGPPeerPrefixDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccBGPPeerPrefixConfig(fvTenantName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciBGPPeerPrefixExists(resourceName, &bgp_peer_prefix_default),
+				),
+			},
+			{
+				Config: CreateAccBGPPeerPrefixUpdatedAttr(fvTenantName, rName, "action", "restart"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciBGPPeerPrefixExists(resourceName, &bgp_peer_prefix_updated),
+					resource.TestCheckResourceAttr(resourceName, "action", "restart"),
+					testAccCheckAciBGPPeerPrefixIdEqual(&bgp_peer_prefix_default, &bgp_peer_prefix_updated),
+				),
+			},
+			{
+				Config: CreateAccBGPPeerPrefixUpdatedAttr(fvTenantName, rName, "action", "shut"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciBGPPeerPrefixExists(resourceName, &bgp_peer_prefix_updated),
+					resource.TestCheckResourceAttr(resourceName, "action", "shut"),
+					testAccCheckAciBGPPeerPrefixIdEqual(&bgp_peer_prefix_default, &bgp_peer_prefix_updated),
+				),
+			},
+			{
+				Config: CreateAccBGPPeerPrefixConfig(fvTenantName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciBGPPeerPrefix_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciBGPPeerPrefixDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccBGPPeerPrefixConfig(fvTenantName, rName),
+			},
+			{
+				Config:      CreateAccBGPPeerPrefixWithInValidParentDn(rName, rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccBGPPeerPrefixUpdatedAttr(fvTenantName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccBGPPeerPrefixUpdatedAttr(fvTenantName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccBGPPeerPrefixUpdatedAttr(fvTenantName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccBGPPeerPrefixUpdatedAttr(fvTenantName, rName, "action", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccBGPPeerPrefixUpdatedAttr(fvTenantName, rName, "max_pfx", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccBGPPeerPrefixUpdatedAttr(fvTenantName, rName, "restart_time", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccBGPPeerPrefixUpdatedAttr(fvTenantName, rName, "thresh", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccBGPPeerPrefixUpdatedAttr(fvTenantName, rName, "thresh", "200"),
+				ExpectError: regexp.MustCompile(`Property thresh of (.)* is out of range`),
+			},
+			{
+				Config:      CreateAccBGPPeerPrefixUpdatedAttr(fvTenantName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccBGPPeerPrefixConfig(fvTenantName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciBGPPeerPrefix_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciBGPPeerPrefixDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccBGPPeerPrefixesConfig(rName, rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciBGPPeerPrefixExists(name string, bgp_peer_prefix *models.BGPPeerPrefixPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("BGP Peer Prefix %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No BGP Peer Prefix dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		bgp_peer_prefixFound := models.BGPPeerPrefixPolicyFromContainer(cont)
+		if bgp_peer_prefixFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("BGP Peer Prefix %s not found", rs.Primary.ID)
+		}
+		*bgp_peer_prefix = *bgp_peer_prefixFound
+		return nil
+	}
+}
+
+func testAccCheckAciBGPPeerPrefixDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing bgp_peer_prefix destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_bgp_peer_prefix" {
+			cont, err := client.Get(rs.Primary.ID)
+			bgp_peer_prefix := models.BGPPeerPrefixPolicyFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("BGP Peer Prefix %s Still exists", bgp_peer_prefix.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciBGPPeerPrefixIdEqual(m1, m2 *models.BGPPeerPrefixPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("bgp_peer_prefix DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciBGPPeerPrefixIdNotEqual(m1, m2 *models.BGPPeerPrefixPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("bgp_peer_prefix DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateBGPPeerPrefixWithoutRequired(fvTenantName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing bgp_peer_prefix creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		
+	}
+	
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	resource "aci_bgp_peer_prefix" "test" {
+	#	tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_bgp_peer_prefix" "test" {
+		tenant_dn  = aci_tenant.test.id
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, rName)
+}
+
+func CreateAccBGPPeerPrefixConfigWithUpdatedRequiredParams(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing bgp_peer_prefix creation with updated required arguments")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_bgp_peer_prefix" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccBGPPeerPrefixConfig(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing bgp_peer_prefix creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_bgp_peer_prefix" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccBGPPeerPrefixesConfig(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing Multiple bgp_peer_prefixes creation")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_bgp_peer_prefix" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	resource "aci_bgp_peer_prefix" "test1" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	resource "aci_bgp_peer_prefix" "test2" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	resource "aci_bgp_peer_prefix" "test3" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName, rName+"1", rName+"2", rName+"3")
+	return resource
+}
+
+func CreateAccBGPPeerPrefixWithInValidParentDn(prName, rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing bgp_peer_prefix creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_aaa_domain" "test"{
+		name = "%s"
+	}
+	resource "aci_bgp_peer_prefix" "test" {
+		tenant_dn  = aci_aaa_domain.test.id
+		name  = "%s"
+	}
+	`, prName, rName)
+	return resource
+}
+
+func CreateAccBGPPeerPrefixConfigWithOptionalValues(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing bgp_peer_prefix creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_bgp_peer_prefix" "test" {
+		tenant_dn  = "${aci_tenant.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_bgp_peer_prefix"
+		action = "log"
+		max_pfx = "2"
+		restart_time = "2"
+		thresh = "2"
+	}
+	`, fvTenantName, rName)
+
+	return resource
+}
+
+func CreateAccBGPPeerPrefixUpdateWithoutRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing bgp_peer_prefix updation without required parameters")
+	resource := fmt.Sprint(`
+	resource "aci_bgp_peer_prefix" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_bgp_peer_prefix"
+		action = "log"
+		max_pfx = "2"
+		restart_time = "2"
+		thresh = "2"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccBGPPeerPrefixUpdatedAttr(fvTenantName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing bgp_peer_prefix attribute: %s=%s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_bgp_peer_prefix" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, fvTenantName, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_fabrichifpol_test.go
+++ b/testacc/resource_aci_fabrichifpol_test.go
@@ -372,7 +372,7 @@ func testAccCheckAciFabricIfPolicyIdNotEqual(m1, m2 *models.LinkLevelPolicy) res
 }
 
 func CreateFabricIfPolicyWithoutName(rName, attrName string) string {
-	fmt.Println("=== STEP  Basic: testing fabric_if_pol creation without Name", attrName)
+	fmt.Println("=== STEP  Basic: testing fabric_if_pol creation without", attrName)
 	rBlock := `
 	
 	`

--- a/testacc/resource_aci_lacplagpol_test.go
+++ b/testacc/resource_aci_lacplagpol_test.go
@@ -204,6 +204,18 @@ func TestAccAciLACPPolicy_Update(t *testing.T) {
 				),
 			},
 			{
+				Config: CreateAccLACPPolicyUpdatedListAttr(rName, "ctrl", StringListtoString([]string{"load-defer", "graceful-conv", "susp-individual", "symmetric-hash", "fast-sel-hot-stdby"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLACPPolicyExists(resourceName, &lacp_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.#", "5"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.0", "load-defer"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.1", "graceful-conv"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.2", "susp-individual"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.3", "symmetric-hash"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.4", "fast-sel-hot-stdby"),
+				),
+			},
+			{
 				Config: CreateAccLACPPolicyUpdatedListAttr(rName, "ctrl", StringListtoString([]string{"susp-individual", "graceful-conv", "fast-sel-hot-stdby"})),
 			},
 			{
@@ -253,12 +265,7 @@ func TestAccAciLACPPolicy_MultipleCreateDelete(t *testing.T) {
 		CheckDestroy:      testAccCheckAciLACPPolicyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(`
-				resource "aci_lacp_policy" "test" {
-					name  = "%s_${count.index}"
-					count = 5
-				}
-				`, rName),
+				Config: CreateAccLACPPoliciesConfig(rName),
 			},
 		},
 	})
@@ -404,7 +411,7 @@ func CreateLACPPolicyWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccLACPPolicyConfigWithRequiredParams(rName string) string {
-	fmt.Println("=== STEP  testing lacp_policy creation with required arguments only")
+	fmt.Println("=== STEP  testing lacp_policy creation with updated required arguments")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_lacp_policy" "test" {
@@ -427,8 +434,31 @@ func CreateAccLACPPolicyConfig(rName string) string {
 	return resource
 }
 
+func CreateAccLACPPoliciesConfig(rName string) string {
+	fmt.Println("=== STEP  testing Multiple lacp_policy creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_lacp_policy" "test" {
+		name  = "%s"
+	}
+
+	resource "aci_lacp_policy" "test1" {
+		name  = "%s"
+	}
+
+	resource "aci_lacp_policy" "test2" {
+		name  = "%s"
+	}
+
+	resource "aci_lacp_policy" "test3" {
+		name  = "%s"
+	}
+	`, rName, rName+"1", rName+"2", rName+"3")
+	return resource
+}
+
 func CreateAccLACPPolicyConfigUpdatedName(rName string) string {
-	fmt.Println("=== STEP  testing lacp_policy creation with uodated name")
+	fmt.Println("=== STEP  testing lacp_policy creation with Invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_lacp_policy" "test" {
@@ -460,7 +490,7 @@ func CreateAccLACPPolicyConfigWithOptionalValues(rName string) string {
 }
 
 func CreateAccLACPPolicyRemovingRequiredField() string {
-	fmt.Println("=== STEP  Basic: testing lacp_policy creation with optional parameters")
+	fmt.Println("=== STEP  Basic: testing lacp_policy updation without required parameters")
 	resource := fmt.Sprintf(`
 	resource "aci_lacp_policy" "test" {
 		description = "created while acceptance testing"

--- a/website/docs/r/lacp_policy.html.markdown
+++ b/website/docs/r/lacp_policy.html.markdown
@@ -33,10 +33,10 @@ resource "aci_lacp_policy" "example" {
 - `name` - (Required) Name of Object LACP Policy.
 - `description` - (Optional) Description for object LACP Policy.
 - `annotation` - (Optional) Annotation for object LACP Policy.
-- `ctrl` - (Optional) List of LAG control properties. Allowed values are "symmetric-hash", "susp-individual", "graceful-conv", "load-defer" and "fast-sel-hot-stdby". default value is \["fast-sel-hot-stdby", "graceful-conv", "susp-individual"\]
+- `ctrl` - (Optional) List of LAG control properties. Allowed values are "symmetric-hash", "susp-individual", "graceful-conv", "load-defer", and "fast-sel-hot-stdby". default value is \["fast-sel-hot-stdby", "graceful-conv", "susp-individual"\]
 - `max_links` - (Optional) Maximum number of links. Allowed value range is "1" - "16". Default is "16".
 - `min_links` - (Optional) Minimum number of links in port channel. Allowed value range is "1" - "16". Default is "1".
-- `mode` - (Optional) policy mode. Allowed values are "off", "active", "passive", "mac-pin" and "mac-pin-nicload". Default is "off".
+- `mode` - (Optional) policy mode. Allowed values are "off", "active", "passive", "mac-pin", "explicit-failover" and "mac-pin-nicload". Default is "off".
 - `name_alias` - (Optional) Name alias for object LACP Policy.
 
 ## Attribute Reference


### PR DESCRIPTION
$ make fmt && make testacc
gofmt -w $(find . -name '*.go' |grep -v vendor)
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v  -timeout 120m
?       github.com/terraform-providers/terraform-provider-aci   [no test files]
?       github.com/terraform-providers/terraform-provider-aci/aci       [no test files]
=== RUN   TestAccAciBGPPeerPrefixDataSource_Basic
=== STEP  Basic: testing bgp_peer_prefix creation without  tenant_dn
=== STEP  Basic: testing bgp_peer_prefix creation without  name
=== STEP  testing bgp_peer_prefix Data Source with required arguments only
=== STEP  testing bgp_peer_prefix Data Source with random attribute
=== STEP  testing bgp_peer_prefix Data Source with Invalid Parent Dn
=== STEP  testing bgp_peer_prefix Data Source with updated resource
=== PAUSE TestAccAciBGPPeerPrefixDataSource_Basic
=== RUN   TestProvider
--- PASS: TestProvider (0.02s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccAciBGPPeerPrefix_Basic
=== STEP  Basic: testing bgp_peer_prefix creation without  tenant_dn
=== STEP  Basic: testing bgp_peer_prefix creation without  name
=== STEP  testing bgp_peer_prefix creation with required arguments only
=== STEP  Basic: testing bgp_peer_prefix creation with optional parameters
=== STEP  testing bgp_peer_prefix creation with required arguments only
=== STEP  Basic: testing bgp_peer_prefix updation without required parameters
=== STEP  testing bgp_peer_prefix creation with updated required arguments
=== STEP  testing bgp_peer_prefix creation with required arguments only
=== STEP  testing bgp_peer_prefix creation with updated required arguments
=== PAUSE TestAccAciBGPPeerPrefix_Basic
=== RUN   TestAccAciBGPPeerPrefix_Update
=== STEP  testing bgp_peer_prefix creation with required arguments only
=== STEP  testing bgp_peer_prefix attribute: action=restart
=== STEP  testing bgp_peer_prefix attribute: action=shut
=== STEP  testing bgp_peer_prefix creation with required arguments only
=== PAUSE TestAccAciBGPPeerPrefix_Update
=== RUN   TestAccAciBGPPeerPrefix_Negative
=== STEP  testing bgp_peer_prefix creation with required arguments only
=== STEP  Negative Case: testing bgp_peer_prefix creation with invalid parent Dn
=== STEP  testing bgp_peer_prefix attribute: description=suvg20wpix4x1rzduqowgcng8uye3aoxgoob7w18wkok6yc1xpwyza684guixqywfvep3chg0ptmy4dpy9qxmi0eioq3kf2p6otqkp2fwz6ggbqs777syqgh2i3w6tu6h
=== STEP  testing bgp_peer_prefix attribute: annotation=b9tfmxmwvsccwdn1cu2fl884zng3yup7mpx9jeh28ten0jnmqg1bh9vdrmx10ign2p2hqkvugvuq214twnh9xnytzg68c8lm0mt4vdfkw7aolyfdda1oy9tgz027flwnf
=== STEP  testing bgp_peer_prefix attribute: name_alias=3up41ni1vzpsux2rzuyql0dy0972q3vr6d0eea8vcnds38ijj208w0pesgned7cv
=== STEP  testing bgp_peer_prefix attribute: action=acctest_qm7ma
=== STEP  testing bgp_peer_prefix attribute: max_pfx=acctest_qm7ma
=== STEP  testing bgp_peer_prefix attribute: restart_time=acctest_qm7ma
=== STEP  testing bgp_peer_prefix attribute: thresh=acctest_qm7ma
=== STEP  testing bgp_peer_prefix attribute: thresh=200
=== STEP  testing bgp_peer_prefix attribute: gtvrt=acctest_qm7ma
=== STEP  testing bgp_peer_prefix creation with required arguments only
=== PAUSE TestAccAciBGPPeerPrefix_Negative
=== RUN   TestAccAciBGPPeerPrefix_MultipleCreateDelete
=== STEP  testing Multiple bgp_peer_prefixes creation
=== STEP  testing bgp_peer_prefix destroy
--- PASS: TestAccAciBGPPeerPrefix_MultipleCreateDelete (39.57s)
=== CONT  TestAccAciBGPPeerPrefixDataSource_Basic
=== CONT  TestAccAciBGPPeerPrefix_Update
=== CONT  TestAccAciBGPPeerPrefix_Negative
=== CONT  TestAccAciBGPPeerPrefix_Basic
=== STEP  testing bgp_peer_prefix destroy
--- PASS: TestAccAciBGPPeerPrefixDataSource_Basic (95.46s)
=== STEP  testing bgp_peer_prefix destroy
--- PASS: TestAccAciBGPPeerPrefix_Update (125.54s)
=== STEP  testing bgp_peer_prefix destroy
--- PASS: TestAccAciBGPPeerPrefix_Negative (182.44s)
=== STEP  testing bgp_peer_prefix destroy
--- PASS: TestAccAciBGPPeerPrefix_Basic (185.43s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   226.330s

$ go test -v -run TestAccAciLACPPolicy_Update
=== RUN   TestAccAciLACPPolicy_Update
=== STEP  testing lacp_policy creation with required arguments only
=== STEP  testing lacp_policy attribute: ctrl=["fast-sel-hot-stdby"]
=== STEP  testing lacp_policy attribute: ctrl=["fast-sel-hot-stdby","graceful-conv"]
=== STEP  testing lacp_policy attribute: ctrl=["graceful-conv"]
=== STEP  testing lacp_policy attribute: ctrl=["fast-sel-hot-stdby","graceful-conv","load-defer"]
=== STEP  testing lacp_policy attribute: ctrl=["graceful-conv","load-defer"]
=== STEP  testing lacp_policy attribute: ctrl=["load-defer"]
=== STEP  testing lacp_policy attribute: ctrl=["fast-sel-hot-stdby","graceful-conv","load-defer","susp-individual"]
=== STEP  testing lacp_policy attribute: ctrl=["graceful-conv","load-defer","susp-individual"]
=== STEP  testing lacp_policy attribute: ctrl=["load-defer","graceful-conv","susp-individual"]
=== STEP  testing lacp_policy attribute: ctrl=["load-defer","graceful-conv","susp-individual","symmetric-hash","fast-sel-hot-stdby"]
=== STEP  testing lacp_policy attribute: ctrl=["susp-individual","graceful-conv","fast-sel-hot-stdby"]
=== STEP  testing lacp_policy attribute: mode=explicit-failover
=== STEP  testing lacp_policy attribute: mode=mac-pin
=== STEP  testing lacp_policy attribute: mode=mac-pin-nicload
=== STEP  testing lacp_policy attribute: mode=passive
=== STEP  testing lacp_policy creation with required arguments only
=== PAUSE TestAccAciLACPPolicy_Update
=== CONT  TestAccAciLACPPolicy_Update
=== STEP  testing lacp_policy destroy
--- PASS: TestAccAciLACPPolicy_Update (478.37s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   480.645s