### PR TITLE
Added resource and bugfix

### DIFF
--- a/testacc/data_source_aci_bgppeerpfxpol_test.go
+++ b/testacc/data_source_aci_bgppeerpfxpol_test.go
@@ -85,7 +85,7 @@ func CreateAccBGPPeerPrefixConfigDataSource(fvTenantName, rName string) string {
 }
 
 func CreateBGPPeerPrefixDSWithoutRequired(fvTenantName, rName, attrName string) string {
-	fmt.Println("=== STEP  Basic: testing bgp_peer_prefix creation without ", attrName)
+	fmt.Println("=== STEP  Basic: testing bgp_peer_prefix Data Source without ", attrName)
 	rBlock := `
 	resource "aci_tenant" "test" {
 		name 		= "%s"

--- a/testacc/data_source_aci_fvnsvlaninstp_test.go
+++ b/testacc/data_source_aci_fvnsvlaninstp_test.go
@@ -1,0 +1,174 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciVLANPoolDataSource_Basic(t *testing.T) {
+	resourceName := "aci_vlan_pool.test"
+	dataSourceName := "data.aci_vlan_pool.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	allocMode := "dynamic"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVLANPoolDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateVLANPoolDSWithoutRequired(rName, allocMode, "alloc_mode"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+
+			{
+				Config:      CreateVLANPoolDSWithoutRequired(rName, allocMode, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccVLANPoolConfigDataSource(rName, allocMode),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "alloc_mode", resourceName, "alloc_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+				),
+			},
+			{
+				Config:      CreateAccVLANPoolDataSourceUpdate(rName, allocMode, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccVLANPoolDSWithInvalidName(rName, allocMode),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccVLANPoolDataSourceUpdatedResource(rName, allocMode, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccVLANPoolDSWithInvalidName(rName, allocMode string) string {
+	fmt.Println("=== STEP  testing vlan_pool Data Source with Invalid Name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vlan_pool" "test" {
+		name  = "%s"
+		alloc_mode  = "%s"
+	}
+
+	data "aci_vlan_pool" "test" {
+		name  = "${aci_vlan_pool.test.name}_invalid"
+		alloc_mode  = aci_vlan_pool.test.alloc_mode
+		depends_on = [ aci_vlan_pool.test ]
+	}
+	`, rName, allocMode)
+	return resource
+}
+
+func CreateAccVLANPoolConfigDataSource(rName, allocMode string) string {
+	fmt.Println("=== STEP  testing vlan_pool Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vlan_pool" "test" {
+	
+		name  = "%s"
+		alloc_mode  = "%s"
+	}
+
+	data "aci_vlan_pool" "test" {
+	
+		name  = aci_vlan_pool.test.name
+		alloc_mode  = aci_vlan_pool.test.alloc_mode
+		depends_on = [ aci_vlan_pool.test ]
+	}
+	`, rName, allocMode)
+	return resource
+}
+
+func CreateVLANPoolDSWithoutRequired(rName, allocMode, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing vlan_pool Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_vlan_pool" "test" {
+	
+		name  = "%s"
+		alloc_mode  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_vlan_pool" "test" {
+	
+	#	name  = "%s"
+		alloc_mode  = "%s"
+		depends_on = [ aci_vlan_pool.test ]
+	}
+		`
+	case "alloc_mode":
+		rBlock += `
+	data "aci_vlan_pool" "test" {
+	
+		name  = "%s"
+	#	alloc_mode  = "%s"
+		depends_on = [ aci_vlan_pool.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName, allocMode)
+}
+
+func CreateAccVLANPoolDataSourceUpdate(rName, allocMode, key, value string) string {
+	fmt.Println("=== STEP  testing vlan_pool Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vlan_pool" "test" {
+	
+		name  = "%s"
+		alloc_mode  = "%s"
+	}
+
+	data "aci_vlan_pool" "test" {
+	
+		name  = aci_vlan_pool.test.name
+		alloc_mode  = aci_vlan_pool.test.alloc_mode
+		%s = "%s"
+		depends_on = [ aci_vlan_pool.test ]
+	}
+	`, rName, allocMode, key, value)
+	return resource
+}
+
+func CreateAccVLANPoolDataSourceUpdatedResource(rName, allocMode, key, value string) string {
+	fmt.Println("=== STEP  testing vlan_pool Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vlan_pool" "test" {
+	
+		name  = "%s"
+		alloc_mode  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_vlan_pool" "test" {
+	
+		name  = aci_vlan_pool.test.name
+		alloc_mode  = aci_vlan_pool.test.alloc_mode
+		depends_on = [ aci_vlan_pool.test ]
+	}
+	`, rName, allocMode, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_infraattentityp_test.go
+++ b/testacc/data_source_aci_infraattentityp_test.go
@@ -1,0 +1,140 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciAttachableAccessEntityProfileDataSource_Basic(t *testing.T) {
+	resourceName := "aci_attachable_access_entity_profile.test"
+	dataSourceName := "data.aci_attachable_access_entity_profile.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciAttachableAccessEntityProfileDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateAttachableAccessEntityProfileDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccAttachableAccessEntityProfileConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+				),
+			},
+			{
+				Config:      CreateAccAttachableAccessEntityProfileDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccAttachableAccessEntityProfileDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccAttachableAccessEntityProfileDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccAttachableAccessEntityProfileConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing attachable_access_entity_profile Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_attachable_access_entity_profile" "test" {
+		name  = "%s"
+	}
+	
+	data "aci_attachable_access_entity_profile" "test" {
+		name  = aci_attachable_access_entity_profile.test.name
+		depends_on = [ aci_attachable_access_entity_profile.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccAttachableAccessEntityProfileDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing attachable_access_entity_profile Data Source with Invalid Name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_attachable_access_entity_profile" "test" {
+		name  = "%s"
+	}
+
+	data "aci_attachable_access_entity_profile" "test" {
+		name  = "${aci_attachable_access_entity_profile.test.name}_invalid"
+		depends_on = [ aci_attachable_access_entity_profile.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAttachableAccessEntityProfileDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing attachable_access_entity_profile Data Source without ", attrName)
+	rBlock := `
+	resource "aci_attachable_access_entity_profile" "test" {
+	name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_attachable_access_entity_profile" "test" {
+	#	name  = "%s"
+		depends_on = [ aci_attachable_access_entity_profile.test ]
+	}
+	`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccAttachableAccessEntityProfileDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing attachable_access_entity_profile Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_attachable_access_entity_profile" "test" {
+		name  = "%s"
+	}
+
+	data "aci_attachable_access_entity_profile" "test" {
+		name  = aci_attachable_access_entity_profile.test.name
+		%s = "%s"
+		depends_on = [ aci_attachable_access_entity_profile.test ]
+	}
+	`, rName, key, value)
+	return resource
+}
+
+func CreateAccAttachableAccessEntityProfileDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing attachable_access_entity_profile Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_attachable_access_entity_profile" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_attachable_access_entity_profile" "test" {	
+		name  = aci_attachable_access_entity_profile.test.name
+		depends_on = [ aci_attachable_access_entity_profile.test ]
+	}
+	`, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_ospfctxpol_test.go
+++ b/testacc/data_source_aci_ospfctxpol_test.go
@@ -38,6 +38,7 @@ func TestAccAciOSPFTimersDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "bw_ref", resourceName, "bw_ref"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ctrl", resourceName, "ctrl"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "dist", resourceName, "dist"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "gr_ctrl", resourceName, "gr_ctrl"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "lsa_arrival_intvl", resourceName, "lsa_arrival_intvl"),
@@ -100,7 +101,7 @@ func CreateAccOSPFTimersConfigDataSource(fvTenantName, rName string) string {
 }
 
 func CreateOSPFTimersDSWithoutRequired(fvTenantName, rName, attrName string) string {
-	fmt.Println("=== STEP  Basic: testing ospf_timers creation without ", attrName)
+	fmt.Println("=== STEP  Basic: testing ospf_timers Data Source without ", attrName)
 	rBlock := `
 	
 	resource "aci_tenant" "test" {

--- a/testacc/data_source_aci_physdomp_test.go
+++ b/testacc/data_source_aci_physdomp_test.go
@@ -1,0 +1,142 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciPhysicalDomainDataSource_Basic(t *testing.T) {
+	resourceName := "aci_physical_domain.test"
+	dataSourceName := "data.aci_physical_domain.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciPhysicalDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreatePhysicalDomainDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccPhysicalDomainConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+				),
+			},
+			{
+				Config:      CreateAccPhysicalDomainDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccPhysicalDomainDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccPhysicalDomainDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccPhysicalDomainConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing physical_domain Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_physical_domain" "test" {
+
+		name  = "%s"
+	}
+
+	data "aci_physical_domain" "test" {
+
+		name  = aci_physical_domain.test.name
+		depends_on = [ aci_physical_domain.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccPhysicalDomainDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing physical_domain Data Source with Invalid Name")
+	resource := fmt.Sprintf(`
+
+	resource "aci_physical_domain" "test" {
+		name  = "%s"
+	}
+
+	data "aci_physical_domain" "test" {
+
+		name  = "${aci_physical_domain.test.name}_invalid"
+		depends_on = [ aci_physical_domain.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreatePhysicalDomainDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing physical_domain Data Source without ", attrName)
+	rBlock := `
+
+	resource "aci_physical_domain" "test" {
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_physical_domain" "test" {
+
+	#	name  = "%s"
+		depends_on = [ aci_physical_domain.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccPhysicalDomainDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing physical_domain Data Source with random attribute")
+	resource := fmt.Sprintf(`
+
+	resource "aci_physical_domain" "test" {
+		name  = "%s"
+	}
+
+	data "aci_physical_domain" "test" {
+		name  = aci_physical_domain.test.name
+		%s = "%s"
+		depends_on = [ aci_physical_domain.test ]
+	}
+	`, rName, key, value)
+	return resource
+}
+
+func CreateAccPhysicalDomainDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing physical_domain Data Source with updated resource")
+	resource := fmt.Sprintf(`
+
+	resource "aci_physical_domain" "test" {
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_physical_domain" "test" {
+		name  = aci_physical_domain.test.name
+		depends_on = [ aci_physical_domain.test ]
+	}
+	`, rName, key, value)
+	return resource
+}

--- a/testacc/resource_aci_fvnsvlaninstp_test.go
+++ b/testacc/resource_aci_fvnsvlaninstp_test.go
@@ -1,0 +1,341 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciVLANPool_Basic(t *testing.T) {
+	var vlan_pool_default models.VLANPool
+	var vlan_pool_updated models.VLANPool
+	resourceName := "aci_vlan_pool.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	allocMode := "dynamic"
+	allocModeUpdated := "static"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVLANPoolDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateVLANPoolWithoutRequired(rName, allocMode, "alloc_mode"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateVLANPoolWithoutRequired(rName, allocMode, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccVLANPoolConfig(rName, allocMode),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVLANPoolExists(resourceName, &vlan_pool_default),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "alloc_mode", allocMode),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+				),
+			},
+			{
+				Config: CreateAccVLANPoolConfigWithOptionalValues(rName, allocMode),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVLANPoolExists(resourceName, &vlan_pool_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "alloc_mode", allocMode),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_vlan_pool"),
+					testAccCheckAciVLANPoolIdEqual(&vlan_pool_default, &vlan_pool_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccVLANPoolConfig(acctest.RandString(65), allocMode),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			{
+				Config: CreateAccVLANPoolConfig(rName, allocMode),
+			},
+			{
+				Config:      CreateAccVLANPoolConfig(rName, acctest.RandString(5)),
+				ExpectError: regexp.MustCompile(`expected (.)* to be one of (.)*`),
+			},
+			{
+				Config:      CreateAccVLANPoolRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccVLANPoolConfigWithRequiredParams(rNameUpdated, allocMode),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVLANPoolExists(resourceName, &vlan_pool_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciVLANPoolIdNotEqual(&vlan_pool_default, &vlan_pool_updated),
+				),
+			},
+			{
+				Config: CreateAccVLANPoolConfig(rName, allocMode),
+			},
+			{
+				Config: CreateAccVLANPoolConfigWithRequiredParams(rName, allocModeUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVLANPoolExists(resourceName, &vlan_pool_updated),
+					resource.TestCheckResourceAttr(resourceName, "alloc_mode", allocModeUpdated),
+					testAccCheckAciVLANPoolIdNotEqual(&vlan_pool_default, &vlan_pool_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciVLANPool_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	allocMode := "dynamic"
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVLANPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccVLANPoolConfig(rName, allocMode),
+			},
+			{
+				Config:      CreateAccVLANPoolUpdatedAttr(rName, allocMode, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccVLANPoolUpdatedAttr(rName, allocMode, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccVLANPoolUpdatedAttr(rName, allocMode, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccVLANPoolUpdatedAttr(rName, allocMode, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccVLANPoolConfig(rName, allocMode),
+			},
+		},
+	})
+}
+
+func TestAccAciVLANPool_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	allocMode := "dynamic"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVLANPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccVLANPoolConfigMultiple(rName, allocMode),
+			},
+		},
+	})
+}
+
+func testAccCheckAciVLANPoolExists(name string, vlan_pool *models.VLANPool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("VLAN Pool %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No VLAN Pool dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		vlan_poolFound := models.VLANPoolFromContainer(cont)
+		if vlan_poolFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("VLAN Pool %s not found", rs.Primary.ID)
+		}
+		*vlan_pool = *vlan_poolFound
+		return nil
+	}
+}
+
+func testAccCheckAciVLANPoolDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing vlan_pool destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_vlan_pool" {
+			cont, err := client.Get(rs.Primary.ID)
+			vlan_pool := models.VLANPoolFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("VLAN Pool %s Still exists", vlan_pool.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciVLANPoolIdEqual(m1, m2 *models.VLANPool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("vlan_pool DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciVLANPoolIdNotEqual(m1, m2 *models.VLANPool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("vlan_pool DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateVLANPoolWithoutRequired(rName, allocMode, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing vlan_pool creation without ", attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_vlan_pool" "test" {
+	
+	#	name  = "%s"
+		alloc_mode  = "%s"
+	}
+		`
+	case "alloc_mode":
+		rBlock += `
+	resource "aci_vlan_pool" "test" {
+	
+		name  = "%s"
+	#	alloc_mode  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName, allocMode)
+}
+
+func CreateAccVLANPoolConfigWithRequiredParams(rName, allocMode string) string {
+	fmt.Println("=== STEP  testing vlan_pool creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vlan_pool" "test" {
+	
+		name  = "%s"
+		alloc_mode  = "%s"
+	}
+	`, rName, allocMode)
+	return resource
+}
+func CreateAccVLANPoolConfigUpdatedName(rName, allocMode string) string {
+	fmt.Println("=== STEP  testing vlan_pool creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vlan_pool" "test" {
+	
+		name  = "%s"
+		alloc_mode  = "%s"
+	}
+	`, rName, allocMode)
+	return resource
+}
+
+func CreateAccVLANPoolConfig(rName, allocMode string) string {
+	fmt.Println("=== STEP  testing vlan_pool creation with required arguments ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vlan_pool" "test" {
+	
+		name  = "%s"
+		alloc_mode  = "%s"
+	}
+	`, rName, allocMode)
+	return resource
+}
+
+func CreateAccVLANPoolConfigMultiple(rName, allocMode string) string {
+	fmt.Println("=== STEP  testing multiple vlan_pool creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vlan_pool" "test" {
+	
+		name  = "%s_${count.index}"
+		alloc_mode  = "dynamic"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccVLANPoolConfigWithOptionalValues(rName, allocMode string) string {
+	fmt.Println("=== STEP  Basic: testing vlan_pool creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vlan_pool" "test" {
+	
+		name  = "%s"
+		alloc_mode  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_vlan_pool"
+		
+	}
+	`, rName, allocMode)
+
+	return resource
+}
+
+func CreateAccVLANPoolRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing vlan_pool updation with required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_vlan_pool" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_vlan_pool"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccVLANPoolUpdatedAttr(rName, allocMode, attribute, value string) string {
+	fmt.Printf("=== STEP  testing vlan_pool attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vlan_pool" "test" {
+	
+		name  = "%s"
+		alloc_mode  = "%s"
+		%s = "%s"
+	}
+	`, rName, allocMode, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_infraattentityp_test.go
+++ b/testacc/resource_aci_infraattentityp_test.go
@@ -1,0 +1,285 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciAttachableAccessEntityProfile_Basic(t *testing.T) {
+	var attachable_access_entity_profile_default models.AttachableAccessEntityProfile
+	var attachable_access_entity_profile_updated models.AttachableAccessEntityProfile
+	resourceName := "aci_attachable_access_entity_profile.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciAttachableAccessEntityProfileDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateAttachableAccessEntityProfileWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccAttachableAccessEntityProfileConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciAttachableAccessEntityProfileExists(resourceName, &attachable_access_entity_profile_default),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+				),
+			},
+			{
+				Config: CreateAccAttachableAccessEntityProfileConfigWithOptionalValues(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciAttachableAccessEntityProfileExists(resourceName, &attachable_access_entity_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_attachable_access_entity_profile"),
+					testAccCheckAciAttachableAccessEntityProfileIdEqual(&attachable_access_entity_profile_default, &attachable_access_entity_profile_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccAttachableAccessEntityProfileConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			{
+				Config:      CreateAccAttachableAccessEntityProfileRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccAttachableAccessEntityProfileConfigWithRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciAttachableAccessEntityProfileExists(resourceName, &attachable_access_entity_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciAttachableAccessEntityProfileIdNotEqual(&attachable_access_entity_profile_default, &attachable_access_entity_profile_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciAttachableAccessEntityProfile_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciAttachableAccessEntityProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccAttachableAccessEntityProfileConfig(rName),
+			},
+
+			{
+				Config:      CreateAccAttachableAccessEntityProfileUpdatedAttr(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccAttachableAccessEntityProfileUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccAttachableAccessEntityProfileUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccAttachableAccessEntityProfileUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccAttachableAccessEntityProfileConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciAttachableAccessEntityProfile_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciAttachableAccessEntityProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccAttachableAccessEntityProfileConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciAttachableAccessEntityProfileExists(name string, attachable_access_entity_profile *models.AttachableAccessEntityProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Attachable Access Entity Profile %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Attachable Access Entity Profile dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		attachable_access_entity_profileFound := models.AttachableAccessEntityProfileFromContainer(cont)
+		if attachable_access_entity_profileFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Attachable Access Entity Profile %s not found", rs.Primary.ID)
+		}
+		*attachable_access_entity_profile = *attachable_access_entity_profileFound
+		return nil
+	}
+}
+
+func testAccCheckAciAttachableAccessEntityProfileDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing attachable_access_entity_profile destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_attachable_access_entity_profile" {
+			cont, err := client.Get(rs.Primary.ID)
+			attachable_access_entity_profile := models.AttachableAccessEntityProfileFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Attachable Access Entity Profile %s Still exists", attachable_access_entity_profile.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciAttachableAccessEntityProfileIdEqual(m1, m2 *models.AttachableAccessEntityProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("attachable_access_entity_profile DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciAttachableAccessEntityProfileIdNotEqual(m1, m2 *models.AttachableAccessEntityProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("attachable_access_entity_profile DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateAttachableAccessEntityProfileWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing attachable_access_entity_profile creation without ", attrName)
+	rBlock := `
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_attachable_access_entity_profile" "test" {
+	#	name  = "%s"
+	}
+	`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccAttachableAccessEntityProfileConfigWithRequiredParams(rName string) string {
+	fmt.Println("=== STEP  testing attachable_access_entity_profile creation with required arguments only ", rName)
+	resource := fmt.Sprintf(`
+	resource "aci_attachable_access_entity_profile" "test" {
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+func CreateAccAttachableAccessEntityProfileConfigUpdatedName(rName string) string {
+	fmt.Println("=== STEP  testing attachable_access_entity_profile creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	resource "aci_attachable_access_entity_profile" "test" {
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccAttachableAccessEntityProfileConfig(rName string) string {
+	fmt.Println("=== STEP  testing attachable_access_entity_profile creation with required arguments only ", rName)
+	resource := fmt.Sprintf(`
+	resource "aci_attachable_access_entity_profile" "test" {
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccAttachableAccessEntityProfileConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple attachable_access_entity_profile creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_attachable_access_entity_profile" "test" {
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccAttachableAccessEntityProfileConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing attachable_access_entity_profile creation with optional parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_attachable_access_entity_profile" "test" {
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_attachable_access_entity_profile"
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccAttachableAccessEntityProfileRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing attachable_access_entity_profile updation with required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_attachable_access_entity_profile" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_attachable_access_entity_profile"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccAttachableAccessEntityProfileUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing attachable_access_entity_profile attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_attachable_access_entity_profile" "test" {	
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_ospfctxpol_test.go
+++ b/testacc/resource_aci_ospfctxpol_test.go
@@ -42,6 +42,7 @@ func TestAccAciOSPFTimers_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
 					resource.TestCheckResourceAttr(resourceName, "bw_ref", "40000"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "dist", "110"),
 					resource.TestCheckResourceAttr(resourceName, "gr_ctrl", ""),
 					resource.TestCheckResourceAttr(resourceName, "lsa_arrival_intvl", "1000"),
@@ -408,6 +409,13 @@ func TestAccAciOSPFTimers_Update(t *testing.T) {
 				),
 			},
 			{
+				Config: CreateAccOSPFTimersUpdatedAttr(fvTenantName, rName, "gr_ctrl", ""),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciOSPFTimersExists(resourceName, &ospf_timers_updated),
+					resource.TestCheckResourceAttr(resourceName, "gr_ctrl", ""),
+				),
+			},
+			{
 				Config: CreateAccOSPFTimersConfig(fvTenantName, rName),
 			},
 		},
@@ -706,7 +714,7 @@ func CreateOSPFTimersWithoutRequired(fvTenantName, rName, attrName string) strin
 }
 
 func CreateAccOSPFTimersConfigWithRequiredParams(fvTenantName, rName string) string {
-	fmt.Println("=== STEP  testing ospf_timers creation with updated required arguments")
+	fmt.Printf("=== STEP  testing ospf_timers creation with Tenant Name %s and OSPF Timers Name %s required arguments\n", fvTenantName, rName)
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {
@@ -722,7 +730,7 @@ func CreateAccOSPFTimersConfigWithRequiredParams(fvTenantName, rName string) str
 }
 
 func CreateAccOSPFTimersConfig(fvTenantName, rName string) string {
-	fmt.Println("=== STEP  testing ospf_timers creation with required arguments only")
+	fmt.Printf("=== STEP  testing ospf_timers creation with Tenant Name %s and OSPF Timers Name %s required arguments\n", fvTenantName, rName)
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {
@@ -823,7 +831,7 @@ func CreateAccOSPFTimersConfigWithOptionalValues(fvTenantName, rName string) str
 }
 
 func CreateAccOSPFTimersRemovingRequiredField() string {
-	fmt.Println("=== STEP  Basic: testing ospf_timers creation without required parameters")
+	fmt.Println("=== STEP  Basic: testing ospf_timers updation without required parameters")
 	resource := fmt.Sprintf(`
 	resource "aci_ospf_timers" "test" {
 		description = "created while acceptance testing"

--- a/testacc/resource_aci_ospfextp_test.go
+++ b/testacc/resource_aci_ospfextp_test.go
@@ -226,7 +226,7 @@ func TestAccAciL3outOspfExternalPolicy_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: CreateAccL3outOspfExternalPolicyUpdatedAttrInfra(rName,  "multipod_internal", "yes"),
+				Config: CreateAccL3outOspfExternalPolicyUpdatedAttrInfra(rName, "multipod_internal", "yes"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciL3outOspfExternalPolicyExists(resourceName, &l3out_ospf_external_policy_updated_infra),
 					resource.TestCheckResourceAttr(resourceName, "multipod_internal", "yes"),

--- a/testacc/resource_aci_physdomp_test.go
+++ b/testacc/resource_aci_physdomp_test.go
@@ -1,0 +1,280 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciPhysicalDomain_Basic(t *testing.T) {
+	var physical_domain_default models.PhysicalDomain
+	var physical_domain_updated models.PhysicalDomain
+	resourceName := "aci_physical_domain.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciPhysicalDomainDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreatePhysicalDomainWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccPhysicalDomainConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciPhysicalDomainExists(resourceName, &physical_domain_default),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+				),
+			},
+			{
+				Config: CreateAccPhysicalDomainConfigWithOptionalValues(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciPhysicalDomainExists(resourceName, &physical_domain_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_physical_domain"),
+					testAccCheckAciPhysicalDomainIdEqual(&physical_domain_default, &physical_domain_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccPhysicalDomainConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccPhysicalDomainRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+
+			{
+				Config: CreateAccPhysicalDomainConfigWithRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciPhysicalDomainExists(resourceName, &physical_domain_updated),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciPhysicalDomainIdNotEqual(&physical_domain_default, &physical_domain_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciPhysicalDomain_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciPhysicalDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccPhysicalDomainConfig(rName),
+			},
+			{
+				Config:      CreateAccPhysicalDomainUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccPhysicalDomainUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccPhysicalDomainUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccPhysicalDomainConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciPhysicalDomain_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciPhysicalDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccPhysicalDomainConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciPhysicalDomainExists(name string, physical_domain *models.PhysicalDomain) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Physical Domain %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Physical Domain dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		physical_domainFound := models.PhysicalDomainFromContainer(cont)
+		if physical_domainFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Physical Domain %s not found", rs.Primary.ID)
+		}
+		*physical_domain = *physical_domainFound
+		return nil
+	}
+}
+
+func testAccCheckAciPhysicalDomainDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing physical_domain destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_physical_domain" {
+			cont, err := client.Get(rs.Primary.ID)
+			physical_domain := models.PhysicalDomainFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Physical Domain %s Still exists", physical_domain.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciPhysicalDomainIdEqual(m1, m2 *models.PhysicalDomain) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("physical_domain DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciPhysicalDomainIdNotEqual(m1, m2 *models.PhysicalDomain) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("physical_domain DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreatePhysicalDomainWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing physical_domain creation without ", attrName)
+	rBlock := `
+
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_physical_domain" "test" {
+
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccPhysicalDomainConfigWithRequiredParams(rName string) string {
+	fmt.Println("=== STEP  testing physical_domain creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_physical_domain" "test" {
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+func CreateAccPhysicalDomainConfigUpdatedName(rName string) string {
+	fmt.Println("=== STEP  testing physical_domain creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	resource "aci_physical_domain" "test" {
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccPhysicalDomainConfig(rName string) string {
+	fmt.Println("=== STEP  testing physical_domain creation with required arguments", rName)
+	resource := fmt.Sprintf(`
+	resource "aci_physical_domain" "test" {
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccPhysicalDomainConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple physical_domain creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_physical_domain" "test" {
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccPhysicalDomainConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing physical_domain creation with optional parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_physical_domain" "test" {
+		name  = "%s"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_physical_domain"
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccPhysicalDomainRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing physical_domain updation with required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_physical_domain" "test" {
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_physical_domain"
+	}
+	`)
+	return resource
+}
+
+func CreateAccPhysicalDomainUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing physical_domain attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_physical_domain" "test" {
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName, attribute, value)
+	return resource
+}

--- a/website/docs/r/ospf_timers.html.markdown
+++ b/website/docs/r/ospf_timers.html.markdown
@@ -51,7 +51,7 @@ resource "aci_ospf_timers" "example" {
 - `bw_ref` - (Optional) OSPF policy bandwidth for OSPF timers object. Range of allowed values is "1" to "4000000". Default value is "40000".
 - `ctrl` - (Optional) List of Control state for OSPF timers object. Allowed values are "name-lookup" and "pfx-suppress".
 - `dist` - (Optional) Preferred administrative distance for OSPF timers object. Range of allowed values is "1" to "255". Default value is "110".
-- `gr_ctrl` - (Optional) Graceful restart enabled or helper only for OSPF timers object. The allowed value is "helper". The default value is "helper". To deselect the option, just pass `gr_ctrl=""`
+- `gr_ctrl` - (Optional) Graceful restart enabled or helper only for OSPF timers object. The allowed value is "helper". The default value is "". To deselect the option, just pass `gr_ctrl=""`
 - `lsa_arrival_intvl` - (Optional) Minimum interval between the arrivals of lsas for OSPF timers object. The range of allowed values is "10" to "600000". The default value is "1000".
 - `lsa_gp_pacing_intvl` - (Optional) LSA group pacing interval for OSPF timers object. The range of allowed values is "1" to "1800". The default value is "10".
 - `lsa_hold_intvl` - (Optional) Throttle hold interval between LSAs for OSPF timers object. The range of allowed values is "50" to "30000". The default value is "5000".


### PR DESCRIPTION
$ go test -v -run TestAccAciAttachableAccessEntityProfile_Basic -timeout=60m
=== RUN   TestAccAciAttachableAccessEntityProfile_Basic
=== STEP  Basic: testing attachable_access_entity_profile creation without  name
=== STEP  testing attachable_access_entity_profile creation with required arguments only  acctest_jcxo3
=== STEP  Basic: testing attachable_access_entity_profile creation with optional parameters
=== STEP  testing attachable_access_entity_profile creation with invalid name =  1sn1jmz1wwo1a3czye09rvv7vd3k0kvfim1t9wr0hsbbp7dke1lyz1677qgk147ij
=== STEP  Basic: testing attachable_access_entity_profile updation with required parameters
=== STEP  testing attachable_access_entity_profile creation with required arguments only  acctest_ign4s
=== PAUSE TestAccAciAttachableAccessEntityProfile_Basic
=== CONT  TestAccAciAttachableAccessEntityProfile_Basic
=== STEP  testing attachable_access_entity_profile destroy
--- PASS: TestAccAciAttachableAccessEntityProfile_Basic (155.58s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   158.092s

$ go test -v -run TestAccAciAttachableAccessEntityProfile_Negative -timeout=60m
=== RUN   TestAccAciAttachableAccessEntityProfile_Negative
=== STEP  testing attachable_access_entity_profile creation with required arguments only  acctest_mr8w0
=== STEP  testing attachable_access_entity_profile attribute: description = x8dqfdk4wz1h239p2fvqhwsx60q4b07ha3va9bmh2ct1an3b46qcalkbviz41ejgohn6u0sr9j8r30pwxkyupri664gz3cpgqeze2etxcvefy93zsty02q6e2bc3hzttb
=== STEP  testing attachable_access_entity_profile attribute: annotation = 6q1ebfkj36wplb7negawsdtaopek3og00ekwy4rlqstbu8kgmhmmivdvqang969vaig7kh97vj7vhttgnns7kxu89cdgqlh6d6c9ll0y8zqcpps8bqamsra1k84b9unxn
=== STEP  testing attachable_access_entity_profile attribute: name_alias = gnzmktpwdtkts6xlrafdkbl8br1aqicjsqee9iebtzf9r0cj741g711d8918lvh0
=== STEP  testing attachable_access_entity_profile attribute: raopp = 8dxko
=== STEP  testing attachable_access_entity_profile creation with required arguments only  acctest_mr8w0
=== PAUSE TestAccAciAttachableAccessEntityProfile_Negative
=== CONT  TestAccAciAttachableAccessEntityProfile_Negative
=== STEP  testing attachable_access_entity_profile destroy
--- PASS: TestAccAciAttachableAccessEntityProfile_Negative (110.02s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   112.280s

$ go test -v -run TestAccAciAttachableAccessEntityProfile_MultipleCreateDelete -timeout=60m
=== RUN   TestAccAciAttachableAccessEntityProfile_MultipleCreateDelete
=== STEP  testing multiple attachable_access_entity_profile creation with required arguments only
=== PAUSE TestAccAciAttachableAccessEntityProfile_MultipleCreateDelete
=== CONT  TestAccAciAttachableAccessEntityProfile_MultipleCreateDelete
=== STEP  testing attachable_access_entity_profile destroy
--- PASS: TestAccAciAttachableAccessEntityProfile_MultipleCreateDelete (46.29s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   49.301s

$ go test -v -run TestAccAciAttachableAccessEntityProfileDataSource_Basic -timeout=60m
=== RUN   TestAccAciAttachableAccessEntityProfileDataSource_Basic
=== STEP  Basic: testing attachable_access_entity_profile Data Source without  name
=== STEP  testing attachable_access_entity_profile Data Source with required arguments only
=== STEP  testing attachable_access_entity_profile Data Source with random attribute
=== STEP  testing attachable_access_entity_profile Data Source with Invalid Name
=== STEP  testing attachable_access_entity_profile Data Source with updated resource
=== PAUSE TestAccAciAttachableAccessEntityProfileDataSource_Basic
=== CONT  TestAccAciAttachableAccessEntityProfileDataSource_Basic
=== STEP  testing attachable_access_entity_profile destroy
--- PASS: TestAccAciAttachableAccessEntityProfileDataSource_Basic (80.21s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   82.500s

$ go test -v -run TestAccAciOSPFTimers_Update -timeout=60m
=== RUN   TestAccAciOSPFTimers_Update
=== STEP  testing ospf_timers creation with Tenant Name acctest_a3osf and OSPF Timers Name acctest_we6kk required arguments
=== STEP  testing ospf_timers attribute: ctrl=["name-lookup","pfx-suppress"]
=== STEP  testing ospf_timers attribute: ctrl=["pfx-suppress","name-lookup"]
=== STEP  testing ospf_timers attribute: ctrl=["pfx-suppress"]
=== STEP  testing ospf_timers attribute: bw_ref=4000000
=== STEP  testing ospf_timers attribute: bw_ref=100000
=== STEP  testing ospf_timers attribute: dist=225
=== STEP  testing ospf_timers attribute: dist=170
=== STEP  testing ospf_timers attribute: lsa_arrival_intvl=600000
=== STEP  testing ospf_timers attribute: lsa_arrival_intvl=10000
=== STEP  testing ospf_timers attribute: lsa_gp_pacing_intvl=1800
=== STEP  testing ospf_timers attribute: lsa_gp_pacing_intvl=1000
=== STEP  testing ospf_timers attribute: lsa_hold_intvl=30000
=== STEP  testing ospf_timers attribute: lsa_hold_intvl=2000
=== STEP  testing ospf_timers attribute: lsa_max_intvl=30000
=== STEP  testing ospf_timers attribute: lsa_max_intvl=2000
=== STEP  testing ospf_timers attribute: lsa_start_intvl=5000
=== STEP  testing ospf_timers attribute: lsa_start_intvl=2500
=== STEP  testing ospf_timers attribute: max_ecmp=64
=== STEP  testing ospf_timers attribute: max_ecmp=30
=== STEP  testing ospf_timers attribute: max_lsa_action=restart
=== STEP  testing ospf_timers attribute: max_lsa_num=4294967295
=== STEP  testing ospf_timers attribute: max_lsa_num=10000
=== STEP  testing ospf_timers attribute: max_lsa_reset_intvl=1440
=== STEP  testing ospf_timers attribute: max_lsa_reset_intvl=100
=== STEP  testing ospf_timers attribute: max_lsa_sleep_cnt=4294967295
=== STEP  testing ospf_timers attribute: max_lsa_sleep_cnt=10000
=== STEP  testing ospf_timers attribute: max_lsa_sleep_intvl=1440
=== STEP  testing ospf_timers attribute: max_lsa_sleep_intvl=100
=== STEP  testing ospf_timers attribute: max_lsa_thresh=100
=== STEP  testing ospf_timers attribute: max_lsa_thresh=50
=== STEP  testing ospf_timers attribute: spf_hold_intvl=60000
=== STEP  testing ospf_timers attribute: spf_hold_intvl=5000
=== STEP  testing ospf_timers attribute: spf_init_intvl=60000
=== STEP  testing ospf_timers attribute: spf_init_intvl=5000
=== STEP  testing ospf_timers attribute: spf_max_intvl=60000
=== STEP  testing ospf_timers attribute: spf_max_intvl=1000
=== STEP  testing ospf_timers attribute: gr_ctrl=
=== STEP  testing ospf_timers creation with Tenant Name acctest_a3osf and OSPF Timers Name acctest_we6kk required arguments
=== PAUSE TestAccAciOSPFTimers_Update
=== STEP  testing ospf_timers destroy
--- PASS: TestAccAciOSPFTimers_Update (1651.28s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   1652.932s

$ go test -v -run TestAccAciOSPFTimers_Basic -timeout=60m
=== RUN   TestAccAciOSPFTimers_Basic
=== STEP  Basic: testing ospf_timers creation without  tenant_dn
=== STEP  Basic: testing ospf_timers creation without  name
=== STEP  testing ospf_timers creation with Tenant Name acctest_xw4iv and OSPF Timers Name acctest_012yg required arguments
=== STEP  Basic: testing ospf_timers creation with optional parameters
=== STEP  testing ospf_timers creation with Tenant Name acctest_xw4iv and OSPF Timers Name ytzbm0jyvbzbeqvml9dcnl3k7ynohfb1llym6lbettskbll491lptjhhgwyq1pe4b required arguments
=== STEP  Basic: testing ospf_timers updation without required parameters
=== STEP  testing ospf_timers creation with Tenant Name acctest_7xyvb and OSPF Timers Name acctest_012yg required arguments
=== STEP  testing ospf_timers creation with Tenant Name acctest_xw4iv and OSPF Timers Name acctest_012yg required arguments
=== STEP  testing ospf_timers creation with Tenant Name acctest_012yg and OSPF Timers Name acctest_7xyvb required arguments
=== PAUSE TestAccAciOSPFTimers_Basic
=== CONT  TestAccAciOSPFTimers_Basic
=== STEP  testing ospf_timers destroy
--- PASS: TestAccAciOSPFTimers_Basic (245.90s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   247.584s

$ go test -v -run TestAccAciOSPFTimersDataSource_Basic -timeout=60m
=== RUN   TestAccAciOSPFTimersDataSource_Basic
=== STEP  Basic: testing ospf_timers Data Source without  tenant_dn
=== STEP  Basic: testing ospf_timers Data Source without  name
=== STEP  testing ospf_timers Data Source with required arguments only
=== STEP  testing ospf_timers Data Source with random attribute
=== STEP  testing ospf_timers Data Source with Invalid Parent Dn
=== STEP  testing ospf_timers Data Source with updated resource
=== PAUSE TestAccAciOSPFTimersDataSource_Basic
=== CONT  TestAccAciOSPFTimersDataSource_Basic
=== STEP  testing ospf_timers destroy
--- PASS: TestAccAciOSPFTimersDataSource_Basic (119.47s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   121.288s

$ go test -v -run TestAccAciPhysicalDomain_Basic -timeout=60m
=== RUN   TestAccAciPhysicalDomain_Basic
=== STEP  Basic: testing physical_domain creation without  name
=== STEP  testing physical_domain creation with required arguments acctest_z3937
=== STEP  Basic: testing physical_domain creation with optional parameters
=== STEP  testing physical_domain creation with invalid name =  x8wuvux8kgsznnma2132v984662zwvi8dhf4tid4w7cfpzhlwwqzgu7rfda1v4r2t
=== STEP  Basic: testing physical_domain updation with required parameters
=== STEP  testing physical_domain creation with required arguments only
=== PAUSE TestAccAciPhysicalDomain_Basic
=== CONT  TestAccAciPhysicalDomain_Basic
=== STEP  testing physical_domain destroy
--- PASS: TestAccAciPhysicalDomain_Basic (337.83s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   339.330s

$ go test -v -run TestAccAciPhysicalDomain_Negative -timeout=60m
=== RUN   TestAccAciPhysicalDomain_Negative
=== STEP  testing physical_domain creation with required arguments acctest_kblvr
=== STEP  testing physical_domain attribute: annotation = eb28xym0i4ke0g8chsxw3yjmymny4awosib7nuyr0uloc2i6f0ylen2f9r0fsuqxckadr1jn4s9ss703kq1us19l1k9brcliou1gncj6g2epnjaou1f1o7cho3qf80oxg
=== STEP  testing physical_domain attribute: name_alias = tf9u0lh4c72qeg8jzaumt7ina9o6wzkxwebe492hkx2odcfn167ribmji3xp78zz
=== STEP  testing physical_domain attribute: siywh = 9qhed
=== STEP  testing physical_domain creation with required arguments acctest_kblvr
=== PAUSE TestAccAciPhysicalDomain_Negative
=== CONT  TestAccAciPhysicalDomain_Negative
=== STEP  testing physical_domain destroy
--- PASS: TestAccAciPhysicalDomain_Negative (272.65s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   275.548s

$ go test -v -run TestAccAciPhysicalDomain_MultipleCreateDelete -timeout=60m
=== RUN   TestAccAciPhysicalDomain_MultipleCreateDelete
=== STEP  testing multiple physical_domain creation with required arguments only
=== PAUSE TestAccAciPhysicalDomain_MultipleCreateDelete
=== CONT  TestAccAciPhysicalDomain_MultipleCreateDelete
=== STEP  testing physical_domain destroy
--- PASS: TestAccAciPhysicalDomain_MultipleCreateDelete (148.16s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   150.471s

$ go test -v -run TestAccAciPhysicalDomainDataSource_Basic -timeout=60m
=== RUN   TestAccAciPhysicalDomainDataSource_Basic
=== STEP  Basic: testing physical_domain Data Source without  name
=== STEP  testing physical_domain Data Source with required arguments only
=== STEP  testing physical_domain Data Source with random attribute
=== STEP  testing physical_domain Data Source with required arguments only
=== STEP  testing physical_domain Data Source with updated resource
=== PAUSE TestAccAciPhysicalDomainDataSource_Basic
=== CONT  TestAccAciPhysicalDomainDataSource_Basic
=== STEP  testing physical_domain destroy
--- PASS: TestAccAciPhysicalDomainDataSource_Basic (185.29s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   186.744s

$ go test -v -run TestAccAciVLANPool_Basic -timeout=60m
=== RUN   TestAccAciVLANPool_Basic
=== STEP  Basic: testing vlan_pool creation without  alloc_mode
=== STEP  Basic: testing vlan_pool creation without  name
=== STEP  testing vlan_pool creation with required arguments only
=== STEP  Basic: testing vlan_pool creation with optional parameters
=== STEP  testing vlan_pool creation with required arguments only
=== STEP  testing vlan_pool creation with required arguments only
=== STEP  testing vlan_pool creation with required arguments only
=== STEP  Basic: testing vlan_pool updation with required parameters
=== STEP  testing vlan_pool creation with required arguments only
=== STEP  testing vlan_pool creation with required arguments only
=== STEP  testing vlan_pool creation with required arguments only
=== PAUSE TestAccAciVLANPool_Basic
=== CONT  TestAccAciVLANPool_Basic
=== STEP  testing vlan_pool destroy
--- PASS: TestAccAciVLANPool_Basic (365.90s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   368.029s

$ go test -v -run TestAccAciVLANPool_MultipleCreateDelete -timeout=60m
=== RUN   TestAccAciVLANPool_MultipleCreateDelete
=== STEP  testing multiple vlan_pool creation with required arguments only
=== PAUSE TestAccAciVLANPool_MultipleCreateDelete
=== CONT  TestAccAciVLANPool_MultipleCreateDelete
=== STEP  testing vlan_pool destroy
--- PASS: TestAccAciVLANPool_MultipleCreateDelete (110.31s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   112.201s

$ go test -v -run TestAccAciVLANPool_Negative -timeout=60m
=== RUN   TestAccAciVLANPool_Negative
=== STEP  testing vlan_pool creation with required arguments only
=== STEP  testing vlan_pool attribute: description = we3gj3umab7zcf32slwqe0bzj3ylwelp8mc7tre64o8eltgzepf1mrmf1jgwljo2ngpaizjo3ssunl8stkrmqjapfx19isujrdvcqgqpswq714ijyxgsa2ixds0edi7la
=== STEP  testing vlan_pool attribute: annotation = lf9s90plhvqwp9vumzney7oko36vk1fb03qzu6d9lv994pldkqgtgd8htszso1it07277mhk3ooj1n10nb4wf1q0ak6htebtmuvoaq9pekf1w8z2ve6s7eoawoia7rovg
=== STEP  testing vlan_pool attribute: name_alias = uoqj42h1wgy2dfmk0u6wg6kg49hs2ubaonnfwzqtfi92jszxjo7cik87iershcar
=== STEP  testing vlan_pool attribute: gqhte = 2ntxw
=== STEP  testing vlan_pool creation with required arguments only
=== PAUSE TestAccAciVLANPool_Negative
=== CONT  TestAccAciVLANPool_Negative
=== STEP  testing vlan_pool destroy
--- PASS: TestAccAciVLANPool_Negative (174.77s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   177.290s

$ go test -v -run TestAccAciVLANPoolDataSource_Basic -timeout=60m
=== RUN   TestAccAciVLANPoolDataSource_Basic
=== STEP  Basic: testing vlan_pool creation without  alloc_mode
=== STEP  Basic: testing vlan_pool creation without  name
=== STEP  testing vlan_pool Data Source with required arguments only
=== STEP  testing vlan_pool Data Source with random attribute
=== STEP  testing vlan_pool Data Source with required arguments only
=== STEP  testing vlan_pool Data Source with updated resource
=== PAUSE TestAccAciVLANPoolDataSource_Basic
=== CONT  TestAccAciVLANPoolDataSource_Basic
=== STEP  testing vlan_pool destroy
--- PASS: TestAccAciVLANPoolDataSource_Basic (144.46s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   146.863s