### PR TITLE
Added VMM Credential

### DIFF
--- a/testacc/data_source_aci_vmmusraccp_test.go
+++ b/testacc/data_source_aci_vmmusraccp_test.go
@@ -1,0 +1,189 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciVMMCredentialDataSource_Basic(t *testing.T) {
+	resourceName := "aci_vmm_credential.test"
+	dataSourceName := "data.aci_vmm_credential.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	vmmDomPName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVMMCredentialDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateVMMCredentialDSWithoutRequired(vmmDomPName, rName, "vmm_domain_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateVMMCredentialDSWithoutRequired(vmmDomPName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccVMMCredentialConfigDataSource(vmmDomPName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "vmm_domain_dn", resourceName, "vmm_domain_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "usr", resourceName, "usr"),
+				),
+			},
+			{
+				Config:      CreateAccVMMCredentialDataSourceUpdate(vmmDomPName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccVMMCredentialDSWithInvalidParentDn(vmmDomPName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+
+			{
+				Config: CreateAccVMMCredentialDataSourceUpdatedResource(vmmDomPName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccVMMCredentialConfigDataSource(vmmDomPName, rName string) string {
+	fmt.Println("=== STEP  testing vmm_credential Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	
+	resource "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+	}
+
+	data "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = aci_vmm_credential.test.name
+		depends_on = [ aci_vmm_credential.test ]
+	}
+	`, vmmDomPName, rName)
+	return resource
+}
+
+func CreateVMMCredentialDSWithoutRequired(vmmDomPName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing vmm_credential creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}	
+	resource "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "vmm_domain_dn":
+		rBlock += `
+	data "aci_vmm_credential" "test" {
+	#	vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+		depends_on = [ aci_vmm_credential.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+	#	name  = "%s"
+		depends_on = [ aci_vmm_credential.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, vmmDomPName, rName)
+}
+
+func CreateAccVMMCredentialDSWithInvalidParentDn(vmmDomPName, rName string) string {
+	fmt.Println("=== STEP  testing vmm_credential Data Source with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	
+	resource "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+	}
+
+	data "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "${aci_vmm_credential.test.name}_invalid"
+		depends_on = [ aci_vmm_credential.test ]
+	}
+	`, vmmDomPName, rName)
+	return resource
+}
+
+func CreateAccVMMCredentialDataSourceUpdate(vmmDomPName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing vmm_credential Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}	
+	resource "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+	}
+
+	data "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = aci_vmm_credential.test.name
+		%s = "%s"
+		depends_on = [ aci_vmm_credential.test ]
+	}
+	`, vmmDomPName, rName, key, value)
+	return resource
+}
+
+func CreateAccVMMCredentialDataSourceUpdatedResource(vmmDomPName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing vmm_credential Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	
+	resource "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = aci_vmm_credential.test.name
+		depends_on = [ aci_vmm_credential.test ]
+	}
+	`, vmmDomPName, rName, key, value)
+	return resource
+}

--- a/testacc/resource_aci_bgppeerpfxpol_test.go
+++ b/testacc/resource_aci_bgppeerpfxpol_test.go
@@ -335,7 +335,7 @@ func CreateBGPPeerPrefixWithoutRequired(fvTenantName, rName, attrName string) st
 }
 
 func CreateAccBGPPeerPrefixConfigWithUpdatedRequiredParams(fvTenantName, rName string) string {
-	fmt.Printf("=== STEP  testing bgp_peer_prefix creation with updated required arguments with Tenant name %s and BGP Peer Prefix %s", fvTenantName, rName)
+	fmt.Printf("=== STEP  testing bgp_peer_prefix creation with updated required arguments with Tenant name %s and BGP Peer Prefix %s\n", fvTenantName, rName)
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {
@@ -351,7 +351,7 @@ func CreateAccBGPPeerPrefixConfigWithUpdatedRequiredParams(fvTenantName, rName s
 }
 
 func CreateAccBGPPeerPrefixConfig(fvTenantName, rName string) string {
-	fmt.Printf("=== STEP  testing bgp_peer_prefix creation with required arguments only with name %s", rName)
+	fmt.Printf("=== STEP  testing bgp_peer_prefix creation with required arguments only with name %s\n", rName)
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {

--- a/testacc/resource_aci_vmmusraccp_test.go
+++ b/testacc/resource_aci_vmmusraccp_test.go
@@ -1,0 +1,409 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciVMMCredential_Basic(t *testing.T) {
+	var vmm_credential_default models.VMMCredential
+	var vmm_credential_updated models.VMMCredential
+	resourceName := "aci_vmm_credential.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	vmmDomPName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVMMCredentialDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateVMMCredentialWithoutRequired(vmmDomPName, rName, "vmm_domain_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateVMMCredentialWithoutRequired(vmmDomPName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccVMMCredentialConfig(vmmDomPName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVMMCredentialExists(resourceName, &vmm_credential_default),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("uni/vmmp-VMware/dom-%s", vmmDomPName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					// resource.TestCheckResourceAttr(resourceName, "pwd", ""),
+					resource.TestCheckResourceAttr(resourceName, "usr", ""),
+				),
+			},
+			{
+				Config: CreateAccVMMCredentialConfigWithOptionalValues(vmmDomPName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVMMCredentialExists(resourceName, &vmm_credential_updated),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("uni/vmmp-VMware/dom-%s", vmmDomPName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_vmm_credential"),
+					resource.TestCheckResourceAttr(resourceName, "pwd", "ABCD"),
+					resource.TestCheckResourceAttr(resourceName, "usr", "ABCD"),
+					testAccCheckAciVMMCredentialIdEqual(&vmm_credential_default, &vmm_credential_updated),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"pwd"},
+			},
+			{
+				Config:      CreateAccVMMCredentialConfigUpdatedName(vmmDomPName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccVMMCredentialRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccVMMCredentialConfigWithRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVMMCredentialExists(resourceName, &vmm_credential_updated),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("uni/vmmp-VMware/dom-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciVMMCredentialIdNotEqual(&vmm_credential_default, &vmm_credential_updated),
+				),
+			},
+			{
+				Config: CreateAccVMMCredentialConfig(vmmDomPName, rName),
+			},
+			{
+				Config: CreateAccVMMCredentialConfigWithRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVMMCredentialExists(resourceName, &vmm_credential_updated),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("uni/vmmp-VMware/dom-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciVMMCredentialIdNotEqual(&vmm_credential_default, &vmm_credential_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciVMMCredential_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	vmmDomPName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVMMCredentialDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccVMMCredentialConfig(vmmDomPName, rName),
+			},
+			{
+				Config:      CreateAccVMMCredentialWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccVMMCredentialUpdatedAttr(vmmDomPName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccVMMCredentialUpdatedAttr(vmmDomPName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccVMMCredentialUpdatedAttr(vmmDomPName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccVMMCredentialUpdatedAttr(vmmDomPName, rName, "usr", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccVMMCredentialUpdatedAttr(vmmDomPName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccVMMCredentialConfig(vmmDomPName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciVMMCredential_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	// vmmProvPName := makeTestVariable(acctest.RandString(5))
+	vmmDomPName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVMMCredentialDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccVMMCredentialConfigMultiple(vmmDomPName, rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciVMMCredentialExists(name string, vmm_credential *models.VMMCredential) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("VMM Credential %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No VMM Credential dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		vmm_credentialFound := models.VMMCredentialFromContainer(cont)
+		if vmm_credentialFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("VMM Credential %s not found", rs.Primary.ID)
+		}
+		*vmm_credential = *vmm_credentialFound
+		return nil
+	}
+}
+
+func testAccCheckAciVMMCredentialDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing vmm_credential destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_vmm_credential" {
+			cont, err := client.Get(rs.Primary.ID)
+			vmm_credential := models.VMMCredentialFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("VMM Credential %s Still exists", vmm_credential.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciVMMCredentialIdEqual(m1, m2 *models.VMMCredential) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("vmm_credential DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciVMMCredentialIdNotEqual(m1, m2 *models.VMMCredential) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("vmm_credential DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateVMMCredentialWithoutRequired(vmmDomPName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing vmm_credential creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	
+	`
+	switch attrName {
+	case "vmm_domain_dn":
+		rBlock += `
+	resource "aci_vmm_credential" "test" {
+	#	vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, vmmDomPName, rName)
+}
+
+func CreateAccVMMCredentialConfigWithRequiredParams(vmmDomPName, rName string) string {
+	fmt.Println("=== STEP  testing vmm_credential creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+
+	resource "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+	}
+	`, vmmDomPName, rName)
+	return resource
+}
+func CreateAccVMMCredentialConfigUpdatedName(vmmDomPName, rName string) string {
+	fmt.Println("=== STEP  testing vmm_credential creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}	
+	resource "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+	}
+	`, vmmDomPName, rName)
+	return resource
+}
+
+func CreateAccVMMCredentialConfig(vmmDomPName, rName string) string {
+	fmt.Println("=== STEP  testing vmm_credential creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	
+	resource "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+	}
+	`, vmmDomPName, rName)
+	return resource
+}
+
+func CreateAccVMMCredentialConfigMultiple(vmmDomPName, rName string) string {
+	fmt.Println("=== STEP  testing multiple vmm_credential creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	
+	resource "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, vmmDomPName, rName)
+	return resource
+}
+
+func CreateAccVMMCredentialWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing vmm_credential creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_tenant.test.id
+		name  = "%s"	
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccVMMCredentialConfigWithOptionalValues(vmmDomPName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing vmm_credential creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	
+	resource "aci_vmm_credential" "test" {
+		vmm_domain_dn  = "${aci_vmm_domain.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_vmm_credential"
+		pwd = "ABCD"
+		usr = "ABCD"
+		
+	}
+	`, vmmDomPName, rName)
+
+	return resource
+}
+
+func CreateAccVMMCredentialRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing vmm_credential updation with required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_vmm_credential" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_vmm_credential"
+		pwd = ""
+		usr = ""
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccVMMCredentialUpdatedAttr(vmmDomPName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing vmm_credential attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	
+	resource "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, vmmDomPName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccVMMCredentialUpdatedAttrList(vmmDomPName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing vmm_credential attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	
+	resource "aci_vmm_credential" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+		%s = %s
+	}
+	`, vmmDomPName, rName, attribute, value)
+	return resource
+}

--- a/website/docs/r/vmm_credential.html.markdown
+++ b/website/docs/r/vmm_credential.html.markdown
@@ -48,7 +48,7 @@ resource "aci_vmm_credential" "example" {
 
 An existing VMMCredential can be [imported][docs-import] into this resource via its Dn, via the following command:
 [docs-import]: https://www.terraform.io/docs/import/index.html
-
+  
 ```
 terraform import vmm_credential.example <Dn>
 ```


### PR DESCRIPTION
$ go test -v -run TestAccAciVMMCredential_Basic -timeout=60m
=== RUN   TestAccAciVMMCredential_Basic
=== STEP  Basic: testing vmm_credential creation without  vmm_domain_dn
=== STEP  Basic: testing vmm_credential creation without  name
=== STEP  testing vmm_credential creation with required arguments only
=== STEP  Basic: testing vmm_credential creation with optional parameters
=== STEP  testing vmm_credential creation with invalid name =  7ysowgwkizwmzov0e4wca8p8axvirz1t239wglg14wro1nr31lu3ua643tme897mk
=== STEP  Basic: testing vmm_credential updation with required parameters
=== STEP  testing vmm_credential creation with required arguments only
=== STEP  testing vmm_credential creation with required arguments only
=== STEP  testing vmm_credential creation with required arguments only
=== PAUSE TestAccAciVMMCredential_Basic
=== CONT  TestAccAciVMMCredential_Basic
=== STEP  testing vmm_credential destroy
--- PASS: TestAccAciVMMCredential_Basic (215.58s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   217.587s

$ go test -v -run TestAccAciVMMCredential_Negative -timeout=60m
=== RUN   TestAccAciVMMCredential_Negative
=== STEP  testing vmm_credential creation with required arguments only
=== STEP  Negative Case: testing vmm_credential creation with invalid parent Dn
=== STEP  testing vmm_credential attribute: description = gkxqd6ax012p7b30v0xejg9tz0eqi920q3wpjjsfq3ibrqk9yqnifag0qtbfv3fz0do7ljtld8k6r1qqy04prt0sghhblf0lnr9mmv8o33dwv8pcb1vc82sok9vk7utc4
=== STEP  testing vmm_credential attribute: annotation = qvvdmtycefvhtqb8271w9abaqt1wwga22unbkint72agmbq4b8a8vg2at6n3t2wxeuxqvx4w4qfznnuldqtppwyq4t2n47cmp8lvp408jmey3mpexbgg3igial3477zer
=== STEP  testing vmm_credential attribute: name_alias = vtqgm4ww01u0emqrxj9apl0kvjdn6rtr9cin6zx0rob9r7z4jlljjhc3m7safjic
=== STEP  testing vmm_credential attribute: usr = dojdntwckkufasjti40zrwnfq3b0eqsaemmx31z4uepqny43gm0raefzt2g0qq1vzanlpubytv21har7ywnve690lh0hnk760wgtsyliv1x1t1dzxcnubz7hqw42t01z7
=== STEP  testing vmm_credential attribute: iqtac = 6ll1r
=== STEP  testing vmm_credential creation with required arguments only
=== PAUSE TestAccAciVMMCredential_Negative
=== CONT  TestAccAciVMMCredential_Negative
=== STEP  testing vmm_credential destroy
--- PASS: TestAccAciVMMCredential_Negative (223.02s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   224.260s

$ go test -v -run TestAccAciVMMCredential_MultipleCreateDelete -timeout=60m
=== RUN   TestAccAciVMMCredential_MultipleCreateDelete
=== STEP  testing multiple vmm_credential creation with required arguments only
=== PAUSE TestAccAciVMMCredential_MultipleCreateDelete
=== CONT  TestAccAciVMMCredential_MultipleCreateDelete
=== STEP  testing vmm_credential destroy
--- PASS: TestAccAciVMMCredential_MultipleCreateDelete (39.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   40.558s

$ go test -v -run TestAccAciVMMCredentialDataSource_Basic -timeout=60m
=== RUN   TestAccAciVMMCredentialDataSource_Basic
=== STEP  Basic: testing vmm_credential creation without  vmm_domain_dn
=== STEP  Basic: testing vmm_credential creation without  name
=== STEP  testing vmm_credential Data Source with required arguments only
=== STEP  testing vmm_credential Data Source with random attribute
=== STEP  testing vmm_credential Data Source with Invalid Parent Dn
=== STEP  testing vmm_credential Data Source with updated resource
=== PAUSE TestAccAciVMMCredentialDataSource_Basic
=== CONT  TestAccAciVMMCredentialDataSource_Basic
=== STEP  testing vmm_credential destroy
--- PASS: TestAccAciVMMCredentialDataSource_Basic (101.63s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   103.095s

