### PR TITLE
added test files for bgpbestpathctrlpol, hsrpgrouppol, l3extdomp

### DIFF
--- a/testacc/data_source_aci_bgpbestpathctrlpol_test.go
+++ b/testacc/data_source_aci_bgpbestpathctrlpol_test.go
@@ -1,0 +1,189 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciBgpBestPathPolicyDataSource_Basic(t *testing.T) {
+	resourceName := "aci_bgp_best_path_policy.test"
+	dataSourceName := "data.aci_bgp_best_path_policy.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciBgpBestPathPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateBgpBestPathPolicyDSWithoutRequired(rName, rName, "tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateBgpBestPathPolicyDSWithoutRequired(rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccBgpBestPathPolicyConfigDataSource(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "tenant_dn", resourceName, "tenant_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ctrl", resourceName, "ctrl"),
+				),
+			},
+			{
+				Config:      CreateAccBgpBestPathPolicyDataSourceUpdate(rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccBgpBestPathPolicyDSWithInvalidName(rName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+
+			{
+				Config: CreateAccBgpBestPathPolicyDataSourceUpdatedResource(rName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccBgpBestPathPolicyConfigDataSource(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing bgp_best_path_policy Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_bgp_best_path_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_bgp_best_path_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_bgp_best_path_policy.test.name
+		depends_on = [ aci_bgp_best_path_policy.test ]
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateBgpBestPathPolicyDSWithoutRequired(fvTenantName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing bgp_best_path_policy Data Source without ", attrName)
+	rBlock := `
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_bgp_best_path_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	data "aci_bgp_best_path_policy" "test" {
+	#	tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		depends_on = [ aci_bgp_best_path_policy.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_bgp_best_path_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+	#	name  = "%s"
+		depends_on = [ aci_bgp_best_path_policy.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, rName)
+}
+
+func CreateAccBgpBestPathPolicyDSWithInvalidName(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing bgp_best_path_policy Data Source with invalid name")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_bgp_best_path_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_bgp_best_path_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "${aci_bgp_best_path_policy.test.name}_invalid"
+		depends_on = [ aci_bgp_best_path_policy.test ]
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccBgpBestPathPolicyDataSourceUpdate(fvTenantName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing bgp_best_path_policy Data Source with random attribute")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_bgp_best_path_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_bgp_best_path_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_bgp_best_path_policy.test.name
+		%s = "%s"
+		depends_on = [ aci_bgp_best_path_policy.test ]
+	}
+	`, fvTenantName, rName, key, value)
+	return resource
+}
+
+func CreateAccBgpBestPathPolicyDataSourceUpdatedResource(fvTenantName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing bgp_best_path_policy Data Source with updated resource")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_bgp_best_path_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_bgp_best_path_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_bgp_best_path_policy.test.name
+		depends_on = [ aci_bgp_best_path_policy.test ]
+	}
+	`, fvTenantName, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_bgpctxafpol_test.go
+++ b/testacc/data_source_aci_bgpctxafpol_test.go
@@ -88,7 +88,7 @@ func CreateAccBGPAddressFamilyContextConfigDataSource(fvTenantName, rName string
 }
 
 func CreateBGPAddressFamilyContextDSWithoutRequired(fvTenantName, rName, attrName string) string {
-	fmt.Println("=== STEP  Basic: testing bgp_address_family_context creation without ", attrName)
+	fmt.Println("=== STEP  Basic: testing bgp_address_family_context Data Source without ", attrName)
 	rBlock := `
 	
 	resource "aci_tenant" "test" {

--- a/testacc/data_source_aci_bgpctxpol_test.go
+++ b/testacc/data_source_aci_bgpctxpol_test.go
@@ -123,7 +123,7 @@ func CreateAccBGPTimersPolicyConfigDataSource(fvTenantName, rName string) string
 	return resource
 }
 func CreateAccBGPTimersPolicyDSWithInvalidName(fvTenantName, rName string) string {
-	fmt.Println("=== STEP  testing bgp_timers_policy Data Source with Invalid Parent Dn")
+	fmt.Println("=== STEP  testing bgp_timers_policy Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {

--- a/testacc/data_source_aci_hsrpgrouppol_test.go
+++ b/testacc/data_source_aci_hsrpgrouppol_test.go
@@ -1,0 +1,197 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciHSRPGroupPolicyDataSource_Basic(t *testing.T) {
+	resourceName := "aci_hsrp_group_policy.test"
+	dataSourceName := "data.aci_hsrp_group_policy.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciHSRPGroupPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateHSRPGroupPolicyDSWithoutRequired(rName, rName, "tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateHSRPGroupPolicyDSWithoutRequired(rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccHSRPGroupPolicyConfigDataSource(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "tenant_dn", resourceName, "tenant_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ctrl", resourceName, "ctrl"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "hello_intvl", resourceName, "hello_intvl"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "hold_intvl", resourceName, "hold_intvl"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "preempt_delay_min", resourceName, "preempt_delay_min"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "preempt_delay_reload", resourceName, "preempt_delay_reload"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "preempt_delay_sync", resourceName, "preempt_delay_sync"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "prio", resourceName, "prio"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "timeout", resourceName, "timeout"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "hsrp_group_policy_type", resourceName, "hsrp_group_policy_type"),
+				),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyDataSourceUpdate(rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccHSRPGroupPolicyDSWithInvalidName(rName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+
+			{
+				Config: CreateAccHSRPGroupPolicyDataSourceUpdatedResource(rName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccHSRPGroupPolicyConfigDataSource(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing hsrp_group_policy Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_hsrp_group_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_hsrp_group_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_hsrp_group_policy.test.name
+		depends_on = [ aci_hsrp_group_policy.test ]
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateHSRPGroupPolicyDSWithoutRequired(fvTenantName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing hsrp_group_policy Data Source without ", attrName)
+	rBlock := `
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_hsrp_group_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	data "aci_hsrp_group_policy" "test" {
+	#	tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		depends_on = [ aci_hsrp_group_policy.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_hsrp_group_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+	#	name  = "%s"
+		depends_on = [ aci_hsrp_group_policy.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, rName)
+}
+
+func CreateAccHSRPGroupPolicyDSWithInvalidName(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing hsrp_group_policy Data Source with invalid name")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_hsrp_group_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_hsrp_group_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "${aci_hsrp_group_policy.test.name}_invalid"
+		depends_on = [ aci_hsrp_group_policy.test ]
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccHSRPGroupPolicyDataSourceUpdate(fvTenantName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing hsrp_group_policy Data Source with random attribute")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_hsrp_group_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_hsrp_group_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_hsrp_group_policy.test.name
+		%s = "%s"
+		depends_on = [ aci_hsrp_group_policy.test ]
+	}
+	`, fvTenantName, rName, key, value)
+	return resource
+}
+
+func CreateAccHSRPGroupPolicyDataSourceUpdatedResource(fvTenantName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing hsrp_group_policy Data Source with updated resource")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_hsrp_group_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_hsrp_group_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_hsrp_group_policy.test.name
+		depends_on = [ aci_hsrp_group_policy.test ]
+	}
+	`, fvTenantName, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_l3extdomp_test.go
+++ b/testacc/data_source_aci_l3extdomp_test.go
@@ -1,0 +1,150 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciL3DomainProfileDataSource_Basic(t *testing.T) {
+	resourceName := "aci_l3_domain_profile.test"
+	dataSourceName := "data.aci_l3_domain_profile.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3DomainProfileDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateL3DomainProfileDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccL3DomainProfileConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+				),
+			},
+			{
+				Config:      CreateAccL3DomainProfileDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccL3DomainProfileDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccL3DomainProfileDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccL3DomainProfileConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing l3_domain_profile Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_l3_domain_profile" "test" {
+
+		name  = "%s"
+	}
+
+	data "aci_l3_domain_profile" "test" {
+
+		name  = aci_l3_domain_profile.test.name
+		depends_on = [ aci_l3_domain_profile.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateL3DomainProfileDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing l3_domain_profile Data Source without ", attrName)
+	rBlock := `
+
+	resource "aci_l3_domain_profile" "test" {
+
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_l3_domain_profile" "test" {
+
+	#	name  = "%s"
+		depends_on = [ aci_l3_domain_profile.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccL3DomainProfileDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing l3_domain_profile Data Source with random attribute")
+	resource := fmt.Sprintf(`
+
+	resource "aci_l3_domain_profile" "test" {
+
+		name  = "%s"
+	}
+
+	data "aci_l3_domain_profile" "test" {
+
+		name  = aci_l3_domain_profile.test.name
+		%s = "%s"
+		depends_on = [ aci_l3_domain_profile.test ]
+	}
+	`, rName, key, value)
+	return resource
+}
+
+func CreateAccL3DomainProfileDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing l3_domain_profile Data Source with updated resource")
+	resource := fmt.Sprintf(`
+
+	resource "aci_l3_domain_profile" "test" {
+
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_l3_domain_profile" "test" {
+
+		name  = aci_l3_domain_profile.test.name
+		depends_on = [ aci_l3_domain_profile.test ]
+	}
+	`, rName, key, value)
+	return resource
+}
+
+func CreateAccL3DomainProfileDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing l3_domain_profile Data Source with invalid name")
+	resource := fmt.Sprintf(`
+
+	resource "aci_l3_domain_profile" "test" {
+
+		name  = "%s"
+	}
+
+	data "aci_l3_domain_profile" "test" {
+
+		name  = "${aci_l3_domain_profile.test.name}_invalid"
+		depends_on = [ aci_l3_domain_profile.test ]
+	}
+	`, rName)
+	return resource
+}

--- a/testacc/resource_aci_bgpbestpathctrlpol_test.go
+++ b/testacc/resource_aci_bgpbestpathctrlpol_test.go
@@ -1,0 +1,371 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciBgpBestPathPolicy_Basic(t *testing.T) {
+	var bgp_best_path_policy_default models.BgpBestPathPolicy
+	var bgp_best_path_policy_updated models.BgpBestPathPolicy
+	resourceName := "aci_bgp_best_path_policy.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciBgpBestPathPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateBgpBestPathPolicyWithoutRequired(rName, rName, "tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateBgpBestPathPolicyWithoutRequired(rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccBgpBestPathPolicyConfig(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciBgpBestPathPolicyExists(resourceName, &bgp_best_path_policy_default),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "ctrl", "0"),
+				),
+			},
+			{
+				Config: CreateAccBgpBestPathPolicyConfigWithOptionalValues(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciBgpBestPathPolicyExists(resourceName, &bgp_best_path_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_bgp_best_path_policy"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl", "asPathMultipathRelax"),
+					testAccCheckAciBgpBestPathPolicyIdEqual(&bgp_best_path_policy_default, &bgp_best_path_policy_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccBgpBestPathPolicyConfigWithRequiredParams(rName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccBgpBestPathPolicyRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccBgpBestPathPolicyConfigWithRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciBgpBestPathPolicyExists(resourceName, &bgp_best_path_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciBgpBestPathPolicyIdNotEqual(&bgp_best_path_policy_default, &bgp_best_path_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccBgpBestPathPolicyConfig(rName, rName),
+			},
+			{
+				Config: CreateAccBgpBestPathPolicyConfigWithRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciBgpBestPathPolicyExists(resourceName, &bgp_best_path_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciBgpBestPathPolicyIdNotEqual(&bgp_best_path_policy_default, &bgp_best_path_policy_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciBgpBestPathPolicy_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciBgpBestPathPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccBgpBestPathPolicyConfig(rName, rName),
+			},
+			{
+				Config:      CreateAccBgpBestPathPolicyWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccBgpBestPathPolicyUpdatedAttr(rName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccBgpBestPathPolicyUpdatedAttr(rName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccBgpBestPathPolicyUpdatedAttr(rName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccBgpBestPathPolicyUpdatedAttr(rName, rName, "ctrl", randomValue),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccBgpBestPathPolicyUpdatedAttr(rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccBgpBestPathPolicyConfig(rName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciBgpBestPathPolicy_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciBgpBestPathPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccBgpBestPathPolicyConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciBgpBestPathPolicyExists(name string, bgp_best_path_policy *models.BgpBestPathPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Bgp Best Path Policy %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Bgp Best Path Policy dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		bgp_best_path_policyFound := models.BgpBestPathPolicyFromContainer(cont)
+		if bgp_best_path_policyFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Bgp Best Path Policy %s not found", rs.Primary.ID)
+		}
+		*bgp_best_path_policy = *bgp_best_path_policyFound
+		return nil
+	}
+}
+
+func testAccCheckAciBgpBestPathPolicyDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing bgp_best_path_policy destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_bgp_best_path_policy" {
+			cont, err := client.Get(rs.Primary.ID)
+			bgp_best_path_policy := models.BgpBestPathPolicyFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Bgp Best Path Policy %s Still exists", bgp_best_path_policy.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciBgpBestPathPolicyIdEqual(m1, m2 *models.BgpBestPathPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("bgp_best_path_policy DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciBgpBestPathPolicyIdNotEqual(m1, m2 *models.BgpBestPathPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("bgp_best_path_policy DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateBgpBestPathPolicyWithoutRequired(fvTenantName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing bgp_best_path_policy creation without ", attrName)
+	rBlock := `
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	resource "aci_bgp_best_path_policy" "test" {
+	#	tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_bgp_best_path_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, rName)
+}
+
+func CreateAccBgpBestPathPolicyConfigWithRequiredParams(fvTenantName, rName string) string {
+	fmt.Printf("=== STEP  testing bgp_best_path_policy creation with tenant name %s and name %s\n", fvTenantName, rName)
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_bgp_best_path_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccBgpBestPathPolicyConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple bgp_best_path_policy creation with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_bgp_best_path_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccBgpBestPathPolicyConfig(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing bgp_best_path_policy creation with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_bgp_best_path_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccBgpBestPathPolicyWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing bgp_best_path_policy creation with invalid tenant_dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_application_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"	
+	}
+	resource "aci_bgp_best_path_policy" "test" {
+		tenant_dn  = aci_application_profile.test.id
+		name  = "%s"	
+	}
+	`, rName, rName, rName)
+	return resource
+}
+
+func CreateAccBgpBestPathPolicyConfigWithOptionalValues(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing bgp_best_path_policy creation with optional parameters")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_bgp_best_path_policy" "test" {
+		tenant_dn  = "${aci_tenant.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_bgp_best_path_policy"
+		ctrl = "asPathMultipathRelax"
+
+	}
+	`, fvTenantName, rName)
+
+	return resource
+}
+
+func CreateAccBgpBestPathPolicyRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing bgp_best_path_policy update with parameters")
+	resource := fmt.Sprintln(`
+	resource "aci_bgp_best_path_policy" "test" {
+		description = "created while acceptance testing"
+		annotation = "tag"
+		name_alias = "test_bgp_best_path_policy"
+		ctrl = "asPathMultipathRelax"
+
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccBgpBestPathPolicyUpdatedAttr(fvTenantName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing bgp_best_path_policy attribute: %s=%s \n", attribute, value)
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_bgp_best_path_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, fvTenantName, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_hsrpgrouppol_test.go
+++ b/testacc/resource_aci_hsrpgrouppol_test.go
@@ -1,0 +1,539 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciHSRPGroupPolicy_Basic(t *testing.T) {
+	var hsrp_group_policy_default models.HSRPGroupPolicy
+	var hsrp_group_policy_updated models.HSRPGroupPolicy
+	resourceName := "aci_hsrp_group_policy.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciHSRPGroupPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateHSRPGroupPolicyWithoutRequired(rName, rName, "tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateHSRPGroupPolicyWithoutRequired(rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccHSRPGroupPolicyConfig(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHSRPGroupPolicyExists(resourceName, &hsrp_group_policy_default),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "ctrl", "0"),
+					resource.TestCheckResourceAttr(resourceName, "hello_intvl", "3000"),
+					resource.TestCheckResourceAttr(resourceName, "hold_intvl", "10000"),
+					resource.TestCheckResourceAttr(resourceName, "preempt_delay_min", "0"),
+					resource.TestCheckResourceAttr(resourceName, "preempt_delay_reload", "0"),
+					resource.TestCheckResourceAttr(resourceName, "preempt_delay_sync", "0"),
+					resource.TestCheckResourceAttr(resourceName, "prio", "100"),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "0"),
+					resource.TestCheckResourceAttr(resourceName, "hsrp_group_policy_type", "simple"),
+				),
+			},
+			{
+				Config: CreateAccHSRPGroupPolicyConfigWithOptionalValues(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHSRPGroupPolicyExists(resourceName, &hsrp_group_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_hsrp_group_policy"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl", "preempt"),
+					resource.TestCheckResourceAttr(resourceName, "hello_intvl", "6000"),
+					resource.TestCheckResourceAttr(resourceName, "hold_intvl", "18000"),
+					resource.TestCheckResourceAttr(resourceName, "key", "cisco"),
+					resource.TestCheckResourceAttr(resourceName, "preempt_delay_min", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "preempt_delay_reload", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "preempt_delay_sync", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "prio", "255"),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "32767"),
+					resource.TestCheckResourceAttr(resourceName, "hsrp_group_policy_type", "md5"),
+					testAccCheckAciHSRPGroupPolicyIdEqual(&hsrp_group_policy_default, &hsrp_group_policy_updated),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"key"},
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyConfigWithRequiredParams(rName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccHSRPGroupPolicyRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccHSRPGroupPolicyConfigWithRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHSRPGroupPolicyExists(resourceName, &hsrp_group_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciHSRPGroupPolicyIdNotEqual(&hsrp_group_policy_default, &hsrp_group_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccHSRPGroupPolicyConfig(rName, rName),
+			},
+			{
+				Config: CreateAccHSRPGroupPolicyConfigWithRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHSRPGroupPolicyExists(resourceName, &hsrp_group_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciHSRPGroupPolicyIdNotEqual(&hsrp_group_policy_default, &hsrp_group_policy_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciHSRPGroupPolicy_Update(t *testing.T) {
+	var hsrp_group_policy_default models.HSRPGroupPolicy
+	var hsrp_group_policy_updated models.HSRPGroupPolicy
+	resourceName := "aci_hsrp_group_policy.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciHSRPGroupPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccHSRPGroupPolicyConfig(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHSRPGroupPolicyExists(resourceName, &hsrp_group_policy_default),
+				),
+			},
+			{
+				Config: CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "preempt_delay_min", "1800"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHSRPGroupPolicyExists(resourceName, &hsrp_group_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "preempt_delay_min", "1800"),
+					testAccCheckAciHSRPGroupPolicyIdEqual(&hsrp_group_policy_default, &hsrp_group_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "preempt_delay_reload", "1800"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHSRPGroupPolicyExists(resourceName, &hsrp_group_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "preempt_delay_reload", "1800"),
+					testAccCheckAciHSRPGroupPolicyIdEqual(&hsrp_group_policy_default, &hsrp_group_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "preempt_delay_sync", "1800"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHSRPGroupPolicyExists(resourceName, &hsrp_group_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "preempt_delay_sync", "1800"),
+					testAccCheckAciHSRPGroupPolicyIdEqual(&hsrp_group_policy_default, &hsrp_group_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "prio", "0"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHSRPGroupPolicyExists(resourceName, &hsrp_group_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "prio", "0"),
+					testAccCheckAciHSRPGroupPolicyIdEqual(&hsrp_group_policy_default, &hsrp_group_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "prio", "125"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHSRPGroupPolicyExists(resourceName, &hsrp_group_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "prio", "125"),
+					testAccCheckAciHSRPGroupPolicyIdEqual(&hsrp_group_policy_default, &hsrp_group_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "timeout", "16000"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciHSRPGroupPolicyExists(resourceName, &hsrp_group_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "16000"),
+					testAccCheckAciHSRPGroupPolicyIdEqual(&hsrp_group_policy_default, &hsrp_group_policy_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciHSRPGroupPolicy_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciHSRPGroupPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccHSRPGroupPolicyConfig(rName, rName),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "ctrl", randomValue),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "hello_intvl", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "hold_intvl", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "preempt_delay_min", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "preempt_delay_reload", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "preempt_delay_sync", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "preempt_delay_min", "3601"),
+				ExpectError: regexp.MustCompile(`Property (.)+ is out of range`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "preempt_delay_reload", "3601"),
+				ExpectError: regexp.MustCompile(`Property (.)+ is out of range`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "preempt_delay_sync", "3601"),
+				ExpectError: regexp.MustCompile(`Property (.)+ is out of range`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "prio", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "prio", "256"),
+				ExpectError: regexp.MustCompile(`Property (.)+ is out of range`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "timeout", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "timeout", "32768"),
+				ExpectError: regexp.MustCompile(`Property (.)+ is out of range`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "hsrp_group_policy_type", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "hello_intvl", "750"),
+				ExpectError: regexp.MustCompile(`Invalid Configuration HSRP Hold and Hello timers not allowed in fractions of secs`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "hold_intvl", "1750"),
+				ExpectError: regexp.MustCompile(`Invalid Configuration HSRP Hold and Hello timers not allowed in fractions of secs`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, "hold_intvl", "1000"),
+				ExpectError: regexp.MustCompile(`Invalid Configuration HSRP Hold timer should be 3X the HSRP Hello timer.`),
+			},
+			{
+				Config:      CreateAccHSRPGroupPolicyUpdatedAttr(rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccHSRPGroupPolicyConfig(rName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciHSRPGroupPolicy_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciHSRPGroupPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccHSRPGroupPolicyConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciHSRPGroupPolicyExists(name string, hsrp_group_policy *models.HSRPGroupPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("HSRP Group Policy %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No HSRP Group Policy dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		hsrp_group_policyFound := models.HSRPGroupPolicyFromContainer(cont)
+		if hsrp_group_policyFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("HSRP Group Policy %s not found", rs.Primary.ID)
+		}
+		*hsrp_group_policy = *hsrp_group_policyFound
+		return nil
+	}
+}
+
+func testAccCheckAciHSRPGroupPolicyDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing hsrp_group_policy destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_hsrp_group_policy" {
+			cont, err := client.Get(rs.Primary.ID)
+			hsrp_group_policy := models.HSRPGroupPolicyFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("HSRP Group Policy %s Still exists", hsrp_group_policy.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciHSRPGroupPolicyIdEqual(m1, m2 *models.HSRPGroupPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("hsrp_group_policy DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciHSRPGroupPolicyIdNotEqual(m1, m2 *models.HSRPGroupPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("hsrp_group_policy DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateHSRPGroupPolicyWithoutRequired(fvTenantName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing hsrp_group_policy creation without ", attrName)
+	rBlock := `
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	resource "aci_hsrp_group_policy" "test" {
+	#	tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_hsrp_group_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, rName)
+}
+
+func CreateAccHSRPGroupPolicyConfigWithRequiredParams(fvTenantName, rName string) string {
+	fmt.Printf("=== STEP  testing hsrp_group_policy creation with tenant name %s and hsrp_group_policy name %s\n", fvTenantName, rName)
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_hsrp_group_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccHSRPGroupPolicyConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple hsrp_group_policy creation with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_hsrp_group_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccHSRPGroupPolicyConfig(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing hsrp_group_policy creation with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_hsrp_group_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccHSRPGroupPolicyWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing hsrp_group_policy creation with invalid tenant_dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+
+	resource "aci_application_profile" "test"{
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_hsrp_group_policy" "test" {
+		tenant_dn  = aci_application_profile.test.id
+		name  = "%s"	
+	}
+	`, rName, rName, rName)
+	return resource
+}
+
+func CreateAccHSRPGroupPolicyConfigWithOptionalValues(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing hsrp_group_policy creation with optional parameters")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_hsrp_group_policy" "test" {
+		tenant_dn  = "${aci_tenant.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_hsrp_group_policy"
+		ctrl = "preempt"
+		hello_intvl = "6000"
+		hold_intvl = "18000"
+		key = "cisco"
+		preempt_delay_min = "3600"
+		preempt_delay_reload = "3600"
+		preempt_delay_sync = "3600"
+		prio = "255"
+		timeout = "32767"
+		hsrp_group_policy_type = "md5"
+	}
+	`, fvTenantName, rName)
+
+	return resource
+}
+
+func CreateAccHSRPGroupPolicyRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing hsrp_group_policy creation with optional parameters")
+	resource := fmt.Sprintln(`
+	resource "aci_hsrp_group_policy" "test" {
+		description = "created while acceptance testing"
+		annotation = "tag"
+		name_alias = "test_hsrp_group_policy"
+		ctrl = "preempt"
+		hello_intvl = "251"
+		hold_intvl = "751"
+		key = ""
+		preempt_delay_min = "1"
+		preempt_delay_reload = "1"
+		preempt_delay_sync = "1"
+		prio = "1"
+		secure_auth_key = ""
+		timeout = "32767"
+		hsrp_group_policy_type = "md5"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccHSRPGroupPolicyUpdatedAttr(fvTenantName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing hsrp_group_policy attribute: %s=%s \n", attribute, value)
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_hsrp_group_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, fvTenantName, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_infraaccportp_test.go
+++ b/testacc/resource_aci_infraaccportp_test.go
@@ -292,7 +292,7 @@ func CreateAccLeafInterfaceProfileConfigWithOptionalValues(rName string) string 
 }
 
 func CreateAccLeafInterfaceProfileRemovingRequiredField() string {
-	fmt.Println("=== STEP  Basic: testing leaf_interface_profile update with required parameters")
+	fmt.Println("=== STEP  Basic: testing leaf_interface_profile update without required parameters")
 	resource := `
 	resource "aci_leaf_interface_profile" "test" {
 		description = "created while acceptance testing"

--- a/testacc/resource_aci_l3extdomp_test.go
+++ b/testacc/resource_aci_l3extdomp_test.go
@@ -1,0 +1,368 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciL3DomainProfile_Basic(t *testing.T) {
+	var l3_domain_profile_default models.L3DomainProfile
+	var l3_domain_profile_updated models.L3DomainProfile
+	resourceName := "aci_l3_domain_profile.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3DomainProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateL3DomainProfileWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccL3DomainProfileConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3DomainProfileExists(resourceName, &l3_domain_profile_default),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_dom_vxlan_ns_def", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vip_addr_ns", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vlan_ns", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vlan_ns_def", ""),
+				),
+			},
+			{
+				Config: CreateAccL3DomainProfileConfigWithOptionalValues(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3DomainProfileExists(resourceName, &l3_domain_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_l3_domain_profile"),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_dom_vxlan_ns_def", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vip_addr_ns", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vlan_ns", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vlan_ns_def", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_extnw_rs_out.#", "0"),
+					testAccCheckAciL3DomainProfileIdEqual(&l3_domain_profile_default, &l3_domain_profile_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccL3DomainProfileConfigWithRequiredParams(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccL3DomainProfileRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccL3DomainProfileConfigWithRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3DomainProfileExists(resourceName, &l3_domain_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciL3DomainProfileIdNotEqual(&l3_domain_profile_default, &l3_domain_profile_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciL3DomainProfile_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3DomainProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccL3DomainProfileConfig(rName),
+			},
+			{
+				Config:      CreateAccL3DomainProfileUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccL3DomainProfileUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccL3DomainProfileUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccL3DomainProfileConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciL3DomainProfile_RelationParameters(t *testing.T) {
+	var l3_domain_profile_default models.L3DomainProfile
+	var l3_domain_profile_updated models.L3DomainProfile
+	rName := makeTestVariable(acctest.RandString(5))
+	relResName1 := makeTestVariable(acctest.RandString(5))
+	relResName2 := makeTestVariable(acctest.RandString(5))
+	resourceName := "aci_l3_domain_profile.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3DomainProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccL3DomainProfileConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3DomainProfileExists(resourceName, &l3_domain_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_dom_vxlan_ns_def", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vip_addr_ns", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vlan_ns", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vlan_ns_def", ""),
+				),
+			},
+			{
+				Config: CreateAccL3DomainProfileRelParams(rName, relResName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3DomainProfileExists(resourceName, &l3_domain_profile_default),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_dom_vxlan_ns_def", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vip_addr_ns", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vlan_ns", fmt.Sprintf("uni/infra/vlanns-[%s]-static", relResName1)),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vlan_ns_def", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_extnw_rs_out.#", "0"),
+					testAccCheckAciL3DomainProfileIdEqual(&l3_domain_profile_default, &l3_domain_profile_updated),
+				),
+			},
+			{
+				Config: CreateAccL3DomainProfileRelParams(rName, relResName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3DomainProfileExists(resourceName, &l3_domain_profile_default),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_dom_vxlan_ns_def", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vip_addr_ns", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vlan_ns", fmt.Sprintf("uni/infra/vlanns-[%s]-static", relResName2)),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vlan_ns_def", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_extnw_rs_out.#", "0"),
+					testAccCheckAciL3DomainProfileIdEqual(&l3_domain_profile_default, &l3_domain_profile_updated),
+				),
+			},
+			{
+				Config: CreateAccL3DomainProfileConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3DomainProfileExists(resourceName, &l3_domain_profile_default),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_dom_vxlan_ns_def", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vip_addr_ns", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vlan_ns", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_infra_rs_vlan_ns_def", ""),
+					resource.TestCheckResourceAttr(resourceName, "relation_extnw_rs_out.#", "0"),
+					testAccCheckAciL3DomainProfileIdEqual(&l3_domain_profile_default, &l3_domain_profile_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciL3DomainProfile_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3DomainProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccL3DomainProfileConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciL3DomainProfileExists(name string, l3_domain_profile *models.L3DomainProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("L3 Domain Profile %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No L3 Domain Profile dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		l3_domain_profileFound := models.L3DomainProfileFromContainer(cont)
+		if l3_domain_profileFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("L3 Domain Profile %s not found", rs.Primary.ID)
+		}
+		*l3_domain_profile = *l3_domain_profileFound
+		return nil
+	}
+}
+
+func testAccCheckAciL3DomainProfileDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing l3_domain_profile destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_l3_domain_profile" {
+			cont, err := client.Get(rs.Primary.ID)
+			l3_domain_profile := models.L3DomainProfileFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("L3 Domain Profile %s Still exists", l3_domain_profile.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciL3DomainProfileIdEqual(m1, m2 *models.L3DomainProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("l3_domain_profile DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciL3DomainProfileIdNotEqual(m1, m2 *models.L3DomainProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("l3_domain_profile DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateL3DomainProfileWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing l3_domain_profile creation without ", attrName)
+	rBlock := `
+
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_l3_domain_profile" "test" {
+
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccL3DomainProfileConfigWithRequiredParams(rName string) string {
+	fmt.Println("=== STEP  testing l3_domain_profile creation with name", rName)
+	resource := fmt.Sprintf(`
+
+	resource "aci_l3_domain_profile" "test" {
+
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccL3DomainProfileRelParams(rName, relName string) string {
+	fmt.Println("=== STEP  testing l3_domain_profile creation relation resource name", relName)
+	resource := fmt.Sprintf(`
+	resource "aci_vlan_pool" "test" {
+		name = "%s"
+		alloc_mode = "static"
+	}
+
+	resource "aci_l3_domain_profile" "test" {
+		name  = "%s"
+		relation_infra_rs_vlan_ns = aci_vlan_pool.test.id
+	}
+	`, relName, rName)
+	return resource
+}
+
+func CreateAccL3DomainProfileConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple l3_domain_profile creation with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_l3_domain_profile" "test" {
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccL3DomainProfileConfig(rName string) string {
+	fmt.Println("=== STEP  testing l3_domain_profile creation with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_l3_domain_profile" "test" {
+
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccL3DomainProfileConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing l3_domain_profile creation with optional parameters")
+	resource := fmt.Sprintf(`
+
+	resource "aci_l3_domain_profile" "test" {
+
+		name  = "%s"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_l3_domain_profile"
+
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccL3DomainProfileRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing l3_domain_profile creation with optional parameters")
+	resource := fmt.Sprintln(`
+	resource "aci_l3_domain_profile" "test" {
+		annotation = "tag"
+		name_alias = "test_l3_domain_profile"
+
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccL3DomainProfileUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing l3_domain_profile attribute: %s=%s \n", attribute, value)
+	resource := fmt.Sprintf(`
+
+	resource "aci_l3_domain_profile" "test" {
+
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName, attribute, value)
+	return resource
+}

--- a/website/docs/r/hsrp_group_policy.html.markdown
+++ b/website/docs/r/hsrp_group_policy.html.markdown
@@ -47,19 +47,19 @@ resource "aci_hsrp_group_policy" "example" {
 
 - `hold_intvl` - (Optional) The period of time before declaring that the neighbor is down. Default value: "10000".
 
-- `key` - (Optional) The key or password used to uniquely identify this configuration object. If `key` is set, the object key will reset when terraform configuration is applied. Default value: "cisco".
+- `key` - (Optional) The key or password used to uniquely identify this configuration object. If `key` is set, the object key will reset when terraform configuration is applied. 
 
 - `name_alias` - (Optional) Name alias for object hsrp group policy.
 
-- `preempt_delay_min` - (Optional) HSRP Group's Minimum Preemption delay. Default value: "0".
+- `preempt_delay_min` - (Optional) HSRP Group's Minimum Preemption delay. Allowed range: "0" - "3600". Default value: "0".
 
-- `preempt_delay_reload` - (Optional) Preemption delay after switch reboot. Default value: "0".
+- `preempt_delay_reload` - (Optional) Preemption delay after switch reboot. Allowed range: "0" - "3600". Default value: "0".
 
-- `preempt_delay_sync` - (Optional) Maximum number of seconds to allow IPredundancy clients to prevent preemption. Default value: "0".
+- `preempt_delay_sync` - (Optional) Maximum number of seconds to allow IPredundancy clients to prevent preemption. Allowed range: "0" - "3600". Default value: "0".
 
-- `prio` - (Optional) The QoS priority class ID. Default value: "100".
+- `prio` - (Optional) The QoS priority class ID. Allowed range: "0" - "255". Default value: "100".
 
-- `timeout` - (Optional) Amount of time between authentication attempts. Default value: "0".
+- `timeout` - (Optional) Amount of time between authentication attempts. Allowed range: "0" - "32767". Default value: "0".
 
 - `hsrp_group_policy_type` - (Optional) The specific type of the object or component.  
   Allowed values: "md5", "simple". Default value: "simple".


### PR DESCRIPTION
$ go test -v -run TestAccAciHSRPGroupPolicy -timeout=60m
=== RUN   TestAccAciHSRPGroupPolicyDataSource_Basic
=== STEP  Basic: testing hsrp_group_policy Data Source without  tenant_dn
=== STEP  Basic: testing hsrp_group_policy Data Source without  name
=== STEP  testing hsrp_group_policy Data Source with required arguments only
=== STEP  testing hsrp_group_policy Data Source with random attribute
=== STEP  testing hsrp_group_policy Data Source with invalid name
=== STEP  testing hsrp_group_policy Data Source with updated resource
=== PAUSE TestAccAciHSRPGroupPolicyDataSource_Basic
=== RUN   TestAccAciHSRPGroupPolicy_Basic
=== STEP  Basic: testing hsrp_group_policy creation without  tenant_dn
=== STEP  Basic: testing hsrp_group_policy creation without  name
=== STEP  testing hsrp_group_policy creation with required arguments only
=== STEP  Basic: testing hsrp_group_policy creation with optional parameters
=== STEP  testing hsrp_group_policy creation with tenant name acctest_sw2gm and hsrp_group_policy name xcuo6x23boi0fag99s8fhov790amyihwoontpqtanx8etg3etyd2uuw3a7tfpw69n
=== STEP  Basic: testing hsrp_group_policy creation with optional parameters
=== STEP  testing hsrp_group_policy creation with tenant name acctest_9zdbb and hsrp_group_policy name acctest_sw2gm
=== STEP  testing hsrp_group_policy creation with required arguments only
=== STEP  testing hsrp_group_policy creation with tenant name acctest_sw2gm and hsrp_group_policy name acctest_9zdbb
=== PAUSE TestAccAciHSRPGroupPolicy_Basic
=== RUN   TestAccAciHSRPGroupPolicy_Update
=== STEP  testing hsrp_group_policy creation with required arguments only
=== STEP  testing hsrp_group_policy attribute: preempt_delay_min=1800
=== STEP  testing hsrp_group_policy attribute: preempt_delay_reload=1800
=== STEP  testing hsrp_group_policy attribute: preempt_delay_sync=1800
=== STEP  testing hsrp_group_policy attribute: prio=0
=== STEP  testing hsrp_group_policy attribute: prio=125
=== STEP  testing hsrp_group_policy attribute: timeout=16000
=== PAUSE TestAccAciHSRPGroupPolicy_Update
=== RUN   TestAccAciHSRPGroupPolicy_Negative
=== STEP  testing hsrp_group_policy creation with required arguments only
=== STEP  Negative Case: testing hsrp_group_policy creation with invalid tenant_dn
=== STEP  testing hsrp_group_policy attribute: description=ihi1k7wsev9b4pnub74ns3cngsucdrb1esdczw4j3fgkcz0lcfjkuqz4quq8zoyobo94vbiidsarnhe1o7pf43vaapxhji1wgo3exq27s9u6f80wfmk81vgnzag3zjpsj
=== STEP  testing hsrp_group_policy attribute: annotation=ais9ckaerup3g0x4va7o0ltk3na00iowj8u8m1lgt14vz8rbqqi67ph86m1kigcb6nrxbm42kcglm9s93x4rk9o2mhesvm4ta4w60vbybcqnz3xfsxpvwhq8d6wlk7k6q
=== STEP  testing hsrp_group_policy attribute: name_alias=8mv3tekhc4q628mebv9mnnu136o4fggklw1ops8f3a4s6u1bb4ffhwqwgt7z8dqf
=== STEP  testing hsrp_group_policy attribute: ctrl=r2s4f
=== STEP  testing hsrp_group_policy attribute: hello_intvl=r2s4f
=== STEP  testing hsrp_group_policy attribute: hold_intvl=r2s4f
=== STEP  testing hsrp_group_policy attribute: preempt_delay_min=-1
=== STEP  testing hsrp_group_policy attribute: preempt_delay_reload=-1
=== STEP  testing hsrp_group_policy attribute: preempt_delay_sync=-1
=== STEP  testing hsrp_group_policy attribute: preempt_delay_min=3601
=== STEP  testing hsrp_group_policy attribute: preempt_delay_reload=3601
=== STEP  testing hsrp_group_policy attribute: preempt_delay_sync=3601
=== STEP  testing hsrp_group_policy attribute: prio=-1
=== STEP  testing hsrp_group_policy attribute: prio=256
=== STEP  testing hsrp_group_policy attribute: timeout=-1
=== STEP  testing hsrp_group_policy attribute: timeout=32768
=== STEP  testing hsrp_group_policy attribute: hsrp_group_policy_type=r2s4f
=== STEP  testing hsrp_group_policy attribute: hello_intvl=750
=== STEP  testing hsrp_group_policy attribute: hold_intvl=1750
=== STEP  testing hsrp_group_policy attribute: hold_intvl=1000
=== STEP  testing hsrp_group_policy attribute: xcauw=r2s4f
=== STEP  testing hsrp_group_policy creation with required arguments only
=== PAUSE TestAccAciHSRPGroupPolicy_Negative
=== RUN   TestAccAciHSRPGroupPolicy_MultipleCreateDelete
=== STEP  testing multiple hsrp_group_policy creation with required arguments only
=== PAUSE TestAccAciHSRPGroupPolicy_MultipleCreateDelete
=== CONT  TestAccAciHSRPGroupPolicyDataSource_Basic
=== CONT  TestAccAciHSRPGroupPolicy_Negative
=== CONT  TestAccAciHSRPGroupPolicy_Update
=== CONT  TestAccAciHSRPGroupPolicy_MultipleCreateDelete
=== CONT  TestAccAciHSRPGroupPolicy_Basic
=== STEP  testing hsrp_group_policy destroy
--- PASS: TestAccAciHSRPGroupPolicy_MultipleCreateDelete (32.39s)
=== STEP  testing hsrp_group_policy destroy
--- PASS: TestAccAciHSRPGroupPolicyDataSource_Basic (64.46s)
=== STEP  testing hsrp_group_policy destroy
--- PASS: TestAccAciHSRPGroupPolicy_Basic (124.27s)
=== STEP  testing hsrp_group_policy destroy
--- PASS: TestAccAciHSRPGroupPolicy_Update (135.24s)
=== STEP  testing hsrp_group_policy destroy
--- PASS: TestAccAciHSRPGroupPolicy_Negative (188.56s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   190.935s
$ go test -v -run TestAccAciBgpBestPathPolicy -timeout=60m
=== RUN   TestAccAciBgpBestPathPolicyDataSource_Basic
=== STEP  Basic: testing bgp_best_path_policy Data Source without  tenant_dn
=== STEP  Basic: testing bgp_best_path_policy Data Source without  name
=== STEP  testing bgp_best_path_policy Data Source with required arguments only
=== STEP  testing bgp_best_path_policy Data Source with random attribute
=== STEP  testing bgp_best_path_policy Data Source with invalid name
=== STEP  testing bgp_best_path_policy Data Source with updated resource
=== PAUSE TestAccAciBgpBestPathPolicyDataSource_Basic
=== RUN   TestAccAciBgpBestPathPolicy_Basic
=== STEP  Basic: testing bgp_best_path_policy creation without  tenant_dn
=== STEP  Basic: testing bgp_best_path_policy creation without  name
=== STEP  testing bgp_best_path_policy creation with required arguments only
=== STEP  Basic: testing bgp_best_path_policy creation with optional parameters
=== STEP  testing bgp_best_path_policy creation with tenant name acctest_wqgni and name zgim9o8y3ffmw8xhzlqgkc80i34paf8jb6mjurvvqg1kvo1blvnjwuc93sqwc9nr8
=== STEP  Basic: testing bgp_best_path_policy update with parameters
=== STEP  testing bgp_best_path_policy creation with tenant name acctest_odd4z and name acctest_wqgni
=== STEP  testing bgp_best_path_policy creation with required arguments only
=== STEP  testing bgp_best_path_policy creation with tenant name acctest_wqgni and name acctest_odd4z
=== PAUSE TestAccAciBgpBestPathPolicy_Basic
=== RUN   TestAccAciBgpBestPathPolicy_Negative
=== STEP  testing bgp_best_path_policy creation with required arguments only
=== STEP  Negative Case: testing bgp_best_path_policy creation with invalid tenant_dn
=== STEP  testing bgp_best_path_policy attribute: description=hmznzzf3xv1vczuc903mztpkzqjo0jy8xvvw6ygflpjjns1dpbc2r1hd72ymswfy3ktcdp3dcdqkthgokxvk1wm3sa08nnt3k33pus801wzv6qdxbz7ujm7dfm4fjt0a1
=== STEP  testing bgp_best_path_policy attribute: annotation=iowo8fl2ucjfj3zcbo6qwmpnfxf7dprwbyyxn6nd3azxp207ofnmwnny3tznury4r7cyd3f0scpuaduwkd9lch0lodkym670tabejds8jvb9mcsdyu90epehc4ref21t7
=== STEP  testing bgp_best_path_policy attribute: name_alias=70jxrjtee4emxwmr32w9wem8bsvp4bchgms6weg2i6daw2lckcx7vu9fqou3w1ug
=== STEP  testing bgp_best_path_policy attribute: ctrl=acctest_s9aw8
=== STEP  testing bgp_best_path_policy attribute: tihcn=acctest_s9aw8
=== STEP  testing bgp_best_path_policy creation with required arguments only
=== PAUSE TestAccAciBgpBestPathPolicy_Negative
=== RUN   TestAccAciBgpBestPathPolicy_MultipleCreateDelete
=== STEP  testing multiple bgp_best_path_policy creation with required arguments only
=== PAUSE TestAccAciBgpBestPathPolicy_MultipleCreateDelete
=== CONT  TestAccAciBgpBestPathPolicyDataSource_Basic
=== CONT  TestAccAciBgpBestPathPolicy_Negative
=== CONT  TestAccAciBgpBestPathPolicy_MultipleCreateDelete
=== CONT  TestAccAciBgpBestPathPolicy_Basic
=== STEP  testing bgp_best_path_policy destroy
--- PASS: TestAccAciBgpBestPathPolicy_MultipleCreateDelete (30.12s)
=== STEP  testing bgp_best_path_policy destroy
--- PASS: TestAccAciBgpBestPathPolicyDataSource_Basic (57.79s)
=== STEP  testing bgp_best_path_policy destroy
--- PASS: TestAccAciBgpBestPathPolicy_Negative (72.76s)
=== STEP  testing bgp_best_path_policy destroy
--- PASS: TestAccAciBgpBestPathPolicy_Basic (128.65s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   130.863s
$ go test -v -run TestAccAciL3DomainProfile -timeout=60m
=== RUN   TestAccAciL3DomainProfileDataSource_Basic
=== STEP  Basic: testing l3_domain_profile Data Source without  name
=== STEP  testing l3_domain_profile Data Source with required arguments only
=== STEP  testing l3_domain_profile Data Source with random attribute
=== STEP  testing l3_domain_profile Data Source with invalid name
=== STEP  testing l3_domain_profile Data Source with updated resource
=== PAUSE TestAccAciL3DomainProfileDataSource_Basic
=== RUN   TestAccAciL3DomainProfile_Basic
=== STEP  Basic: testing l3_domain_profile creation without  name
=== STEP  testing l3_domain_profile creation with required arguments only
=== STEP  Basic: testing l3_domain_profile creation with optional parameters
=== STEP  testing l3_domain_profile creation with name b1husfa4f0rzin49fshi71bsbg7j1ajndbuvn184g24klbx2xslb1it1vcn9ergnq
=== STEP  Basic: testing l3_domain_profile creation with optional parameters
=== STEP  testing l3_domain_profile creation with name acctest_ga4yb
=== PAUSE TestAccAciL3DomainProfile_Basic
=== RUN   TestAccAciL3DomainProfile_Negative
=== STEP  testing l3_domain_profile creation with required arguments only
=== STEP  testing l3_domain_profile attribute: annotation=q212zhocwf47wvftmz29uqzjmuaybfpyb9k0v8003q80460qjj69m330esqw87mrnblq9zjfbx6snskslnxknzpf37q1zc4oul0mqpnn8x0ja7zo2mvm9smyws0egvf80
=== STEP  testing l3_domain_profile attribute: name_alias=h30r0lz9xcy6oektarapofnh0txlyy93go7lkbeoul4pzteplxzeed7fxpqbrg7a
=== STEP  testing l3_domain_profile attribute: ojxma=g9b2l
=== STEP  testing l3_domain_profile creation with required arguments only
=== PAUSE TestAccAciL3DomainProfile_Negative
=== RUN   TestAccAciL3DomainProfile_RelationParameters
=== STEP  testing l3_domain_profile creation with required arguments only
=== STEP  testing l3_domain_profile creation relation resource name acctest_yks0q
=== STEP  testing l3_domain_profile creation relation resource name acctest_e0o3o
=== STEP  testing l3_domain_profile creation with required arguments only
=== PAUSE TestAccAciL3DomainProfile_RelationParameters
=== RUN   TestAccAciL3DomainProfile_MultipleCreateDelete
=== STEP  testing multiple l3_domain_profile creation with required arguments only
=== PAUSE TestAccAciL3DomainProfile_MultipleCreateDelete
=== CONT  TestAccAciL3DomainProfileDataSource_Basic
=== CONT  TestAccAciL3DomainProfile_RelationParameters
=== CONT  TestAccAciL3DomainProfile_Negative
=== CONT  TestAccAciL3DomainProfile_MultipleCreateDelete
=== CONT  TestAccAciL3DomainProfile_Basic
=== STEP  testing l3_domain_profile destroy
--- PASS: TestAccAciL3DomainProfile_MultipleCreateDelete (29.97s)
=== STEP  testing l3_domain_profile destroy
--- PASS: TestAccAciL3DomainProfileDataSource_Basic (59.48s)
=== STEP  testing l3_domain_profile destroy
--- PASS: TestAccAciL3DomainProfile_Negative (62.42s)
=== STEP  testing l3_domain_profile destroy
--- PASS: TestAccAciL3DomainProfile_Basic (80.62s)
=== STEP  testing l3_domain_profile destroy
--- PASS: TestAccAciL3DomainProfile_RelationParameters (90.50s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   92.678s
