### PR TITLE
updated validation in hsrpGroupPol

### DIFF
--- a/aci/resource_aci_hsrpgrouppol.go
+++ b/aci/resource_aci_hsrpgrouppol.go
@@ -51,21 +51,21 @@ func resourceAciHSRPGroupPolicy() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validateNonEmptyString(),
+				ValidateFunc: validation.NoZeroValues,
 			},
 
 			"hold_intvl": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validateNonEmptyString(),
+				ValidateFunc: validation.NoZeroValues,
 			},
 
 			"key": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validateNonEmptyString(),
+				ValidateFunc: validation.NoZeroValues,
 			},
 
 			"name_alias": &schema.Schema{
@@ -78,35 +78,35 @@ func resourceAciHSRPGroupPolicy() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validateNonEmptyString(),
+				ValidateFunc: validation.NoZeroValues,
 			},
 
 			"preempt_delay_reload": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validateNonEmptyString(),
+				ValidateFunc: validation.NoZeroValues,
 			},
 
 			"preempt_delay_sync": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validateNonEmptyString(),
+				ValidateFunc: validation.NoZeroValues,
 			},
 
 			"prio": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validateNonEmptyString(),
+				ValidateFunc: validation.NoZeroValues,
 			},
 
 			"timeout": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validateNonEmptyString(),
