### PR TITLE
Added infraAccPortGrp and infraAccBndlGrp

### DIFF
--- a/testacc/data_source_aci_infraaccbndlgrp_test.go
+++ b/testacc/data_source_aci_infraaccbndlgrp_test.go
@@ -1,0 +1,140 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciLeafAccessBundlePolicyGroupDataSource_Basic(t *testing.T) {
+	resourceName := "aci_leaf_access_bundle_policy_group.test"
+	dataSourceName := "data.aci_leaf_access_bundle_policy_group.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLeafAccessBundlePolicyGroupDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateLeafAccessBundlePolicyGroupDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLeafAccessBundlePolicyGroupConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "lag_t", resourceName, "lag_t"),
+				),
+			},
+			{
+				Config:      CreateAccLeafAccessBundlePolicyGroupDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccLeafAccessBundlePolicyGroupDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccLeafAccessBundlePolicyGroupDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccLeafAccessBundlePolicyGroupConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing leaf_access_bundle_policy_group Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_access_bundle_policy_group" "test" {
+		name  = "%s"
+	}
+
+	data "aci_leaf_access_bundle_policy_group" "test" {
+		name  = aci_leaf_access_bundle_policy_group.test.name
+		depends_on = [ aci_leaf_access_bundle_policy_group.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLeafAccessBundlePolicyGroupDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing leaf_access_bundle_policy_group Data Source with Invalid Name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_access_bundle_policy_group" "test" {
+		name  = "%s"
+	}
+
+	data "aci_leaf_access_bundle_policy_group" "test" {
+		name  = "${aci_leaf_access_bundle_policy_group.test.name}_invalid"
+		depends_on = [ aci_leaf_access_bundle_policy_group.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateLeafAccessBundlePolicyGroupDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing leaf_access_bundle_policy_group Data Source without ", attrName)
+	rBlock := `
+	resource "aci_leaf_access_bundle_policy_group" "test" {
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_leaf_access_bundle_policy_group" "test" {
+	#	name  = "%s"
+		depends_on = [ aci_leaf_access_bundle_policy_group.test ]
+	}
+	`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccLeafAccessBundlePolicyGroupDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing leaf_access_bundle_policy_group Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_access_bundle_policy_group" "test" {
+		name  = "%s"
+	}
+
+	data "aci_leaf_access_bundle_policy_group" "test" {
+		name  = aci_leaf_access_bundle_policy_group.test.name
+		%s = "%s"
+		depends_on = [ aci_leaf_access_bundle_policy_group.test ]
+	}
+	`, rName, key, value)
+	return resource
+}
+
+func CreateAccLeafAccessBundlePolicyGroupDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing leaf_access_bundle_policy_group Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_access_bundle_policy_group" "test" {
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_leaf_access_bundle_policy_group" "test" {
+		name  = aci_leaf_access_bundle_policy_group.test.name
+		depends_on = [ aci_leaf_access_bundle_policy_group.test ]
+	}
+	`, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_infraaccportgrp_test.go
+++ b/testacc/data_source_aci_infraaccportgrp_test.go
@@ -1,0 +1,145 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciLeafAccessPortPolicyGroupDataSource_Basic(t *testing.T) {
+	resourceName := "aci_leaf_access_port_policy_group.test"
+	dataSourceName := "data.aci_leaf_access_port_policy_group.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLeafAccessPortPolicyGroupDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateLeafAccessPortPolicyGroupDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLeafAccessPortPolicyGroupConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+				),
+			},
+			{
+				Config:      CreateAccLeafAccessPortPolicyGroupDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccLeafAccessPortPolicyGroupDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccLeafAccessPortPolicyGroupDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccLeafAccessPortPolicyGroupConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing leaf_access_port_policy_group Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_access_port_policy_group" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_leaf_access_port_policy_group" "test" {
+	
+		name  = aci_leaf_access_port_policy_group.test.name
+		depends_on = [ aci_leaf_access_port_policy_group.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLeafAccessPortPolicyGroupDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing leaf_access_port_policy_group Data Source with Invalid Name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_access_port_policy_group" "test" {
+		name  = "%s"
+	}
+
+	data "aci_leaf_access_port_policy_group" "test" {
+	
+		name  = "${aci_leaf_access_port_policy_group.test.name}_invalid"
+		depends_on = [ aci_leaf_access_port_policy_group.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateLeafAccessPortPolicyGroupDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing leaf_access_port_policy_group Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_leaf_access_port_policy_group" "test" {
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_leaf_access_port_policy_group" "test" {
+	#	name  = "%s"
+		depends_on = [ aci_leaf_access_port_policy_group.test ]
+	}
+	`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccLeafAccessPortPolicyGroupDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing leaf_access_port_policy_group Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_access_port_policy_group" "test" {
+		name  = "%s"
+	}
+
+	data "aci_leaf_access_port_policy_group" "test" {
+		name  = aci_leaf_access_port_policy_group.test.name
+		%s = "%s"
+		depends_on = [ aci_leaf_access_port_policy_group.test ]
+	}
+	`, rName, key, value)
+	return resource
+}
+
+func CreateAccLeafAccessPortPolicyGroupDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing leaf_access_port_policy_group Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_access_port_policy_group" "test" {
+		name  = "%s"
+		%s = "%s"
+	}
+	
+	data "aci_leaf_access_port_policy_group" "test" {	
+		name  = aci_leaf_access_port_policy_group.test.name
+		depends_on = [ aci_leaf_access_port_policy_group.test ]
+	}
+	`, rName, key, value)
+	return resource
+}

--- a/testacc/resource_aci_fvnsvlaninstp_test.go
+++ b/testacc/resource_aci_fvnsvlaninstp_test.go
@@ -63,7 +63,7 @@ func TestAccAciVLANPool_Basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:      CreateAccVLANPoolConfig(acctest.RandString(65), allocMode),
+				Config:      CreateAccVLANPoolConfigUpdatedName(acctest.RandString(65), allocMode),
 				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
 			},
 			{
@@ -268,7 +268,7 @@ func CreateAccVLANPoolConfigUpdatedName(rName, allocMode string) string {
 }
 
 func CreateAccVLANPoolConfig(rName, allocMode string) string {
-	fmt.Println("=== STEP  testing vlan_pool creation with required arguments ", rName)
+	fmt.Printf("=== STEP  testing vlan_pool creation with required arguments name %s and alloc_mode %s\n", rName, allocMode)
 	resource := fmt.Sprintf(`
 	
 	resource "aci_vlan_pool" "test" {
@@ -313,7 +313,7 @@ func CreateAccVLANPoolConfigWithOptionalValues(rName, allocMode string) string {
 }
 
 func CreateAccVLANPoolRemovingRequiredField() string {
-	fmt.Println("=== STEP  Basic: testing vlan_pool updation with required parameters")
+	fmt.Println("=== STEP  Basic: testing vlan_pool updation without required parameters")
 	resource := fmt.Sprintf(`
 	resource "aci_vlan_pool" "test" {
 		description = "created while acceptance testing"

--- a/testacc/resource_aci_infraaccbndlgrp_test.go
+++ b/testacc/resource_aci_infraaccbndlgrp_test.go
@@ -1,0 +1,325 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciLeafAccessBundlePolicyGroup_Basic(t *testing.T) {
+	var leaf_access_bundle_policy_group_default models.PCVPCInterfacePolicyGroup
+	var leaf_access_bundle_policy_group_updated models.PCVPCInterfacePolicyGroup
+	resourceName := "aci_leaf_access_bundle_policy_group.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLeafAccessBundlePolicyGroupDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateLeafAccessBundlePolicyGroupWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLeafAccessBundlePolicyGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLeafAccessBundlePolicyGroupExists(resourceName, &leaf_access_bundle_policy_group_default),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "lag_t", "link"),
+				),
+			},
+			{
+				Config: CreateAccLeafAccessBundlePolicyGroupConfigWithOptionalValues(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLeafAccessBundlePolicyGroupExists(resourceName, &leaf_access_bundle_policy_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_leaf_access_bundle_policy_group"),
+					resource.TestCheckResourceAttr(resourceName, "lag_t", "node"),
+					testAccCheckAciLeafAccessBundlePolicyGroupIdEqual(&leaf_access_bundle_policy_group_default, &leaf_access_bundle_policy_group_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccLeafAccessBundlePolicyGroupConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			{
+				Config:      CreateAccLeafAccessBundlePolicyGroupRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLeafAccessBundlePolicyGroupConfigWithUpdatedRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLeafAccessBundlePolicyGroupExists(resourceName, &leaf_access_bundle_policy_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciLeafAccessBundlePolicyGroupIdNotEqual(&leaf_access_bundle_policy_group_default, &leaf_access_bundle_policy_group_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciLeafAccessBundlePolicyGroup_Update(t *testing.T) {
+	var leaf_access_bundle_policy_group_default models.PCVPCInterfacePolicyGroup
+	var leaf_access_bundle_policy_group_updated models.PCVPCInterfacePolicyGroup
+	resourceName := "aci_leaf_access_bundle_policy_group.test"
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLeafAccessBundlePolicyGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLeafAccessBundlePolicyGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLeafAccessBundlePolicyGroupExists(resourceName, &leaf_access_bundle_policy_group_default),
+				),
+			},
+			{
+				Config: CreateAccLeafAccessBundlePolicyGroupUpdatedAttr(rName, "lag_t", "not-aggregated"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLeafAccessBundlePolicyGroupExists(resourceName, &leaf_access_bundle_policy_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "lag_t", "not-aggregated"),
+					testAccCheckAciLeafAccessBundlePolicyGroupIdEqual(&leaf_access_bundle_policy_group_default, &leaf_access_bundle_policy_group_updated),
+				),
+			},
+			{
+				Config: CreateAccLeafAccessBundlePolicyGroupConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciLeafAccessBundlePolicyGroup_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLeafAccessBundlePolicyGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLeafAccessBundlePolicyGroupConfig(rName),
+			},
+			{
+				Config:      CreateAccLeafAccessBundlePolicyGroupUpdatedAttr(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLeafAccessBundlePolicyGroupUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLeafAccessBundlePolicyGroupUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLeafAccessBundlePolicyGroupUpdatedAttr(rName, "lag_t", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccLeafAccessBundlePolicyGroupUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccLeafAccessBundlePolicyGroupConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciLeafAccessBundlePolicyGroup_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLeafAccessBundlePolicyGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLeafAccessBundlePolicyGroupConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciLeafAccessBundlePolicyGroupExists(name string, leaf_access_bundle_policy_group *models.PCVPCInterfacePolicyGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Leaf Access Bundle Policy Group %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Leaf Access Bundle Policy Group dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		leaf_access_bundle_policy_groupFound := models.PCVPCInterfacePolicyGroupFromContainer(cont)
+		if leaf_access_bundle_policy_groupFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Leaf Access Bundle Policy Group %s not found", rs.Primary.ID)
+		}
+		*leaf_access_bundle_policy_group = *leaf_access_bundle_policy_groupFound
+		return nil
+	}
+}
+
+func testAccCheckAciLeafAccessBundlePolicyGroupDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing leaf_access_bundle_policy_group destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_leaf_access_bundle_policy_group" {
+			cont, err := client.Get(rs.Primary.ID)
+			leaf_access_bundle_policy_group := models.PCVPCInterfacePolicyGroupFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Leaf Access Bundle Policy Group %s Still exists", leaf_access_bundle_policy_group.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciLeafAccessBundlePolicyGroupIdEqual(m1, m2 *models.PCVPCInterfacePolicyGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("leaf_access_bundle_policy_group DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciLeafAccessBundlePolicyGroupIdNotEqual(m1, m2 *models.PCVPCInterfacePolicyGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("leaf_access_bundle_policy_group DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateLeafAccessBundlePolicyGroupWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing leaf_access_bundle_policy_group creation without ", attrName)
+	rBlock := `
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_leaf_access_bundle_policy_group" "test" {
+	#	name  = "%s"
+	}
+	`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccLeafAccessBundlePolicyGroupConfigWithUpdatedRequiredParams(rName string) string {
+	fmt.Println("=== STEP  testing leaf_access_bundle_policy_group creation with Updated required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_access_bundle_policy_group" "test" {
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLeafAccessBundlePolicyGroupConfigUpdatedName(rName string) string {
+	fmt.Println("=== STEP  testing leaf_access_bundle_policy_group creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_access_bundle_policy_group" "test" {
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLeafAccessBundlePolicyGroupConfig(rName string) string {
+	fmt.Println("=== STEP  testing leaf_access_bundle_policy_group creation with required arguments ", rName)
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_access_bundle_policy_group" "test" {
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLeafAccessBundlePolicyGroupConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple leaf_access_bundle_policy_group creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_access_bundle_policy_group" "test" {
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLeafAccessBundlePolicyGroupConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing leaf_access_bundle_policy_group creation with optional parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_access_bundle_policy_group" "test" {
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_leaf_access_bundle_policy_group"
+		lag_t = "node"
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccLeafAccessBundlePolicyGroupRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing leaf_access_bundle_policy_group updation with required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_access_bundle_policy_group" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_leaf_access_bundle_policy_group"
+		lag_t = "node"
+	}
+	`)
+	return resource
+}
+
+func CreateAccLeafAccessBundlePolicyGroupUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing leaf_access_bundle_policy_group attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_access_bundle_policy_group" "test" {
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_infraaccportgrp_test.go
+++ b/testacc/resource_aci_infraaccportgrp_test.go
@@ -1,0 +1,275 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciLeafAccessPortPolicyGroup_Basic(t *testing.T) {
+	var leaf_access_port_policy_group_default models.LeafAccessPortPolicyGroup
+	var leaf_access_port_policy_group_updated models.LeafAccessPortPolicyGroup
+	resourceName := "aci_leaf_access_port_policy_group.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLeafAccessPortPolicyGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateLeafAccessPortPolicyGroupWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLeafAccessPortPolicyGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLeafAccessPortPolicyGroupExists(resourceName, &leaf_access_port_policy_group_default),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+				),
+			},
+			{
+				Config: CreateAccLeafAccessPortPolicyGroupConfigWithOptionalValues(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLeafAccessPortPolicyGroupExists(resourceName, &leaf_access_port_policy_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_leaf_access_port_policy_group"),
+					testAccCheckAciLeafAccessPortPolicyGroupIdEqual(&leaf_access_port_policy_group_default, &leaf_access_port_policy_group_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccLeafAccessPortPolicyGroupConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			{
+				Config:      CreateAccLeafAccessPortPolicyGroupRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLeafAccessPortPolicyGroupConfigWithUpdatedRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLeafAccessPortPolicyGroupExists(resourceName, &leaf_access_port_policy_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciLeafAccessPortPolicyGroupIdNotEqual(&leaf_access_port_policy_group_default, &leaf_access_port_policy_group_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciLeafAccessPortPolicyGroup_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLeafAccessPortPolicyGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLeafAccessPortPolicyGroupConfig(rName),
+			},
+			{
+				Config:      CreateAccLeafAccessPortPolicyGroupUpdatedAttr(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLeafAccessPortPolicyGroupUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLeafAccessPortPolicyGroupUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLeafAccessPortPolicyGroupUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccLeafAccessPortPolicyGroupConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciLeafAccessPortPolicyGroup_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLeafAccessPortPolicyGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLeafAccessPortPolicyGroupConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciLeafAccessPortPolicyGroupExists(name string, leaf_access_port_policy_group *models.LeafAccessPortPolicyGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Leaf Access Port Policy Group %s not found", name)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Leaf Access Port Policy Group dn was set")
+		}
+		client := testAccProvider.Meta().(*client.Client)
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		leaf_access_port_policy_groupFound := models.LeafAccessPortPolicyGroupFromContainer(cont)
+		if leaf_access_port_policy_groupFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Leaf Access Port Policy Group %s not found", rs.Primary.ID)
+		}
+		*leaf_access_port_policy_group = *leaf_access_port_policy_groupFound
+		return nil
+	}
+}
+
+func testAccCheckAciLeafAccessPortPolicyGroupDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing leaf_access_port_policy_group destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_leaf_access_port_policy_group" {
+			cont, err := client.Get(rs.Primary.ID)
+			leaf_access_port_policy_group := models.LeafAccessPortPolicyGroupFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Leaf Access Port Policy Group %s Still exists", leaf_access_port_policy_group.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciLeafAccessPortPolicyGroupIdEqual(m1, m2 *models.LeafAccessPortPolicyGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("leaf_access_port_policy_group DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciLeafAccessPortPolicyGroupIdNotEqual(m1, m2 *models.LeafAccessPortPolicyGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("leaf_access_port_policy_group DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateLeafAccessPortPolicyGroupWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing leaf_access_port_policy_group creation without ", attrName)
+	rBlock := `
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_leaf_access_port_policy_group" "test" {
+	#	name  = "%s"
+	}
+	`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccLeafAccessPortPolicyGroupConfigWithUpdatedRequiredParams(rName string) string {
+	fmt.Println("=== STEP  testing leaf_access_port_policy_group creation with updation required arguments ", rName)
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_access_port_policy_group" "test" {
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+func CreateAccLeafAccessPortPolicyGroupConfigUpdatedName(rName string) string {
+	fmt.Println("=== STEP  testing leaf_access_port_policy_group creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_access_port_policy_group" "test" {
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLeafAccessPortPolicyGroupConfig(rName string) string {
+	fmt.Println("=== STEP  testing leaf_access_port_policy_group creation with required arguments", rName)
+	resource := fmt.Sprintf(`	
+	resource "aci_leaf_access_port_policy_group" "test" {
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLeafAccessPortPolicyGroupConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple leaf_access_port_policy_group creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_access_port_policy_group" "test" {
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLeafAccessPortPolicyGroupConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing leaf_access_port_policy_group creation with optional parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_access_port_policy_group" "test" {
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_leaf_access_port_policy_group"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLeafAccessPortPolicyGroupRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing leaf_access_port_policy_group updation with required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_access_port_policy_group" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_leaf_access_port_policy_group"
+	}
+	`)
+	return resource
+}
+
+func CreateAccLeafAccessPortPolicyGroupUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing leaf_access_port_policy_group attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_access_port_policy_group" "test" {
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_infraattentityp_test.go
+++ b/testacc/resource_aci_infraattentityp_test.go
@@ -207,7 +207,7 @@ func CreateAttachableAccessEntityProfileWithoutRequired(rName, attrName string) 
 }
 
 func CreateAccAttachableAccessEntityProfileConfigWithRequiredParams(rName string) string {
-	fmt.Println("=== STEP  testing attachable_access_entity_profile creation with required arguments only ", rName)
+	fmt.Println("=== STEP  testing attachable_access_entity_profile creation with Updated required arguments only ", rName)
 	resource := fmt.Sprintf(`
 	resource "aci_attachable_access_entity_profile" "test" {
 		name  = "%s"
@@ -261,7 +261,7 @@ func CreateAccAttachableAccessEntityProfileConfigWithOptionalValues(rName string
 }
 
 func CreateAccAttachableAccessEntityProfileRemovingRequiredField() string {
-	fmt.Println("=== STEP  Basic: testing attachable_access_entity_profile updation with required parameters")
+	fmt.Println("=== STEP  Basic: testing attachable_access_entity_profile updation without required parameters")
 	resource := fmt.Sprintf(`
 	resource "aci_attachable_access_entity_profile" "test" {
 		description = "created while acceptance testing"

--- a/testacc/resource_aci_physdomp_test.go
+++ b/testacc/resource_aci_physdomp_test.go
@@ -205,7 +205,7 @@ func CreatePhysicalDomainWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccPhysicalDomainConfigWithRequiredParams(rName string) string {
-	fmt.Println("=== STEP  testing physical_domain creation with required arguments only")
+	fmt.Println("=== STEP  testing physical_domain creation with Updated required arguments only")
 	resource := fmt.Sprintf(`
 	resource "aci_physical_domain" "test" {
 		name  = "%s"
@@ -258,7 +258,7 @@ func CreateAccPhysicalDomainConfigWithOptionalValues(rName string) string {
 }
 
 func CreateAccPhysicalDomainRemovingRequiredField() string {
-	fmt.Println("=== STEP  Basic: testing physical_domain updation with required parameters")
+	fmt.Println("=== STEP  Basic: testing physical_domain updation without required parameters")
 	resource := fmt.Sprintf(`
 	resource "aci_physical_domain" "test" {
 		annotation = "orchestrator:terraform_testacc"


### PR DESCRIPTION
$ go test -v -run TestAccAciLeafAccessPortPolicyGroupDataSource_Basic -timeout=60m
=== RUN   TestAccAciLeafAccessPortPolicyGroupDataSource_Basic
=== STEP  Basic: testing leaf_access_port_policy_group Data Source without  name
=== STEP  testing leaf_access_port_policy_group Data Source with required arguments only
=== STEP  testing leaf_access_port_policy_group Data Source with random attribute
=== STEP  testing leaf_access_port_policy_group Data Source with Invalid Name
=== STEP  testing leaf_access_port_policy_group Data Source with updated resource
=== PAUSE TestAccAciLeafAccessPortPolicyGroupDataSource_Basic
=== CONT  TestAccAciLeafAccessPortPolicyGroupDataSource_Basic
=== STEP  testing leaf_access_port_policy_group destroy
--- PASS: TestAccAciLeafAccessPortPolicyGroupDataSource_Basic (151.95s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   154.161s

$ go test -v -run TestAccAciLeafAccessPortPolicyGroup_Basic -timeout=60m
=== RUN   TestAccAciLeafAccessPortPolicyGroup_Basic
=== STEP  Basic: testing leaf_access_port_policy_group creation without  name
=== STEP  testing leaf_access_port_policy_group creation with required arguments acctest_y7mf1
=== STEP  Basic: testing leaf_access_port_policy_group creation with optional parameters
=== STEP  testing leaf_access_port_policy_group creation with invalid name =  ve03sz1owljvsqwjttpcdfdk2pkxh1m0t6lknsz824y8g0d9he7gmrdawreuo7alw
=== STEP  Basic: testing leaf_access_port_policy_group updation with required parameters
=== STEP  testing leaf_access_port_policy_group creation with updation required arguments  acctest_drtdy
=== PAUSE TestAccAciLeafAccessPortPolicyGroup_Basic
=== CONT  TestAccAciLeafAccessPortPolicyGroup_Basic
=== STEP  testing leaf_access_port_policy_group destroy
--- PASS: TestAccAciLeafAccessPortPolicyGroup_Basic (277.75s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   279.963s

$ go test -v -run TestAccAciLeafAccessPortPolicyGroup_Negative -timeout=60m
=== RUN   TestAccAciLeafAccessPortPolicyGroup_Negative
=== STEP  testing leaf_access_port_policy_group creation with required arguments acctest_ta4xs
=== STEP  testing leaf_access_port_policy_group attribute: description = netzxnsvps9tt4r9xcb4wzdxdxtwpo3022qqu7f316mn94n2qqlftvz2cwlhyrulh27ncpvlv49kvio9h91li6neo0vqonxvbu7mnzin2lettxqzp0fx80bvbslfatupo
=== STEP  testing leaf_access_port_policy_group attribute: annotation = repc4bva6flxrodhyaxapuf77l7ldhr2im14vzs1kymnlj4rzbua0exvelctrymw2l07xavc79rljxm0nnolbvccjqw0v2uc3sebfmkr0uzx2m3t6hj37xaru41us38i1
=== STEP  testing leaf_access_port_policy_group attribute: name_alias = s8d9y7xqzutnh4dyuzmmlbgt4n2fclwf3nks6a4k3o22zqdezyp08jnz4jz1o974
=== STEP  testing leaf_access_port_policy_group attribute: nvtsw = 0enbn
=== STEP  testing leaf_access_port_policy_group creation with required arguments acctest_ta4xs
=== PAUSE TestAccAciLeafAccessPortPolicyGroup_Negative
=== CONT  TestAccAciLeafAccessPortPolicyGroup_Negative
=== STEP  testing leaf_access_port_policy_group destroy
--- PASS: TestAccAciLeafAccessPortPolicyGroup_Negative (235.28s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   237.774s


$ go test -v -run TestAccAciLeafAccessPortPolicyGroup_MultipleCreateDelete -timeout=60m
=== RUN   TestAccAciLeafAccessPortPolicyGroup_MultipleCreateDelete
=== STEP  testing multiple leaf_access_port_policy_group creation with required arguments only
=== PAUSE TestAccAciLeafAccessPortPolicyGroup_MultipleCreateDelete
=== CONT  TestAccAciLeafAccessPortPolicyGroup_MultipleCreateDelete
=== STEP  testing leaf_access_port_policy_group destroy
--- PASS: TestAccAciLeafAccessPortPolicyGroup_MultipleCreateDelete (71.81s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   74.562s

$ go test -v -run TestAccAciLeafAccessBundlePolicyGroup_Basic -timeout=60m
=== RUN   TestAccAciLeafAccessBundlePolicyGroup_Basic
=== STEP  Basic: testing leaf_access_bundle_policy_group creation without  name
=== STEP  testing leaf_access_bundle_policy_group creation with required arguments  acctest_vxml2
=== STEP  Basic: testing leaf_access_bundle_policy_group creation with optional parameters
=== STEP  testing leaf_access_bundle_policy_group creation with invalid name =  8umqax0n4emox2fekwrnl20qr7exjlndb1mbbwocok77dat07pszgc2kwzgl3tvnj
=== STEP  Basic: testing leaf_access_bundle_policy_group updation with required parameters
=== STEP  testing leaf_access_bundle_policy_group creation with Updated required arguments only
=== PAUSE TestAccAciLeafAccessBundlePolicyGroup_Basic
=== CONT  TestAccAciLeafAccessBundlePolicyGroup_Basic
=== STEP  testing leaf_access_bundle_policy_group destroy
--- PASS: TestAccAciLeafAccessBundlePolicyGroup_Basic (203.01s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   205.210s

$ go test -v -run TestAccAciLeafAccessBundlePolicyGroupDataSource_Basic -timeout=60m
=== RUN   TestAccAciLeafAccessBundlePolicyGroupDataSource_Basic
=== STEP  Basic: testing leaf_access_bundle_policy_group Data Source without  name
=== STEP  testing leaf_access_bundle_policy_group Data Source with required arguments only
=== STEP  testing leaf_access_bundle_policy_group Data Source with random attribute
=== STEP  testing leaf_access_bundle_policy_group Data Source with Invalid Name
=== STEP  testing leaf_access_bundle_policy_group Data Source with updated resource
=== PAUSE TestAccAciLeafAccessBundlePolicyGroupDataSource_Basic
=== CONT  TestAccAciLeafAccessBundlePolicyGroupDataSource_Basic
=== STEP  testing leaf_access_bundle_policy_group destroy
--- PASS: TestAccAciLeafAccessBundlePolicyGroupDataSource_Basic (152.98s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   155.413s

$ go test -v -run TestAccAciLeafAccessBundlePolicyGroup_Update -timeout=60m
=== RUN   TestAccAciLeafAccessBundlePolicyGroup_Update
=== STEP  testing leaf_access_bundle_policy_group creation with required arguments  acctest_kl7uc
=== STEP  testing leaf_access_bundle_policy_group attribute: lag_t = not-aggregated
=== STEP  testing leaf_access_bundle_policy_group creation with required arguments  acctest_kl7uc
=== PAUSE TestAccAciLeafAccessBundlePolicyGroup_Update
=== CONT  TestAccAciLeafAccessBundlePolicyGroup_Update
=== STEP  testing leaf_access_bundle_policy_group destroy
--- PASS: TestAccAciLeafAccessBundlePolicyGroup_Update (157.47s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   159.688s

$ go test -v -run TestAccAciLeafAccessBundlePolicyGroup_Negative -timeout=60m
=== RUN   TestAccAciLeafAccessBundlePolicyGroup_Negative
=== STEP  testing leaf_access_bundle_policy_group creation with required arguments  acctest_xrwrj
=== STEP  testing leaf_access_bundle_policy_group attribute: description = ksve8x9e7793yi3wfu941ote406twv7jpldpvwj7dacsamm4mumhxdyge4o7nyc62bwp8otdtstxfthldjue7y0fqy03nd2lyb3wnmkooo1ak7enmbdsykznahdhyqx0v
=== STEP  testing leaf_access_bundle_policy_group attribute: annotation = j4wgtuczzzy2amxjs738rwpxvh0i3l8qbedzczqepm670n329vfjqdd2gbj0bfzh4iqny064mmq6zcf91aai4mxc1jyeuhltgk3iix1crrm7tlvqmsbtpcd9us4b7fvcc
=== STEP  testing leaf_access_bundle_policy_group attribute: name_alias = uo13qqy4ir2sd7d7y1fl0z396xdyjrk1od4pxf32uivo8209hizcu6shctznv6fu
=== STEP  testing leaf_access_bundle_policy_group attribute: lag_t = zgf9l
=== STEP  testing leaf_access_bundle_policy_group attribute: jgwum = zgf9l
=== STEP  testing leaf_access_bundle_policy_group creation with required arguments  acctest_xrwrj
=== PAUSE TestAccAciLeafAccessBundlePolicyGroup_Negative
=== CONT  TestAccAciLeafAccessBundlePolicyGroup_Negative
=== STEP  testing leaf_access_bundle_policy_group destroy
--- PASS: TestAccAciLeafAccessBundlePolicyGroup_Negative (196.20s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   198.340s

$ go test -v -run TestAccAciLeafAccessBundlePolicyGroup_MultipleCreateDelete -timeout=60m
=== RUN   TestAccAciLeafAccessBundlePolicyGroup_MultipleCreateDelete
=== STEP  testing multiple leaf_access_bundle_policy_group creation with required arguments only
=== PAUSE TestAccAciLeafAccessBundlePolicyGroup_MultipleCreateDelete
=== CONT  TestAccAciLeafAccessBundlePolicyGroup_MultipleCreateDelete
=== STEP  testing leaf_access_bundle_policy_group destroy
--- PASS: TestAccAciLeafAccessBundlePolicyGroup_MultipleCreateDelete (66.48s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   68.841s