+				ValidateFunc: validation.NoZeroValues,
 			},
 
 			"hsrp_group_policy_type": &schema.Schema{


### PR DESCRIPTION
$ go test -v -run TestAccAciHSRPGroupPolicy -timeout=60m
=== RUN   TestAccAciHSRPGroupPolicyDataSource_Basic
=== STEP  Basic: testing hsrp_group_policy Data Source without  tenant_dn
=== STEP  Basic: testing hsrp_group_policy Data Source without  name
=== STEP  testing hsrp_group_policy Data Source with required arguments only
=== STEP  testing hsrp_group_policy Data Source with random attribute
=== STEP  testing hsrp_group_policy Data Source with invalid name
=== STEP  testing hsrp_group_policy Data Source with updated resource
=== PAUSE TestAccAciHSRPGroupPolicyDataSource_Basic
=== RUN   TestAccAciHSRPGroupPolicy_Basic
=== STEP  Basic: testing hsrp_group_policy creation without  tenant_dn
=== STEP  Basic: testing hsrp_group_policy creation without  name
=== STEP  testing hsrp_group_policy creation with required arguments only
=== STEP  Basic: testing hsrp_group_policy creation with optional parameters
=== STEP  testing hsrp_group_policy creation with tenant name acctest_7hv4x and hsrp_group_policy name erfijcb98zz1h0jnuc1aoogldr6icu4idq9zbuwnwptgfridiazrqebo7wsavs6kr
=== STEP  Basic: testing hsrp_group_policy creation with optional parameters
=== STEP  testing hsrp_group_policy creation with tenant name acctest_z7h42 and hsrp_group_policy name acctest_7hv4x
=== STEP  testing hsrp_group_policy creation with required arguments only
=== STEP  testing hsrp_group_policy creation with tenant name acctest_7hv4x and hsrp_group_policy name acctest_z7h42
=== PAUSE TestAccAciHSRPGroupPolicy_Basic
=== RUN   TestAccAciHSRPGroupPolicy_Update
=== STEP  testing hsrp_group_policy creation with required arguments only
=== STEP  testing hsrp_group_policy attribute: preempt_delay_min=1800
=== STEP  testing hsrp_group_policy attribute: preempt_delay_reload=1800
=== STEP  testing hsrp_group_policy attribute: preempt_delay_sync=1800
=== STEP  testing hsrp_group_policy attribute: prio=0
=== STEP  testing hsrp_group_policy attribute: prio=125
=== STEP  testing hsrp_group_policy attribute: timeout=16000
=== PAUSE TestAccAciHSRPGroupPolicy_Update
=== RUN   TestAccAciHSRPGroupPolicy_Negative
=== STEP  testing hsrp_group_policy creation with required arguments only
=== STEP  Negative Case: testing hsrp_group_policy creation with invalid tenant_dn
=== STEP  testing hsrp_group_policy attribute: description=khkryk4waiidyrwk1tsy7pmeno399872f423dk2acg7pnak7roaysn1zvhef8gh3i00tnhtl0zfypdhbrsq8xor0v8v71p0f7eg1kxfy7te7pbxclmnji9yrpp3tec0jo
=== STEP  testing hsrp_group_policy attribute: annotation=uj2ohdue8k1ek13txzgz29fq2labun0i9pflgzj28r3wy2pml2x9nx46uxxolr9ka1hbokwq7qyfoqhbkghe37sf9w8c4av4cunbyfn7ogcsf2vhwqh7awnjxmtho0olp
=== STEP  testing hsrp_group_policy attribute: name_alias=hl4clpaxxfj6er10sh0yg2pcbuyvvl83ibopwtxhepcxifvwcz6btkic0djvx7yg
=== STEP  testing hsrp_group_policy attribute: ctrl=8gyig
=== STEP  testing hsrp_group_policy attribute: hello_intvl=8gyig
=== STEP  testing hsrp_group_policy attribute: hold_intvl=8gyig
=== STEP  testing hsrp_group_policy attribute: preempt_delay_min=-1
=== STEP  testing hsrp_group_policy attribute: preempt_delay_reload=-1
=== STEP  testing hsrp_group_policy attribute: preempt_delay_sync=-1
=== STEP  testing hsrp_group_policy attribute: preempt_delay_min=3601
=== STEP  testing hsrp_group_policy attribute: preempt_delay_reload=3601
=== STEP  testing hsrp_group_policy attribute: preempt_delay_sync=3601
=== STEP  testing hsrp_group_policy attribute: prio=-1
=== STEP  testing hsrp_group_policy attribute: prio=256
=== STEP  testing hsrp_group_policy attribute: timeout=-1
=== STEP  testing hsrp_group_policy attribute: timeout=32768
=== STEP  testing hsrp_group_policy attribute: hsrp_group_policy_type=8gyig
=== STEP  testing hsrp_group_policy attribute: hello_intvl=750
=== STEP  testing hsrp_group_policy attribute: hold_intvl=1750
=== STEP  testing hsrp_group_policy attribute: hold_intvl=1000
=== STEP  testing hsrp_group_policy attribute: grjik=8gyig
=== STEP  testing hsrp_group_policy creation with required arguments only
=== PAUSE TestAccAciHSRPGroupPolicy_Negative
=== RUN   TestAccAciHSRPGroupPolicy_MultipleCreateDelete
=== STEP  testing multiple hsrp_group_policy creation with required arguments only
=== PAUSE TestAccAciHSRPGroupPolicy_MultipleCreateDelete
=== CONT  TestAccAciHSRPGroupPolicyDataSource_Basic
=== CONT  TestAccAciHSRPGroupPolicy_Negative
=== CONT  TestAccAciHSRPGroupPolicy_MultipleCreateDelete
=== CONT  TestAccAciHSRPGroupPolicy_Update
=== CONT  TestAccAciHSRPGroupPolicy_Basic
=== STEP  testing hsrp_group_policy destroy
--- PASS: TestAccAciHSRPGroupPolicy_MultipleCreateDelete (57.02s)
=== STEP  testing hsrp_group_policy destroy
--- PASS: TestAccAciHSRPGroupPolicyDataSource_Basic (155.32s)
=== STEP  testing hsrp_group_policy destroy
--- PASS: TestAccAciHSRPGroupPolicy_Basic (323.51s)
=== STEP  testing hsrp_group_policy destroy
--- PASS: TestAccAciHSRPGroupPolicy_Update (363.29s)
=== STEP  testing hsrp_group_policy destroy
--- PASS: TestAccAciHSRPGroupPolicy_Negative (493.22s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   497.653s
