### PR TITLE
added sprint-3 resources

### DIFF
--- a/aci/data_source_aci_cloudctxprofile.go
+++ b/aci/data_source_aci_cloudctxprofile.go
@@ -33,6 +33,18 @@ func dataSourceAciCloudContextProfile() *schema.Resource {
 				Computed: true,
 			},
 
+			"primary_cidr": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"type": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,

--- a/aci/data_source_aci_cloudregion.go
+++ b/aci/data_source_aci_cloudregion.go
@@ -91,7 +91,6 @@ func setCloudProvidersRegionAttributes(cloudRegion *models.CloudProvidersRegion,
 	if dn != cloudRegion.DistinguishedName {
 		d.Set("cloud_provider_profile_dn", "")
 	}
-	d.Set("description", cloudRegion.Description)
 	cloudRegionMap, err := cloudRegion.ToMap()
 	if err != nil {
 		return d, err

--- a/aci/data_source_aci_cloudsubnet.go
+++ b/aci/data_source_aci_cloudsubnet.go
@@ -40,9 +40,12 @@ func dataSourceAciCloudSubnet() *schema.Resource {
 			},
 
 			"scope": &schema.Schema{
-				Type:     schema.TypeString,
+				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 
 			"usage": &schema.Schema{

--- a/aci/data_source_aci_l3extrsnodel3outatt.go
+++ b/aci/data_source_aci_l3extrsnodel3outatt.go
@@ -16,7 +16,7 @@ func dataSourceAciFabricNode() *schema.Resource {
 
 		SchemaVersion: 1,
 
-		Schema: AppendBaseAttrSchema(map[string]*schema.Schema{
+		Schema: map[string]*schema.Schema{
 			"logical_node_profile_dn": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -39,12 +39,18 @@ func dataSourceAciFabricNode() *schema.Resource {
 				Computed: true,
 			},
 
+			"annotation": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"rtr_id_loop_back": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-		}),
+		},
 	}
 }
 

--- a/aci/resource_aci_cloudsubnet.go
+++ b/aci/resource_aci_cloudsubnet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"reflect"
 	"sort"
 	"strings"
 
@@ -129,8 +130,17 @@ func setCloudSubnetAttributes(cloudSubnet *models.CloudSubnet, d *schema.Resourc
 		scopeGet = append(scopeGet, strings.Trim(val, " "))
 	}
 	sort.Strings(scopeGet)
-	if len(scopeGet) == 1 && scopeGet[0] == "" {
-		d.Set("scope", make([]string, 0, 1))
+	if scopeInp, ok := d.GetOk("scope"); ok {
+		scopeAct := make([]string, 0, 1)
+		for _, val := range scopeInp.([]interface{}) {
+			scopeAct = append(scopeAct, val.(string))
+		}
+		sort.Strings(scopeAct)
+		if reflect.DeepEqual(scopeAct, scopeGet) {
+			d.Set("scope", d.Get("scope").([]interface{}))
+		} else {
+			d.Set("scope", scopeGet)
+		}
 	} else {
 		d.Set("scope", scopeGet)
 	}

--- a/aci/resource_aci_l3extrsnodel3outatt.go
+++ b/aci/resource_aci_l3extrsnodel3outatt.go
@@ -25,7 +25,7 @@ func resourceAciFabricNode() *schema.Resource {
 
 		SchemaVersion: 1,
 
-		Schema: AppendBaseAttrSchema(map[string]*schema.Schema{
+		Schema: map[string]*schema.Schema{
 			"logical_node_profile_dn": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -62,6 +62,15 @@ func resourceAciFabricNode() *schema.Resource {
 				Computed: true,
 			},
 
+			"annotation": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				DefaultFunc: func() (interface{}, error) {
+					return "orchestrator:terraform", nil
+				},
+			},
+
 			"rtr_id_loop_back": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -81,7 +90,7 @@ func resourceAciFabricNode() *schema.Resource {
 					return false
 				},
 			},
-		}),
+		},
 	}
 }
 func getRemoteFabricNode(client *client.Client, dn string) (*models.FabricNode, error) {

--- a/testacc/data_source_aci_bgppeerp_test.go
+++ b/testacc/data_source_aci_bgppeerp_test.go
@@ -47,7 +47,6 @@ func TestAccAciPeerConnectivityProfileDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "allowed_self_as_cnt", resourceName, "allowed_self_as_cnt"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "ctrl.#", resourceName, "ctrl.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "ctrl.0", resourceName, "ctrl.0"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "password", resourceName, "password"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "peer_ctrl.#", resourceName, "peer_ctrl.#"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "peer_ctrl.0", resourceName, "peer_ctrl.0"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "private_a_sctrl.#", resourceName, "private_a_sctrl.#"),

--- a/testacc/data_source_aci_cloudepg_test.go
+++ b/testacc/data_source_aci_cloudepg_test.go
@@ -1,0 +1,218 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciCloudEPgDataSource_Basic(t *testing.T) {
+	resourceName := "aci_cloud_epg.test"
+	dataSourceName := "data.aci_cloud_epg.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudEPgDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateCloudEPgDSWithoutRequired(rName, rName, rName, "cloud_applicationcontainer_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateCloudEPgDSWithoutRequired(rName, rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudEPgConfigDataSource(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "cloud_applicationcontainer_dn", resourceName, "cloud_applicationcontainer_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "flood_on_encap", resourceName, "flood_on_encap"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "match_t", resourceName, "match_t"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "exception_tag", resourceName, "exception_tag"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "pref_gr_memb", resourceName, "pref_gr_memb"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "prio", resourceName, "prio"),
+				),
+			},
+			{
+				Config:      CreateAccCloudEPgDataSourceUpdate(rName, rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccCloudEPgDSWithInvalidName(rName, rName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+
+			{
+				Config: CreateAccCloudEPgDataSourceUpdatedResource(rName, rName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccCloudEPgConfigDataSource(fvTenantName, cloudAppName, rName string) string {
+	fmt.Println("=== STEP  testing cloud_epg Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+	}
+
+	data "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = aci_cloud_epg.test.name
+		depends_on = [ aci_cloud_epg.test ]
+	}
+	`, fvTenantName, cloudAppName, rName)
+	return resource
+}
+
+func CreateCloudEPgDSWithoutRequired(fvTenantName, cloudAppName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_epg Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "cloud_applicationcontainer_dn":
+		rBlock += `
+	data "aci_cloud_epg" "test" {
+	#	cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = aci_cloud_epg.test.name
+		depends_on = [ aci_cloud_epg.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+	#	name  = aci_cloud_epg.test.name
+		depends_on = [ aci_cloud_epg.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, cloudAppName, rName)
+}
+
+func CreateAccCloudEPgDSWithInvalidName(fvTenantName, cloudAppName, rName string) string {
+	fmt.Println("=== STEP  testing cloud_epg Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+	}
+
+	data "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "${aci_cloud_epg.test.name}_invalid"
+		depends_on = [ aci_cloud_epg.test ]
+	}
+	`, fvTenantName, cloudAppName, rName)
+	return resource
+}
+
+func CreateAccCloudEPgDataSourceUpdate(fvTenantName, cloudAppName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing cloud_epg Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+	}
+
+	data "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = aci_cloud_epg.test.name
+		%s = "%s"
+		depends_on = [ aci_cloud_epg.test ]
+	}
+	`, fvTenantName, cloudAppName, rName, key, value)
+	return resource
+}
+
+func CreateAccCloudEPgDataSourceUpdatedResource(fvTenantName, cloudAppName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing cloud_epg Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = aci_cloud_epg.test.name
+		depends_on = [ aci_cloud_epg.test ]
+	}
+	`, fvTenantName, cloudAppName, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_cloudprovp_test.go
+++ b/testacc/data_source_aci_cloudprovp_test.go
@@ -1,0 +1,78 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const cloudVendor = "aws"
+
+func TestAccAciCloudProviderProfileDataSource_Basic(t *testing.T) {
+	dataSourceName := "data.aci_cloud_provider_profile.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateCloudProviderProfileDSWithoutRequired(cloudVendor, "vendor"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudProviderProfileConfigDataSource(cloudVendor),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "vendor", cloudVendor),
+				),
+			},
+			{
+				Config:      CreateAccCloudProviderProfileDataSourceUpdate(cloudVendor, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccCloudProviderProfileConfigDataSource(cloudVendor),
+			},
+		},
+	})
+}
+
+func CreateAccCloudProviderProfileConfigDataSource(vendor string) string {
+	fmt.Println("=== STEP  testing cloud_provider_profile Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	data "aci_cloud_provider_profile" "test" {
+		vendor  = "%s"
+	}
+	`, vendor)
+	return resource
+}
+
+func CreateCloudProviderProfileDSWithoutRequired(vendor, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_provider_profile Data Source without ", attrName)
+	rBlock := ``
+	switch attrName {
+	case "vendor":
+		rBlock += `
+	data "aci_cloud_provider_profile" "test" {
+	
+	#	vendor  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, vendor)
+}
+
+func CreateAccCloudProviderProfileDataSourceUpdate(vendor, key, value string) string {
+	fmt.Println("=== STEP  testing cloud_provider_profile Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	data "aci_cloud_provider_profile" "test" {
+	
+		vendor  = "%s"
+		%s = "%s"
+	}
+	`, vendor, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_cloudregion_test.go
+++ b/testacc/data_source_aci_cloudregion_test.go
@@ -1,0 +1,136 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const cloudProvPName = "aws"
+const name = "us-east-1"
+
+func TestAccAciCloudProvidersRegionDataSource_Basic(t *testing.T) {
+	dataSourceName := "data.aci_cloud_providers_region.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateCloudProvidersRegionDSWithoutRequired(cloudProvPName, name, "cloud_provider_profile_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateCloudProvidersRegionDSWithoutRequired(cloudProvPName, name, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudProvidersRegionConfigDataSource(cloudProvPName, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "cloud_provider_profile_dn", fmt.Sprintf("uni/clouddomp/provp-%s", cloudProvPName)),
+					resource.TestCheckResourceAttr(dataSourceName, "name", name),
+					resource.TestCheckResourceAttrSet(dataSourceName, "admin_st"),
+				),
+			},
+			{
+				Config:      CreateAccCloudProvidersRegionDataSourceUpdate(cloudProvPName, name, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccCloudProvidersRegionDSWithInvalidName(cloudProvPName, randomParameter),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccCloudProvidersRegionConfigDataSource(cloudProvPName, name),
+			},
+		},
+	})
+}
+
+func CreateAccCloudProvidersRegionConfigDataSource(cloudProvPName, rName string) string {
+	fmt.Println("=== STEP  testing cloud_providers_region Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+
+	data "aci_cloud_providers_region" "test" {
+		cloud_provider_profile_dn  = "uni/clouddomp/provp-%s"
+		name  = "%s"
+	}
+	`, cloudProvPName, rName)
+	return resource
+}
+
+func CreateCloudProvidersRegionDSWithoutRequired(cloudProvPName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_providers_region Data Source without ", attrName)
+	rBlock := `
+	`
+	switch attrName {
+	case "cloud_provider_profile_dn":
+		rBlock += `
+	data "aci_cloud_providers_region" "test" {
+	#	cloud_provider_profile_dn  = "%s"
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_cloud_providers_region" "test" {
+		cloud_provider_profile_dn  = "%s"
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, cloudProvPName, rName)
+}
+
+func CreateAccCloudProvidersRegionDSWithInvalidName(cloudProvPName, rName string) string {
+	fmt.Println("=== STEP  testing cloud_providers_region Data Source with invalid name")
+	resource := fmt.Sprintf(`
+
+	data "aci_cloud_providers_region" "test" {
+		cloud_provider_profile_dn  = "uni/clouddomp/provp-%s"
+		name  = "%s"
+	}
+	`, cloudProvPName, rName)
+	return resource
+}
+
+func CreateAccCloudProvidersRegionDataSourceUpdate(cloudProvPName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing cloud_providers_region Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	data "aci_cloud_providers_region" "test" {
+		cloud_provider_profile_dn  = "uni/clouddomp/provp-%s"
+		name  = "%s"
+		%s = "%s"
+	}
+	`, cloudProvPName, rName, key, value)
+	return resource
+}
+
+func CreateAccCloudProvidersRegionDataSourceUpdatedResource(cloudProvPName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing cloud_providers_region Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_cloud_provider_profile" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_cloud_providers_region" "test" {
+		cloud_provider_profile_dn  = aci_cloud_provider_profile.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_cloud_providers_region" "test" {
+		cloud_provider_profile_dn  = aci_cloud_provider_profile.test.id
+		name  = aci_cloud_providers_region.test.name
+		depends_on = [ aci_cloud_providers_region.test ]
+	}
+	`, cloudProvPName, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_infraleafs_test.go
+++ b/testacc/data_source_aci_infraleafs_test.go
@@ -1,0 +1,213 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciSwitchAssociationDataSource_Basic(t *testing.T) {
+	resourceName := "aci_leaf_selector.test"
+	dataSourceName := "data.aci_leaf_selector.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSwitchAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateSwitchAssociationDSWithoutRequired(rName, rName, "ALL", "leaf_profile_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateSwitchAssociationDSWithoutRequired(rName, rName, "ALL", "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateSwitchAssociationDSWithoutRequired(rName, rName, "ALL", "switch_association_type"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccSwitchAssociationConfigDataSource(rName, rName, "ALL"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "leaf_profile_dn", resourceName, "leaf_profile_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "switch_association_type", resourceName, "switch_association_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+				),
+			},
+			{
+				Config:      CreateAccSwitchAssociationDataSourceUpdate(rName, rName, "ALL", randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccSwitchAssociationDSWithInvalidName(rName, rName, "ALL"),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+
+			{
+				Config: CreateAccSwitchAssociationDataSourceUpdatedResource(rName, rName, "ALL", "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccSwitchAssociationConfigDataSource(infraNodePName, rName, switch_association_type string) string {
+	fmt.Println("=== STEP  testing switch_association Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = "%s"
+		switch_association_type  = "%s"
+	}
+
+	data "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = aci_leaf_selector.test.name
+		switch_association_type  = aci_leaf_selector.test.switch_association_type
+		depends_on = [ aci_leaf_selector.test ]
+	}
+	`, infraNodePName, rName, switch_association_type)
+	return resource
+}
+
+func CreateSwitchAssociationDSWithoutRequired(infraNodePName, rName, switch_association_type, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing switch_association Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = "%s"
+		switch_association_type  = "%s"
+	}
+	`
+	switch attrName {
+	case "leaf_profile_dn":
+		rBlock += `
+	data "aci_leaf_selector" "test" {
+	#	leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = aci_leaf_selector.test.name	
+		switch_association_type  = aci_leaf_selector.test.switch_association_type
+		depends_on = [ aci_leaf_selector.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+	#	name  = aci_leaf_selector.test.name
+		switch_association_type  = aci_leaf_selector.test.switch_association_type
+		depends_on = [ aci_leaf_selector.test ]
+	}
+		`
+	case "switch_association_type":
+		rBlock += `
+	data "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = aci_leaf_selector.test.name
+	#	switch_association_type  = aci_leaf_selector.test.switch_association_type
+		depends_on = [ aci_leaf_selector.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, infraNodePName, rName, switch_association_type)
+}
+
+func CreateAccSwitchAssociationDSWithInvalidName(infraNodePName, rName, switch_association_type string) string {
+	fmt.Println("=== STEP  testing switch_association Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = "%s"
+		switch_association_type  = "%s"
+	}
+
+	data "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = "${aci_leaf_selector.test.name}_invalid"
+		switch_association_type  = aci_leaf_selector.test.switch_association_type
+		depends_on = [ aci_leaf_selector.test ]
+	}
+	`, infraNodePName, rName, switch_association_type)
+	return resource
+}
+
+func CreateAccSwitchAssociationDataSourceUpdate(infraNodePName, rName, switch_association_type, key, value string) string {
+	fmt.Println("=== STEP  testing switch_association Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = "%s"
+		switch_association_type  = "%s"
+	}
+
+	data "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = aci_leaf_selector.test.name
+		switch_association_type  = aci_leaf_selector.test.switch_association_type
+		%s = "%s"
+		depends_on = [ aci_leaf_selector.test ]
+	}
+	`, infraNodePName, rName, switch_association_type, key, value)
+	return resource
+}
+
+func CreateAccSwitchAssociationDataSourceUpdatedResource(infraNodePName, rName, switch_association_type, key, value string) string {
+	fmt.Println("=== STEP  testing switch_association Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = "%s"
+		switch_association_type  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = aci_leaf_selector.test.name
+		switch_association_type  = aci_leaf_selector.test.switch_association_type
+		depends_on = [ aci_leaf_selector.test ]
+	}
+	`, infraNodePName, rName, switch_association_type, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_infraleafs_test.go
+++ b/testacc/data_source_aci_infraleafs_test.go
@@ -64,7 +64,7 @@ func TestAccAciSwitchAssociationDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccSwitchAssociationConfigDataSource(infraNodePName, rName, switch_association_type string) string {
-	fmt.Println("=== STEP  testing switch_association Data Source with required arguments only")
+	fmt.Println("=== STEP  testing leaf_selector Data Source with required arguments only")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_leaf_profile" "test" {
@@ -89,7 +89,7 @@ func CreateAccSwitchAssociationConfigDataSource(infraNodePName, rName, switch_as
 }
 
 func CreateSwitchAssociationDSWithoutRequired(infraNodePName, rName, switch_association_type, attrName string) string {
-	fmt.Println("=== STEP  Basic: testing switch_association Data Source without ", attrName)
+	fmt.Println("=== STEP  Basic: testing leaf_selector Data Source without ", attrName)
 	rBlock := `
 	
 	resource "aci_leaf_profile" "test" {
@@ -136,7 +136,7 @@ func CreateSwitchAssociationDSWithoutRequired(infraNodePName, rName, switch_asso
 }
 
 func CreateAccSwitchAssociationDSWithInvalidName(infraNodePName, rName, switch_association_type string) string {
-	fmt.Println("=== STEP  testing switch_association Data Source with invalid name")
+	fmt.Println("=== STEP  testing leaf_selector Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_leaf_profile" "test" {
@@ -161,7 +161,7 @@ func CreateAccSwitchAssociationDSWithInvalidName(infraNodePName, rName, switch_a
 }
 
 func CreateAccSwitchAssociationDataSourceUpdate(infraNodePName, rName, switch_association_type, key, value string) string {
-	fmt.Println("=== STEP  testing switch_association Data Source with random attribute")
+	fmt.Println("=== STEP  testing leaf_selector Data Source with random attribute")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_leaf_profile" "test" {
@@ -187,7 +187,7 @@ func CreateAccSwitchAssociationDataSourceUpdate(infraNodePName, rName, switch_as
 }
 
 func CreateAccSwitchAssociationDataSourceUpdatedResource(infraNodePName, rName, switch_association_type, key, value string) string {
-	fmt.Println("=== STEP  testing switch_association Data Source with updated resource")
+	fmt.Println("=== STEP  testing leaf_selector Data Source with updated resource")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_leaf_profile" "test" {

--- a/testacc/data_source_aci_infranodeblk_test.go
+++ b/testacc/data_source_aci_infranodeblk_test.go
@@ -1,0 +1,219 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciNodeBlockDataSource_Basic(t *testing.T) {
+	resourceName := "aci_node_block.test"
+	dataSourceName := "data.aci_node_block.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciNodeBlockDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateNodeBlockDSWithoutRequired(rName, rName, rName, "switch_association_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateNodeBlockDSWithoutRequired(rName, rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccNodeBlockConfigDataSource(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "switch_association_dn", resourceName, "switch_association_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "from_", resourceName, "from_"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "to_", resourceName, "to_"),
+				),
+			},
+			{
+				Config:      CreateAccNodeBlockDataSourceUpdate(rName, rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccNodeBlockDSWithInvalidName(rName, rName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+
+			{
+				Config: CreateAccNodeBlockDataSourceUpdatedResource(rName, rName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccNodeBlockConfigDataSource(mgmtNodeGrpName, infrazoneNodeGrpName, rName string) string {
+	fmt.Println("=== STEP  testing node_block Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+
+  	resource "aci_leaf_selector" "test" {
+    	name = "%s"
+    	leaf_profile_dn = aci_leaf_profile.test.id
+    	switch_association_type = "ALL"
+  	}
+
+	resource "aci_node_block" "test"{
+  		switch_association_dn = aci_leaf_selector.test.id
+  		name = "%s"
+	}
+
+	data "aci_node_block" "test" {
+		switch_association_dn  = aci_node_block.test.switch_association_dn
+		name  = aci_node_block.test.name
+		depends_on = [ aci_node_block.test ]
+	}
+	`, mgmtNodeGrpName, infrazoneNodeGrpName, rName)
+	return resource
+}
+
+func CreateNodeBlockDSWithoutRequired(mgmtNodeGrpName, infrazoneNodeGrpName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing node_block Data Source without ", attrName)
+	rBlock := `
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+
+  	resource "aci_leaf_selector" "test" {
+    	name = "%s"
+    	leaf_profile_dn = aci_leaf_profile.test.id
+    	switch_association_type = "ALL"
+  	}
+
+	resource "aci_node_block" "test"{
+  		switch_association_dn = aci_leaf_selector.test.id
+  		name = "%s"
+	}
+	`
+	switch attrName {
+	case "switch_association_dn":
+		rBlock += `
+	data "aci_node_block" "test" {
+	#	switch_association_dn  = aci_node_block.test.switch_association_dn
+		name  = aci_node_block.test.name
+		depends_on = [ aci_node_block.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_node_block" "test" {
+		switch_association_dn  = aci_node_block.test.switch_association_dn
+	#	name  = aci_node_block.test.name
+		depends_on = [ aci_node_block.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, mgmtNodeGrpName, infrazoneNodeGrpName, rName)
+}
+
+func CreateAccNodeBlockDSWithInvalidName(mgmtNodeGrpName, infrazoneNodeGrpName, rName string) string {
+	fmt.Println("=== STEP  testing node_block Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+
+  	resource "aci_leaf_selector" "test" {
+    	name = "%s"
+    	leaf_profile_dn = aci_leaf_profile.test.id
+    	switch_association_type = "ALL"
+  	}
+
+	resource "aci_node_block" "test"{
+  		switch_association_dn = aci_leaf_selector.test.id
+  		name = "%s"
+	}
+
+	data "aci_node_block" "test" {
+		switch_association_dn  = aci_leaf_selector.test.id
+		name  = "${aci_node_block.test.name}_invalid"
+		depends_on = [ aci_node_block.test ]
+	}
+	`, mgmtNodeGrpName, infrazoneNodeGrpName, rName)
+	return resource
+}
+
+func CreateAccNodeBlockDataSourceUpdate(mgmtNodeGrpName, infrazoneNodeGrpName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing node_block Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+
+  	resource "aci_leaf_selector" "test" {
+    	name = "%s"
+    	leaf_profile_dn = aci_leaf_profile.test.id
+    	switch_association_type = "ALL"
+  	}
+
+	resource "aci_node_block" "test"{
+  		switch_association_dn = aci_leaf_selector.test.id
+  		name = "%s"
+	}
+
+	data "aci_node_block" "test" {
+		switch_association_dn  = aci_leaf_selector.test.id
+		name  = aci_node_block.test.name
+		%s = "%s"
+		depends_on = [ aci_node_block.test ]
+	}
+	`, mgmtNodeGrpName, infrazoneNodeGrpName, rName, key, value)
+	return resource
+}
+
+func CreateAccNodeBlockDataSourceUpdatedResource(mgmtNodeGrpName, infrazoneNodeGrpName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing node_block Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+
+  	resource "aci_leaf_selector" "test" {
+    	name = "%s"
+    	leaf_profile_dn = aci_leaf_profile.test.id
+    	switch_association_type = "ALL"
+  	}
+
+	resource "aci_node_block" "test"{
+  		switch_association_dn = aci_leaf_selector.test.id
+  		name = "%s"
+		%s = "%s"
+	}
+
+	data "aci_node_block" "test" {
+		switch_association_dn  = aci_leaf_selector.test.id
+		name  = aci_node_block.test.name
+		depends_on = [ aci_node_block.test ]
+	}
+	`, mgmtNodeGrpName, infrazoneNodeGrpName, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_infranodep_test.go
+++ b/testacc/data_source_aci_infranodep_test.go
@@ -1,0 +1,148 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciLeafProfileDataSource_Basic(t *testing.T) {
+	resourceName := "aci_leaf_profile.test"
+	dataSourceName := "data.aci_leaf_profile.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLeafProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateLeafProfileDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLeafProfileConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+				),
+			},
+			{
+				Config:      CreateAccLeafProfileDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccLeafProfileDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccLeafProfileDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccLeafProfileConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing leaf_profile Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_leaf_profile" "test" {
+	
+		name  = aci_leaf_profile.test.name
+		depends_on = [ aci_leaf_profile.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateLeafProfileDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing leaf_profile Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_leaf_profile" "test" {
+	
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_leaf_profile" "test" {
+	
+	#	name  = aci_leaf_profile.test.name
+		depends_on = [ aci_leaf_profile.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccLeafProfileDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing leaf_profile Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_leaf_profile" "test" {
+	
+		name  = "${aci_leaf_profile.test.name}_invalid"
+		depends_on = [ aci_leaf_profile.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLeafProfileDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing leaf_profile Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_leaf_profile" "test" {
+	
+		name  = aci_leaf_profile.test.name
+		%s = "%s"
+		depends_on = [ aci_leaf_profile.test ]
+	}
+	`, rName, key, value)
+	return resource
+}
+
+func CreateAccLeafProfileDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing leaf_profile Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_leaf_profile" "test" {
+	
+		name  = aci_leaf_profile.test.name
+		depends_on = [ aci_leaf_profile.test ]
+	}
+	`, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_l3extrsnodel3outatt_test.go
+++ b/testacc/data_source_aci_l3extrsnodel3outatt_test.go
@@ -1,0 +1,247 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const fabDn1 = "topology/pod-1/node-101"
+
+func TestAccAciFabricNodeDataSource_Basic(t *testing.T) {
+	resourceName := "aci_logical_node_to_fabric_node.test"
+	dataSourceName := "data.aci_logical_node_to_fabric_node.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	rtrid, _ := acctest.RandIpAddress("10.1.0.0/16")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFabricNodeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateFabricNodeDSWithoutRequired(rName, rName, rName, fabDn1, "logical_node_profile_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateFabricNodeDSWithoutRequired(rName, rName, rName, fabDn1, "tdn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccFabricNodeConfigDataSource(rName, rName, rName, fabDn1, rtrid),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "logical_node_profile_dn", resourceName, "logical_node_profile_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tdn", resourceName, "tdn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "config_issues", resourceName, "config_issues"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "rtr_id", resourceName, "rtr_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "rtr_id_loop_back", resourceName, "rtr_id_loop_back"),
+				),
+			},
+			{
+				Config:      CreateAccFabricNodeDataSourceUpdate(rName, rName, rName, fabDn1, rtrid, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccFabricNodeDSWithInvalidParentDn(rName, rName, rName, fabDn1, rtrid),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+
+			{
+				Config: CreateAccFabricNodeDataSourceUpdatedResource(rName, rName, rName, fabDn1, rtrid, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccFabricNodeConfigDataSource(fvTenantName, l3extOutName, l3extLNodePName, tDn, ip string) string {
+	fmt.Println("=== STEP  testing logical_node_to_fabric_node Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+	}
+
+	data "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = aci_logical_node_to_fabric_node.test.tdn
+		depends_on = [ aci_logical_node_to_fabric_node.test ]
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, tDn, ip)
+	return resource
+}
+
+func CreateFabricNodeDSWithoutRequired(fvTenantName, l3extOutName, l3extLNodePName, tDn, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing logical_node_to_fabric_node Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "10.1.0.0"
+	}
+	`
+	switch attrName {
+	case "logical_node_profile_dn":
+		rBlock += `
+	data "aci_logical_node_to_fabric_node" "test" {
+	#	logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = aci_logical_node_to_fabric_node.test.tdn
+		depends_on = [ aci_logical_node_to_fabric_node.test ]
+	}
+		`
+	case "tdn":
+		rBlock += `
+	data "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+	#	tdn  = aci_logical_node_to_fabric_node.test.tdn
+		depends_on = [ aci_logical_node_to_fabric_node.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, l3extOutName, l3extLNodePName, tDn)
+}
+
+func CreateAccFabricNodeDSWithInvalidParentDn(fvTenantName, l3extOutName, l3extLNodePName, tDn, ip string) string {
+	fmt.Println("=== STEP  testing logical_node_to_fabric_node Data Source with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+	}
+
+	data "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = "${aci_logical_node_profile.test.id}_invalie"
+		tdn  = aci_logical_node_to_fabric_node.test.tdn
+		depends_on = [ aci_logical_node_to_fabric_node.test ]
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, tDn, ip)
+	return resource
+}
+
+func CreateAccFabricNodeDataSourceUpdate(fvTenantName, l3extOutName, l3extLNodePName, tDn, ip, key, value string) string {
+	fmt.Println("=== STEP  testing logical_node_to_fabric_node Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+	}
+
+	data "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = aci_logical_node_to_fabric_node.test.tdn
+		%s = "%s"
+		depends_on = [ aci_logical_node_to_fabric_node.test ]
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, tDn, ip, key, value)
+	return resource
+}
+
+func CreateAccFabricNodeDataSourceUpdatedResource(fvTenantName, l3extOutName, l3extLNodePName, tDn, ip, key, value string) string {
+	fmt.Println("=== STEP  testing logical_node_to_fabric_node Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+		%s = "%s"
+	}
+
+	data "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = aci_logical_node_to_fabric_node.test.tdn
+		depends_on = [ aci_logical_node_to_fabric_node.test ]
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, tDn, ip, key, value)
+	return resource
+}

--- a/testacc/resource_aci_bgppeerp_test.go
+++ b/testacc/resource_aci_bgppeerp_test.go
@@ -99,7 +99,7 @@ func TestAccAciPeerConnectivityProfile_Basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"password"},
 			},
 			{
-				Config:      CreateAccPeerConnectivityProfileWithInavalidIP(rName, rName, rName, addr),
+				Config:      CreateAccPeerConnectivityProfileWithInvalidIP(rName, rName, rName, addr),
 				ExpectError: regexp.MustCompile(`unknown property value (.)+`),
 			},
 
@@ -108,10 +108,10 @@ func TestAccAciPeerConnectivityProfile_Basic(t *testing.T) {
 				ExpectError: regexp.MustCompile(`Missing required argument`),
 			},
 			{
-				Config: CreateAccPeerConnectivityProfileConfigWithRequiredParams(rName, rName, rNameUpdated, addr),
+				Config: CreateAccPeerConnectivityProfileConfigWithRequiredParams(rName, addr),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciPeerConnectivityProfileExists(resourceName, &peer_connectivity_profile_updated),
-					resource.TestCheckResourceAttr(resourceName, "parent_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s", rName, rName, rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "parent_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s", rName, rName, rName)),
 					resource.TestCheckResourceAttr(resourceName, "addr", addr),
 					testAccCheckAciPeerConnectivityProfileIdNotEqual(&peer_connectivity_profile_default, &peer_connectivity_profile_updated),
 				),
@@ -120,10 +120,10 @@ func TestAccAciPeerConnectivityProfile_Basic(t *testing.T) {
 				Config: CreateAccPeerConnectivityProfileConfig(fvTenantName, l3extOutName, l3extLNodePName, addr),
 			},
 			{
-				Config: CreateAccPeerConnectivityProfileConfigWithRequiredParams(rName, rName, rName, addrUpdated),
+				Config: CreateAccPeerConnectivityProfileConfigWithRequiredParams(rNameUpdated, addrUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciPeerConnectivityProfileExists(resourceName, &peer_connectivity_profile_updated),
-					resource.TestCheckResourceAttr(resourceName, "parent_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s", rName, rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "parent_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s", rNameUpdated, rNameUpdated, rNameUpdated)),
 					resource.TestCheckResourceAttr(resourceName, "addr", addrUpdated),
 					testAccCheckAciPeerConnectivityProfileIdNotEqual(&peer_connectivity_profile_default, &peer_connectivity_profile_updated),
 				),
@@ -488,8 +488,8 @@ func CreatePeerConnectivityProfileWithoutRequired(fvTenantName, l3extOutName, l3
 	return fmt.Sprintf(rBlock, fvTenantName, l3extOutName, l3extLNodePName, addr)
 }
 
-func CreateAccPeerConnectivityProfileConfigWithRequiredParams(fvTenantName, l3extOutName, l3extLNodePName, addr string) string {
-	fmt.Println("=== STEP  testing peer_connectivity_profile creation with required arguments only")
+func CreateAccPeerConnectivityProfileConfigWithRequiredParams(prName, addr string) string {
+	fmt.Printf("=== STEP  testing peer_connectivity_profile creation with parent resource name %s and address %s\n", prName, addr)
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {
@@ -511,7 +511,7 @@ func CreateAccPeerConnectivityProfileConfigWithRequiredParams(fvTenantName, l3ex
 		parent_dn  = aci_logical_node_profile.test.id
 		addr  = "%s"
 	}
-	`, fvTenantName, l3extOutName, l3extLNodePName, addr)
+	`, prName, prName, prName, addr)
 	return resource
 }
 
@@ -542,8 +542,8 @@ func CreateAccPeerConnectivityProfileConfig(fvTenantName, l3extOutName, l3extLNo
 	return resource
 }
 
-func CreateAccPeerConnectivityProfileWithInavalidIP(fvTenantName, l3extOutName, l3extLNodePName, addr string) string {
-	fmt.Println("=== STEP  testing peer_connectivity_profile creation with required arguments only")
+func CreateAccPeerConnectivityProfileWithInvalidIP(fvTenantName, l3extOutName, l3extLNodePName, addr string) string {
+	fmt.Println("=== STEP  testing peer_connectivity_profile creation with invalid IP")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {

--- a/testacc/resource_aci_cloudepg_test.go
+++ b/testacc/resource_aci_cloudepg_test.go
@@ -1,0 +1,538 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciCloudEPg_Basic(t *testing.T) {
+	var cloud_epg_default models.CloudEPg
+	var cloud_epg_updated models.CloudEPg
+	resourceName := "aci_cloud_epg.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudEPgDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateCloudEPgWithoutRequired(rName, rName, rName, "cloud_applicationcontainer_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateCloudEPgWithoutRequired(rName, rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudEPgConfig(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudEPgExists(resourceName, &cloud_epg_default),
+					resource.TestCheckResourceAttr(resourceName, "cloud_applicationcontainer_dn", fmt.Sprintf("uni/tn-%s/cloudapp-%s", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "flood_on_encap", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "match_t", "AtleastOne"),
+					resource.TestCheckResourceAttr(resourceName, "pref_gr_memb", "exclude"),
+					resource.TestCheckResourceAttr(resourceName, "prio", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "exception_tag", ""),
+				),
+			},
+			{
+				Config: CreateAccCloudEPgConfigWithOptionalValues(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudEPgExists(resourceName, &cloud_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "cloud_applicationcontainer_dn", fmt.Sprintf("uni/tn-%s/cloudapp-%s", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_cloud_epg"),
+					resource.TestCheckResourceAttr(resourceName, "flood_on_encap", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "match_t", "All"),
+					resource.TestCheckResourceAttr(resourceName, "pref_gr_memb", "include"),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level1"),
+					resource.TestCheckResourceAttr(resourceName, "exception_tag", "0"),
+					testAccCheckAciCloudEPgIdEqual(&cloud_epg_default, &cloud_epg_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccCloudEPgConfigUpdatedName(rName, rName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccCloudEPgRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudEPgConfigWithRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudEPgExists(resourceName, &cloud_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "cloud_applicationcontainer_dn", fmt.Sprintf("uni/tn-%s/cloudapp-%s", rNameUpdated, rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciCloudEPgIdNotEqual(&cloud_epg_default, &cloud_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudEPgConfig(rName, rName, rName),
+			},
+			{
+				Config: CreateAccCloudEPgConfigWithRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudEPgExists(resourceName, &cloud_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "cloud_applicationcontainer_dn", fmt.Sprintf("uni/tn-%s/cloudapp-%s", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciCloudEPgIdNotEqual(&cloud_epg_default, &cloud_epg_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciCloudEPg_Update(t *testing.T) {
+	var cloud_epg_default models.CloudEPg
+	var cloud_epg_updated models.CloudEPg
+	resourceName := "aci_cloud_epg.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciCloudEPgDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccCloudEPgConfig(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudEPgExists(resourceName, &cloud_epg_default),
+				),
+			},
+
+			{
+				Config: CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "match_t", "AtmostOne"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudEPgExists(resourceName, &cloud_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "match_t", "AtmostOne"),
+					testAccCheckAciCloudEPgIdEqual(&cloud_epg_default, &cloud_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "match_t", "None"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudEPgExists(resourceName, &cloud_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "match_t", "None"),
+					testAccCheckAciCloudEPgIdEqual(&cloud_epg_default, &cloud_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "prio", "level2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudEPgExists(resourceName, &cloud_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level2"),
+					testAccCheckAciCloudEPgIdEqual(&cloud_epg_default, &cloud_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "prio", "level3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudEPgExists(resourceName, &cloud_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level3"),
+					testAccCheckAciCloudEPgIdEqual(&cloud_epg_default, &cloud_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "prio", "level4"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudEPgExists(resourceName, &cloud_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level4"),
+					testAccCheckAciCloudEPgIdEqual(&cloud_epg_default, &cloud_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "prio", "level5"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudEPgExists(resourceName, &cloud_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level5"),
+					testAccCheckAciCloudEPgIdEqual(&cloud_epg_default, &cloud_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "prio", "level6"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudEPgExists(resourceName, &cloud_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level6"),
+					testAccCheckAciCloudEPgIdEqual(&cloud_epg_default, &cloud_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudEPgConfig(rName, rName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciCloudEPg_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciCloudEPgDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccCloudEPgConfig(rName, rName, rName),
+			},
+			{
+				Config:      CreateAccCloudEPgWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "flood_on_encap", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "match_t", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "pref_gr_memb", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "prio", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "prio", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "prio", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccCloudEPgUpdatedAttr(rName, rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccCloudEPgConfig(rName, rName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciCloudEPg_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciCloudEPgDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccCloudEPgConfigMultiple(rName, rName, rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciCloudEPgExists(name string, cloud_epg *models.CloudEPg) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Cloud EPg %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Cloud EPg dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		cloud_epgFound := models.CloudEPgFromContainer(cont)
+		if cloud_epgFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Cloud EPg %s not found", rs.Primary.ID)
+		}
+		*cloud_epg = *cloud_epgFound
+		return nil
+	}
+}
+
+func testAccCheckAciCloudEPgDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing cloud_epg destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_cloud_epg" {
+			cont, err := client.Get(rs.Primary.ID)
+			cloud_epg := models.CloudEPgFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Cloud EPg %s Still exists", cloud_epg.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciCloudEPgIdEqual(m1, m2 *models.CloudEPg) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("cloud_epg DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciCloudEPgIdNotEqual(m1, m2 *models.CloudEPg) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("cloud_epg DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateCloudEPgWithoutRequired(fvTenantName, cloudAppName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_epg creation without ", attrName)
+	rBlock := `
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	`
+	switch attrName {
+	case "cloud_applicationcontainer_dn":
+		rBlock += `
+	resource "aci_cloud_epg" "test" {
+	#	cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, cloudAppName, rName)
+}
+
+func CreateAccCloudEPgConfigWithRequiredParams(prName, rName string) string {
+	fmt.Printf("=== STEP  testing cloud_epg creation with parent resource name %s and resource name %s\n", prName, rName)
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+	}
+	`, prName, prName, rName)
+	return resource
+}
+func CreateAccCloudEPgConfigUpdatedName(fvTenantName, cloudAppName, rName string) string {
+	fmt.Println("=== STEP  testing cloud_epg creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, cloudAppName, rName)
+	return resource
+}
+
+func CreateAccCloudEPgConfig(fvTenantName, cloudAppName, rName string) string {
+	fmt.Println("=== STEP  testing cloud_epg creation with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, cloudAppName, rName)
+	return resource
+}
+
+func CreateAccCloudEPgConfigMultiple(fvTenantName, cloudAppName, rName string) string {
+	fmt.Println("=== STEP  testing multiple cloud_epg creation with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, fvTenantName, cloudAppName, rName)
+	return resource
+}
+
+func CreateAccCloudEPgWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing cloud_epg creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, rName ,rName)
+	return resource
+}
+
+func CreateAccCloudEPgConfigWithOptionalValues(fvTenantName, cloudAppName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_epg creation with optional parameters")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = "${aci_cloud_applicationcontainer.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_cloud_epg"
+		flood_on_encap = "enabled"
+		match_t = "All"
+		pref_gr_memb = "include"
+		prio = "level1"
+		exception_tag = "0"
+	}
+	`, fvTenantName, cloudAppName, rName)
+
+	return resource
+}
+
+func CreateAccCloudEPgRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing cloud_epg updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_cloud_epg" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_cloud_epg"
+		az_application_security_group = ""
+		az_network_security_group = ""
+		flood_on_encap = "enabled"
+		match_t = "All"
+		pref_gr_memb = "include"
+		prio = "level1"
+
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccCloudEPgUpdatedAttr(fvTenantName, cloudAppName, rName,attribute,value string) string {
+	fmt.Printf("=== STEP  testing cloud_epg attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_cloud_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, fvTenantName, cloudAppName, rName,attribute,value)
+	return resource
+}

--- a/testacc/resource_aci_infraleafs_test.go
+++ b/testacc/resource_aci_infraleafs_test.go
@@ -1,0 +1,438 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciSwitchAssociation_Basic(t *testing.T) {
+	var leaf_selector_default models.SwitchAssociation
+	var leaf_selector_updated models.SwitchAssociation
+	resourceName := "aci_leaf_selector.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSwitchAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateSwitchAssociationWithoutRequired(rName, rName, "ALL", "leaf_profile_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateSwitchAssociationWithoutRequired(rName, rName, "ALL", "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateSwitchAssociationWithoutRequired(rName, rName, "ALL", "switch_association_type"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccSwitchAssociationConfig(rName, rName, "ALL"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSwitchAssociationExists(resourceName, &leaf_selector_default),
+					resource.TestCheckResourceAttr(resourceName, "leaf_profile_dn", fmt.Sprintf("uni/infra/nprof-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "switch_association_type", "ALL"),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "switch_association_type", "ALL"),
+				),
+			},
+			{
+				Config: CreateAccSwitchAssociationConfigWithOptionalValues(rName, rName, "ALL"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSwitchAssociationExists(resourceName, &leaf_selector_updated),
+					resource.TestCheckResourceAttr(resourceName, "leaf_profile_dn", fmt.Sprintf("uni/infra/nprof-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "switch_association_type", "ALL"),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_leaf_selector"),
+					resource.TestCheckResourceAttr(resourceName, "switch_association_type", "ALL"),
+					testAccCheckAciSwitchAssociationIdEqual(&leaf_selector_default, &leaf_selector_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccSwitchAssociationConfigUpdatedName(rName, acctest.RandString(65), "ALL"),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			{
+				Config:      CreateAccSwitchAssociationRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccSwitchAssociationConfigWithRequiredParams(rNameUpdated, rName, "ALL"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSwitchAssociationExists(resourceName, &leaf_selector_updated),
+					resource.TestCheckResourceAttr(resourceName, "leaf_profile_dn", fmt.Sprintf("uni/infra/nprof-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "switch_association_type", "ALL"),
+					testAccCheckAciSwitchAssociationIdNotEqual(&leaf_selector_default, &leaf_selector_updated),
+				),
+			},
+			{
+				Config: CreateAccSwitchAssociationConfig(rName, rName, "ALL"),
+			},
+			{
+				Config: CreateAccSwitchAssociationConfigWithRequiredParams(rName, rNameUpdated, "ALL"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSwitchAssociationExists(resourceName, &leaf_selector_updated),
+					resource.TestCheckResourceAttr(resourceName, "leaf_profile_dn", fmt.Sprintf("uni/infra/nprof-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "switch_association_type", "ALL"),
+					testAccCheckAciSwitchAssociationIdNotEqual(&leaf_selector_default, &leaf_selector_updated),
+				),
+			},
+			{
+				Config: CreateAccSwitchAssociationConfig(rName, rName, "ALL"),
+			},
+			{
+				Config: CreateAccSwitchAssociationConfigWithRequiredParams(rName, rName, "range"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSwitchAssociationExists(resourceName, &leaf_selector_updated),
+					resource.TestCheckResourceAttr(resourceName, "leaf_profile_dn", fmt.Sprintf("uni/infra/nprof-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "switch_association_type", "range"),
+					testAccCheckAciSwitchAssociationIdNotEqual(&leaf_selector_default, &leaf_selector_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciSwitchAssociation_Update(t *testing.T) {
+	var leaf_selector_default models.SwitchAssociation
+	resourceName := "aci_leaf_selector.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSwitchAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccSwitchAssociationConfig(rName, rName, "ALL_IN_POD"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSwitchAssociationExists(resourceName, &leaf_selector_default),
+					resource.TestCheckResourceAttr(resourceName, "leaf_profile_dn", fmt.Sprintf("uni/infra/nprof-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "switch_association_type", "ALL_IN_POD"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciSwitchAssociation_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSwitchAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccSwitchAssociationConfig(rName, rName, "ALL"),
+			},
+			{
+				Config:      CreateAccSwitchAssociationConfig(rName, rName, rName),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccSwitchAssociationWithInValidParentDn(rName, "ALL"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccSwitchAssociationUpdatedAttr(rName, rName, "ALL", "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccSwitchAssociationUpdatedAttr(rName, rName, "ALL", "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccSwitchAssociationUpdatedAttr(rName, rName, "ALL", "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccSwitchAssociationUpdatedAttr(rName, rName, "ALL", randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccSwitchAssociationConfig(rName, rName, "ALL"),
+			},
+		},
+	})
+}
+
+func TestAccAciSwitchAssociation_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSwitchAssociationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccSwitchAssociationConfigMultiple(rName, rName, "ALL"),
+			},
+		},
+	})
+}
+
+func testAccCheckAciSwitchAssociationExists(name string, leaf_selector *models.SwitchAssociation) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Switch Association %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Switch Association dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		leaf_selectorFound := models.SwitchAssociationFromContainer(cont)
+		if leaf_selectorFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Switch Association %s not found", rs.Primary.ID)
+		}
+		*leaf_selector = *leaf_selectorFound
+		return nil
+	}
+}
+
+func testAccCheckAciSwitchAssociationDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing leaf_selector destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_leaf_selector" {
+			cont, err := client.Get(rs.Primary.ID)
+			leaf_selector := models.SwitchAssociationFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Switch Association %s Still exists", leaf_selector.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciSwitchAssociationIdEqual(m1, m2 *models.SwitchAssociation) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("leaf_selector DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciSwitchAssociationIdNotEqual(m1, m2 *models.SwitchAssociation) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("leaf_selector DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateSwitchAssociationWithoutRequired(infraNodePName, rName, switch_association_type, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing leaf_selector creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+		
+	}
+	
+	`
+	switch attrName {
+	case "leaf_profile_dn":
+		rBlock += `
+	resource "aci_leaf_selector" "test" {
+	#	leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = "%s"	
+		switch_association_type  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+	#	name  = "%s"
+		switch_association_type  = "%s"
+	}
+		`
+	case "switch_association_type":
+		rBlock += `
+	resource "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = "%s"
+	#	switch_association_type  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, infraNodePName, rName, switch_association_type)
+}
+
+func CreateAccSwitchAssociationConfigWithRequiredParams(infraNodePName, rName, switch_association_type string) string {
+	fmt.Printf("=== STEP  testing leaf_selector creation with parent resource name %s, resource name %s and switch_association_type %s\n", infraNodePName, rName, switch_association_type)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = "%s"
+		switch_association_type  = "%s"
+	}
+	`, infraNodePName, rName, switch_association_type)
+	return resource
+}
+func CreateAccSwitchAssociationConfigUpdatedName(infraNodePName, rName, switch_association_type string) string {
+	fmt.Println("=== STEP  testing leaf_selector creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = "%s"
+		switch_association_type  = "%s"
+	}
+	`, infraNodePName, rName, switch_association_type)
+	return resource
+}
+
+func CreateAccSwitchAssociationConfig(infraNodePName, rName, switch_association_type string) string {
+	fmt.Println("=== STEP  testing leaf_selector creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = "%s"
+		switch_association_type  = "%s"
+	}
+	`, infraNodePName, rName, switch_association_type)
+	return resource
+}
+
+func CreateAccSwitchAssociationConfigMultiple(infraNodePName, rName, switch_association_type string) string {
+	fmt.Println("=== STEP  testing multiple leaf_selector creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = "%s_${count.index}"
+		switch_association_type  = "%s"
+		count = 5
+	}
+	`, infraNodePName, rName, switch_association_type)
+	return resource
+}
+
+func CreateAccSwitchAssociationWithInValidParentDn(rName, switch_association_type string) string {
+	fmt.Println("=== STEP  Negative Case: testing leaf_selector creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_tenant.test.id
+		name  = "%s"
+		switch_association_type  = "%s"	
+	}
+	`, rName, rName, switch_association_type)
+	return resource
+}
+
+func CreateAccSwitchAssociationConfigWithOptionalValues(infraNodePName, rName, switch_association_type string) string {
+	fmt.Println("=== STEP  Basic: testing leaf_selector creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_leaf_selector" "test" {
+		leaf_profile_dn  = "${aci_leaf_profile.test.id}"
+		name  = "%s"
+		switch_association_type  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_leaf_selector"
+	}
+	`, infraNodePName, rName, switch_association_type)
+
+	return resource
+}
+
+func CreateAccSwitchAssociationRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing leaf_selector updation without required parameters")
+	resource := fmt.Sprintln(`
+	resource "aci_leaf_selector" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_leaf_selector"		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccSwitchAssociationUpdatedAttr(infraNodePName, rName, switch_association_type, attribute, value string) string {
+	fmt.Printf("=== STEP  testing leaf_selector attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_leaf_selector" "test" {
+		leaf_profile_dn  = aci_leaf_profile.test.id
+		name  = "%s"
+		switch_association_type  = "%s"
+		%s = "%s"
+	}
+	`, infraNodePName, rName, switch_association_type, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_infranodeblk_test.go
+++ b/testacc/resource_aci_infranodeblk_test.go
@@ -1,0 +1,480 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciNodeBlock_Basic(t *testing.T) {
+	var node_block_default models.NodeBlock
+	var node_block_updated models.NodeBlock
+	resourceName := "aci_node_block.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciNodeBlockDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateNodeBlockWithoutRequired(rName, rName, rName, "switch_association_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateNodeBlockWithoutRequired(rName, rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccNodeBlockConfig(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciNodeBlockExists(resourceName, &node_block_default),
+					resource.TestCheckResourceAttr(resourceName, "switch_association_dn", fmt.Sprintf("uni/infra/nprof-%s/leaves-%s-typ-ALL", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "from_", "1"),
+					resource.TestCheckResourceAttr(resourceName, "to_", "1"),
+				),
+			},
+			{
+				Config: CreateAccNodeBlockConfigWithOptionalValues(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciNodeBlockExists(resourceName, &node_block_updated),
+					resource.TestCheckResourceAttr(resourceName, "switch_association_dn", fmt.Sprintf("uni/infra/nprof-%s/leaves-%s-typ-ALL", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_node_block"),
+					resource.TestCheckResourceAttr(resourceName, "from_", "1600"),
+					resource.TestCheckResourceAttr(resourceName, "to_", "1600"),
+					testAccCheckAciNodeBlockIdEqual(&node_block_default, &node_block_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccNodeBlockConfigUpdatedName(rName, rName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccNodeBlockRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccNodeBlockConfigWithRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciNodeBlockExists(resourceName, &node_block_updated),
+					resource.TestCheckResourceAttr(resourceName, "switch_association_dn", fmt.Sprintf("uni/infra/nprof-%s/leaves-%s-typ-ALL", rNameUpdated, rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciNodeBlockIdNotEqual(&node_block_default, &node_block_updated),
+				),
+			},
+			{
+				Config: CreateAccNodeBlockConfig(rName, rName, rName),
+			},
+			{
+				Config: CreateAccNodeBlockConfigWithRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciNodeBlockExists(resourceName, &node_block_updated),
+					resource.TestCheckResourceAttr(resourceName, "switch_association_dn", fmt.Sprintf("uni/infra/nprof-%s/leaves-%s-typ-ALL", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciNodeBlockIdNotEqual(&node_block_default, &node_block_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciNodeBlock_Update(t *testing.T) {
+	var node_block_default models.NodeBlock
+	var node_block_updated models.NodeBlock
+	resourceName := "aci_node_block.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciNodeBlockDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccNodeBlockConfig(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciNodeBlockExists(resourceName, &node_block_default),
+				),
+			},
+			{
+				Config: CreateAccNodeBlockUpdatedAttr(rName, rName, rName, "to_", "8000"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciNodeBlockExists(resourceName, &node_block_updated),
+					resource.TestCheckResourceAttr(resourceName, "to_", "8000"),
+					testAccCheckAciNodeBlockIdEqual(&node_block_default, &node_block_updated),
+				),
+			},
+			{
+				Config: CreateAccNodeBlockUpdatedAttr(rName, rName, rName, "from_", "8000"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciNodeBlockExists(resourceName, &node_block_updated),
+					resource.TestCheckResourceAttr(resourceName, "from_", "8000"),
+					testAccCheckAciNodeBlockIdEqual(&node_block_default, &node_block_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciNodeBlock_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciNodeBlockDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccNodeBlockConfig(rName, rName, rName),
+			},
+			{
+				Config:      CreateAccNodeBlockWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccNodeBlockUpdatedAttr(rName, rName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccNodeBlockUpdatedAttr(rName, rName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccNodeBlockUpdatedAttr(rName, rName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccNodeBlockUpdatedAttr(rName, rName, rName, "from_", "0"),
+				ExpectError: regexp.MustCompile(`Property (.)+ is out of range`),
+			},
+			{
+				Config:      CreateAccNodeBlockUpdatedAttr(rName, rName, rName, "from_", "16001"),
+				ExpectError: regexp.MustCompile(`Property (.)+ is out of range`),
+			},
+			{
+				Config:      CreateAccNodeBlockUpdatedAttr(rName, rName, rName, "to_", "0"),
+				ExpectError: regexp.MustCompile(`Property (.)+ is out of range`),
+			},
+			{
+				Config:      CreateAccNodeBlockUpdatedAttr(rName, rName, rName, "to_", "16001"),
+				ExpectError: regexp.MustCompile(`Property (.)+ is out of range`),
+			},
+			{
+				Config:      CreateAccNodeBlockUpdatedAttr(rName, rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccNodeBlockUpdatedAttr(rName, rName, rName, "to_", "100"),
+			},
+			{
+				Config:      CreateAccNodeBlockUpdatedAttr(rName, rName, rName, "from_", "200"),
+				ExpectError: regexp.MustCompile(`to_ cannot be less than from_`),
+			},
+			{
+				Config: CreateAccNodeBlockConfig(rName, rName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciNodeBlock_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciNodeBlockDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccNodeBlockConfigMultiple(rName, rName, rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciNodeBlockExists(name string, node_block *models.NodeBlock) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Node Block %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Node Block dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		node_blockFound := models.NodeBlockFromContainerBLK(cont)
+		if node_blockFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Node Block %s not found", rs.Primary.ID)
+		}
+		*node_block = *node_blockFound
+		return nil
+	}
+}
+
+func testAccCheckAciNodeBlockDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing node_block destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_node_block" {
+			cont, err := client.Get(rs.Primary.ID)
+			node_block := models.NodeBlockFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Node Block %s Still exists", node_block.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciNodeBlockIdEqual(m1, m2 *models.NodeBlock) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("node_block DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciNodeBlockIdNotEqual(m1, m2 *models.NodeBlock) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("node_block DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateNodeBlockWithoutRequired(mgmtNodeGrpName, infrazoneNodeGrpName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing node_block creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+
+  	resource "aci_leaf_selector" "test" {
+    	name = "%s"
+    	leaf_profile_dn = aci_leaf_profile.test.id
+    	switch_association_type = "ALL"
+  	}
+	
+	`
+	switch attrName {
+	case "switch_association_dn":
+		rBlock += `
+	resource "aci_node_block" "test" {
+	#	switch_association_dn  = aci_leaf_selector.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_node_block" "test" {
+		switch_association_dn  = aci_leaf_selector.test.id
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, mgmtNodeGrpName, infrazoneNodeGrpName, rName)
+}
+
+func CreateAccNodeBlockConfigWithRequiredParams(prName, rName string) string {
+	fmt.Printf("=== STEP  testing node_block creation with parent resource name %s and resource name %s\n", prName, rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+
+  	resource "aci_leaf_selector" "test" {
+    	name = "%s"
+    	leaf_profile_dn = aci_leaf_profile.test.id
+    	switch_association_type = "ALL"
+  	}
+	
+	resource "aci_node_block" "test" {
+		switch_association_dn  = aci_leaf_selector.test.id
+		name  = "%s"
+	}
+	`, prName, prName, rName)
+	return resource
+}
+func CreateAccNodeBlockConfigUpdatedName(mgmtNodeGrpName, infrazoneNodeGrpName, rName string) string {
+	fmt.Println("=== STEP  testing node_block creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+
+  	resource "aci_leaf_selector" "test" {
+    	name = "%s"
+    	leaf_profile_dn = aci_leaf_profile.test.id
+    	switch_association_type = "ALL"
+  	}
+	
+	resource "aci_node_block" "test" {
+		switch_association_dn  = aci_leaf_selector.test.id
+		name  = "%s"
+	}
+	`, mgmtNodeGrpName, infrazoneNodeGrpName, rName)
+	return resource
+}
+
+func CreateAccNodeBlockConfig(mgmtNodeGrpName, infrazoneNodeGrpName, rName string) string {
+	fmt.Println("=== STEP  testing node_block creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+
+  	resource "aci_leaf_selector" "test" {
+    	name = "%s"
+    	leaf_profile_dn = aci_leaf_profile.test.id
+    	switch_association_type = "ALL"
+  	}
+	
+	resource "aci_node_block" "test" {
+		switch_association_dn  = aci_leaf_selector.test.id
+		name  = "%s"
+	}
+	`, mgmtNodeGrpName, infrazoneNodeGrpName, rName)
+	return resource
+}
+
+func CreateAccNodeBlockConfigMultiple(mgmtNodeGrpName, infrazoneNodeGrpName, rName string) string {
+	fmt.Println("=== STEP  testing multiple node_block creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+
+  	resource "aci_leaf_selector" "test" {
+    	name = "%s"
+    	leaf_profile_dn = aci_leaf_profile.test.id
+    	switch_association_type = "ALL"
+  	}
+	
+	resource "aci_node_block" "test" {
+		switch_association_dn  = aci_leaf_selector.test.id
+		name  = "%s_${count.index}"
+		from_ = (count.index+1)*10
+		to_ = (count.index+1)*10+5
+		count = 5
+	}
+	`, mgmtNodeGrpName, infrazoneNodeGrpName, rName)
+	return resource
+}
+
+func CreateAccNodeBlockWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing node_block creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_node_block" "test" {
+		switch_association_dn  = aci_tenant.test.id
+		name  = "%s"	
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccNodeBlockConfigWithOptionalValues(mgmtNodeGrpName, infrazoneNodeGrpName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing node_block creation with optional parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+
+  	resource "aci_leaf_selector" "test" {
+    	name = "%s"
+    	leaf_profile_dn = aci_leaf_profile.test.id
+    	switch_association_type = "ALL"
+  	}
+	
+	resource "aci_node_block" "test" {
+		switch_association_dn  = "${aci_leaf_selector.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_node_block"
+		from_ = "1600"
+		to_ = "1600"
+		
+	}
+	`, mgmtNodeGrpName, infrazoneNodeGrpName, rName)
+
+	return resource
+}
+
+func CreateAccNodeBlockRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing node_block updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_node_block" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_node_block"
+		from_ = "2"
+		to_ = "2"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccNodeBlockUpdatedAttr(mgmtNodeGrpName, infrazoneNodeGrpName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing node_block attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_profile" "test" {
+		name 		= "%s"
+	
+	}
+
+  	resource "aci_leaf_selector" "test" {
+    	name = "%s"
+    	leaf_profile_dn = aci_leaf_profile.test.id
+    	switch_association_type = "ALL"
+  	}
+	
+	resource "aci_node_block" "test" {
+		switch_association_dn  = aci_leaf_selector.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, mgmtNodeGrpName, infrazoneNodeGrpName, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_infranodep_test.go
+++ b/testacc/resource_aci_infranodep_test.go
@@ -1,0 +1,560 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciLeafProfile_Basic(t *testing.T) {
+	var leaf_profile_default models.LeafProfile
+	var leaf_profile_updated models.LeafProfile
+	resourceName := "aci_leaf_profile.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLeafProfileDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateLeafProfileWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLeafProfileConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLeafProfileExists(resourceName, &leaf_profile_default),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+				),
+			},
+			{
+				Config: CreateAccLeafProfileConfigWithOptionalValuesWithoutSelectorNodeBlock(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLeafProfileExists(resourceName, &leaf_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_leaf_profile"),
+					testAccCheckAciLeafProfileIdEqual(&leaf_profile_default, &leaf_profile_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: CreateAccLeafProfileConfigWithOptionalValues(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLeafProfileExists(resourceName, &leaf_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_leaf_profile"),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.description", ""),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.switch_association_type", "ALL"),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.node_block.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.node_block.0.description", ""),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.node_block.0.from_", "1"),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.node_block.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.node_block.0.to_", "1"),
+					testAccCheckAciLeafProfileIdEqual(&leaf_profile_default, &leaf_profile_updated),
+				),
+			},
+			{
+				Config:      CreateAccLeafProfileRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateAccLeafProfileWithSelectorWithoutName(rName),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateAccLeafProfileWithSelectorWithoutSwitchAssocType(rName),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateAccLeafProfileWithNodeblockWithoutName(rName),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLeafProfileConfigWithOptionalValuesSelectorNodeBlock(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLeafProfileExists(resourceName, &leaf_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_leaf_profile"),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.description", "leaf_selector description"),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.switch_association_type", "range"),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.node_block.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.node_block.0.description", "node_block description"),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.node_block.0.from_", "1600"),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.node_block.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.node_block.0.to_", "1600"),
+					testAccCheckAciLeafProfileIdEqual(&leaf_profile_default, &leaf_profile_updated),
+				),
+			},
+			{
+				Config:      CreateAccLeafProfileConfigWithRequiredParams(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			{
+				Config: CreateAccLeafProfileConfigWithRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLeafProfileExists(resourceName, &leaf_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciLeafProfileIdNotEqual(&leaf_profile_default, &leaf_profile_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciLeafProfile_Update(t *testing.T) {
+	var leaf_profile_default models.LeafProfile
+	var leaf_profile_updated models.LeafProfile
+	resourceName := "aci_leaf_profile.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLeafProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLeafProfileConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLeafProfileExists(resourceName, &leaf_profile_default),
+				),
+			},
+			{
+				Config: CreateAccLeafProfileUpdatedAttrSetSWAssocType(rName, "ALL_IN_POD"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLeafProfileExists(resourceName, &leaf_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.switch_association_type", "ALL_IN_POD"),
+					testAccCheckAciLeafProfileIdEqual(&leaf_profile_default, &leaf_profile_updated),
+				),
+			},
+			{
+				Config: CreateAccLeafProfileUpdatedAttrNode(rName, "to_", "8000"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLeafProfileExists(resourceName, &leaf_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.node_block.0.to_", "8000"),
+					testAccCheckAciLeafProfileIdEqual(&leaf_profile_default, &leaf_profile_updated),
+				),
+			},
+			{
+				Config: CreateAccLeafProfileUpdatedAttrNode(rName, "from_", "8000"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLeafProfileExists(resourceName, &leaf_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "leaf_selector.0.node_block.0.from_", "8000"),
+					testAccCheckAciLeafProfileIdEqual(&leaf_profile_default, &leaf_profile_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciLeafProfile_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLeafProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLeafProfileConfig(rName),
+			},
+			{
+				Config:      CreateAccLeafProfileUpdatedAttr(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLeafProfileUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLeafProfileUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLeafProfileUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccLeafProfileUpdatedAttrLeafSelector(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLeafProfileUpdatedAttrSetSWAssocType(rName, randomValue),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+`),
+			},
+			{
+				Config:      CreateAccLeafProfileUpdatedAttrLeafSelector(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`Unsupported argument`),
+			},
+			{
+				Config:      CreateAccLeafProfileUpdatedAttrNode(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLeafProfileUpdatedAttrNode(rName, "from_", "0"),
+				ExpectError: regexp.MustCompile(`Property (.)+ is out of range`),
+			},
+			{
+				Config:      CreateAccLeafProfileUpdatedAttrNode(rName, "to_", "0"),
+				ExpectError: regexp.MustCompile(`Property (.)+ is out of range`),
+			},
+			{
+				Config:      CreateAccLeafProfileUpdatedAttrNode(rName, "from_", "16001"),
+				ExpectError: regexp.MustCompile(`Property (.)+ is out of range`),
+			},
+			{
+				Config:      CreateAccLeafProfileUpdatedAttrNode(rName, "to_", "16001"),
+				ExpectError: regexp.MustCompile(`Property (.)+ is out of range`),
+			},
+			{
+				Config:      CreateAccLeafProfileUpdatedAttrNode(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`Unsupported argument`),
+			},
+			{
+				Config: CreateAccLeafProfileUpdatedAttrNode(rName, "to_", "100"),
+			},
+			{
+				Config:      CreateAccLeafProfileUpdatedAttrNode(rName, "from_", "200"),
+				ExpectError: regexp.MustCompile(`to_ cannot be less than from_`),
+			},
+		},
+	})
+}
+
+func TestAccAciLeafProfile_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLeafProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLeafProfileConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciLeafProfileExists(name string, leaf_profile *models.LeafProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Leaf Profile %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Leaf Profile dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		leaf_profileFound := models.LeafProfileFromContainer(cont)
+		if leaf_profileFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Leaf Profile %s not found", rs.Primary.ID)
+		}
+		*leaf_profile = *leaf_profileFound
+		return nil
+	}
+}
+
+func testAccCheckAciLeafProfileDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing leaf_profile destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_leaf_profile" {
+			cont, err := client.Get(rs.Primary.ID)
+			leaf_profile := models.LeafProfileFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Leaf Profile %s Still exists", leaf_profile.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciLeafProfileIdEqual(m1, m2 *models.LeafProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("leaf_profile DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciLeafProfileIdNotEqual(m1, m2 *models.LeafProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("leaf_profile DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateAccLeafProfileConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple leaf_profile creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_leaf_profile" "test" {
+	
+		name  = "%s_${count.index}"
+		
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+func CreateLeafProfileWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing leaf_profile creation without ", attrName)
+	rBlock := `
+
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_leaf_profile" "test" {
+
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccLeafProfileConfigWithRequiredParams(rName string) string {
+	fmt.Println("=== STEP  testing leaf_profile creation with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_leaf_profile" "test" {
+
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLeafProfileConfig(rName string) string {
+	fmt.Println("=== STEP  testing leaf_profile creation with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_leaf_profile" "test" {
+
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLeafProfileConfigWithOptionalValuesWithoutSelectorNodeBlock(rName string) string {
+	fmt.Println("=== STEP  Basic: testing leaf_profile creation with optional parameters of leaf_profile")
+	resource := fmt.Sprintf(`
+
+	resource "aci_leaf_profile" "test" {
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_leaf_profile"
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccLeafProfileConfigWithOptionalValuesSelectorNodeBlock(rName string) string {
+	fmt.Println("=== STEP  Basic: testing leaf_profile creation with optional parameters of leaf_selector and node block")
+	resource := fmt.Sprintf(`
+
+	resource "aci_leaf_profile" "test" {
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_leaf_profile"
+		leaf_selector {
+			name = "%s"
+			switch_association_type = "range"
+			description = "leaf_selector description"
+			node_block {
+				name = "%s"
+				from_ = "1600"
+				to_ = "1600"
+				description = "node_block description"
+			}
+		}
+	}
+	`, rName, rName, rName)
+
+	return resource
+}
+
+func CreateAccLeafProfileConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing leaf_profile creation with optional parameters")
+	resource := fmt.Sprintf(`
+
+	resource "aci_leaf_profile" "test" {
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_leaf_profile"
+		leaf_selector {
+			name = "%s"
+			switch_association_type = "ALL"
+			node_block {
+				name = "%s"
+			}
+		}
+	}
+	`, rName, rName, rName)
+
+	return resource
+}
+
+func CreateAccLeafProfileWithNodeblockWithoutName(rName string) string {
+	fmt.Println("=== STEP  Basic: testing leaf_profile without leaf_selector's switch_association_type")
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_profile" "test" {
+		name = "%s"
+		leaf_selector {
+			name = "%s"
+			switch_association_type = "ALL"
+			node_block {
+			}
+		}
+	}
+	`, rName, rName)
+
+	return resource
+}
+
+func CreateAccLeafProfileWithSelectorWithoutSwitchAssocType(rName string) string {
+	fmt.Println("=== STEP  Basic: testing leaf_profile without leaf_selector's switch_association_type")
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_profile" "test" {
+		name = "%s"
+		leaf_selector {
+			name = "%s"
+		}
+	}
+	`, rName, rName)
+
+	return resource
+}
+
+func CreateAccLeafProfileWithSelectorWithoutName(rName string) string {
+	fmt.Println("=== STEP  Basic: testing leaf_profile without leaf_selector's name")
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_profile" "test" {
+		name = "%s"
+		leaf_selector {
+			switch_association_type = "ALL"
+		}
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccLeafProfileRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing leaf_profile update without required parameters")
+	resource := fmt.Sprintln(`
+	resource "aci_leaf_profile" "test" {
+		description = "created while acceptance testing"
+		annotation = "tag"
+		name_alias = "test_leaf_profile"
+
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccLeafProfileUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing leaf_profile attribute: %s=%s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_profile" "test" {
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName, attribute, value)
+	return resource
+}
+
+func CreateAccLeafProfileUpdatedAttrLeafSelector(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing leaf_profile's leaf_selector attribute: %s=%s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_profile" "test" {
+		name  = "%s"
+		leaf_selector {
+			name = "%s"
+			switch_association_type = "range"
+			%s = "%s"
+		}
+	}
+	`, rName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccLeafProfileUpdatedAttrSetSWAssocType(rName, swtype string) string {
+	fmt.Printf("=== STEP  testing leaf_profile's leaf_selector for switch_association_type = %s\n", swtype)
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_profile" "test" {
+		name  = "%s"
+		leaf_selector {
+			name = "%s"
+			switch_association_type = "%s"
+		}
+	}
+	`, rName, rName, swtype)
+	return resource
+}
+
+func CreateAccLeafProfileUpdatedAttrNode(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing leaf_profile's node_block attribute: %s=%s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_leaf_profile" "test" {
+		name  = "%s"
+		leaf_selector {
+			name = "%s"
+			switch_association_type = "range"
+			node_block {
+				name = "%s"
+				%s = "%s"
+			}
+		}
+	}
+	`, rName, rName, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_infrasubportblk_test.go
+++ b/testacc/resource_aci_infrasubportblk_test.go
@@ -428,7 +428,6 @@ func CreateAccessSubPortBlockWithoutRequired(infraAccPortPName, infraHPortSName,
 	return fmt.Sprintf(rBlock, infraAccPortPName, infraHPortSName, rName)
 }
 
-
 func CreateAccAccessSubPortBlockUpdatedPortAttr(infraAccPortPName, infraHPortSName, rName, from, to string) string {
 	fmt.Printf("=== STEP  testing access_sub_port_block  from_port = \"%s\" and to_port = \"%s\" \n", from, to)
 	resource := fmt.Sprintf(`

--- a/testacc/resource_aci_l3extrsnodel3outatt_test.go
+++ b/testacc/resource_aci_l3extrsnodel3outatt_test.go
@@ -1,0 +1,484 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const fabDn2 = "topology/pod-1/node-201"
+const fabDn3 = "topology/pod-1/node-111"
+const fabDn4 = "topology/pod-1/node-1"
+
+func TestAccAciFabricNode_Basic(t *testing.T) {
+	var fabric_node_default models.FabricNode
+	var fabric_node_updated models.FabricNode
+	resourceName := "aci_logical_node_to_fabric_node.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	rtrid, _ := acctest.RandIpAddress("10.2.0.0/16")
+	rtridOther, _ := acctest.RandIpAddress("10.3.0.0/16")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFabricNodeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateFabricNodeWithoutRequired(rName, rName, rName, fabDn2, "logical_node_profile_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateFabricNodeWithoutRequired(rName, rName, rName, fabDn2, "tdn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccFabricNodeConfig(rName, rName, rName, fabDn2, rtrid),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeExists(resourceName, &fabric_node_default),
+					resource.TestCheckResourceAttr(resourceName, "logical_node_profile_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s", rName, rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "tdn", fabDn2),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "config_issues", "none"),
+					resource.TestCheckResourceAttr(resourceName, "rtr_id", rtrid),
+					resource.TestCheckResourceAttr(resourceName, "rtr_id_loop_back", "yes"),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeConfigWithOptionalValues(rName, rName, rName, fabDn2, rtridOther),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeExists(resourceName, &fabric_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "logical_node_profile_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s", rName, rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "tdn", fabDn2),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "config_issues", "anchor-node-mismatch"),
+					resource.TestCheckResourceAttr(resourceName, "rtr_id", rtridOther),
+					resource.TestCheckResourceAttr(resourceName, "rtr_id_loop_back", "no"),
+					testAccCheckAciFabricNodeIdEqual(&fabric_node_default, &fabric_node_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+			{
+				Config:      CreateAccFabricNodeRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccFabricNodeUpdatedAttr(rName, rName, rName, fabDn2, rtrid, "config_issues", "bd-profile-missmatch"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeExists(resourceName, &fabric_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "config_issues", "bd-profile-missmatch"),
+					testAccCheckAciFabricNodeIdEqual(&fabric_node_default, &fabric_node_updated),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeUpdatedAttr(rName, rName, rName, fabDn2, rtrid, "config_issues", "loopback-ip-missing"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeExists(resourceName, &fabric_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "config_issues", "loopback-ip-missing"),
+					testAccCheckAciFabricNodeIdEqual(&fabric_node_default, &fabric_node_updated),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeUpdatedAttr(rName, rName, rName, fabDn2, rtrid, "config_issues", "missing-mpls-infra-l3out"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeExists(resourceName, &fabric_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "config_issues", "missing-mpls-infra-l3out"),
+					testAccCheckAciFabricNodeIdEqual(&fabric_node_default, &fabric_node_updated),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeUpdatedAttr(rName, rName, rName, fabDn2, rtrid, "config_issues", "missing-rs-export-route-profile"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeExists(resourceName, &fabric_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "config_issues", "missing-rs-export-route-profile"),
+					testAccCheckAciFabricNodeIdEqual(&fabric_node_default, &fabric_node_updated),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeUpdatedAttr(rName, rName, rName, fabDn2, rtrid, "config_issues", "node-path-misconfig"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeExists(resourceName, &fabric_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "config_issues", "node-path-misconfig"),
+					testAccCheckAciFabricNodeIdEqual(&fabric_node_default, &fabric_node_updated),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeUpdatedAttr(rName, rName, rName, fabDn2, rtrid, "config_issues", "node-vlif-misconfig"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeExists(resourceName, &fabric_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "config_issues", "node-vlif-misconfig"),
+					testAccCheckAciFabricNodeIdEqual(&fabric_node_default, &fabric_node_updated),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeUpdatedAttr(rName, rName, rName, fabDn2, rtrid, "config_issues", "routerid-not-changable-with-mcast"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeExists(resourceName, &fabric_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "config_issues", "routerid-not-changable-with-mcast"),
+					testAccCheckAciFabricNodeIdEqual(&fabric_node_default, &fabric_node_updated),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeUpdatedAttr(rName, rName, rName, fabDn2, rtrid, "config_issues", "subnet-mismatch"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeExists(resourceName, &fabric_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "config_issues", "subnet-mismatch"),
+					testAccCheckAciFabricNodeIdEqual(&fabric_node_default, &fabric_node_updated),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeConfigWithRequiredParams(rNameUpdated, fabDn2, rtrid),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeExists(resourceName, &fabric_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "logical_node_profile_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s", rNameUpdated, rNameUpdated, rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "tdn", fabDn2),
+					testAccCheckAciFabricNodeIdNotEqual(&fabric_node_default, &fabric_node_updated),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeConfig(rName, rName, rName, fabDn2, rtrid),
+			},
+			{
+				Config: CreateAccFabricNodeConfigWithRequiredParams(rName, fabDn3, rtrid),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeExists(resourceName, &fabric_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "logical_node_profile_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s", rName, rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "tdn", fabDn3),
+					testAccCheckAciFabricNodeIdNotEqual(&fabric_node_default, &fabric_node_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciFabricNode_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	rtrid, _ := acctest.RandIpAddress("10.5.0.0/16")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFabricNodeDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccFabricNodeConfig(rName, rName, rName, fabDn4, rtrid),
+			},
+			{
+				Config:      CreateAccFabricNodeWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccFabricNodeUpdatedAttr(rName, rName, rName, fabDn4, rtrid, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccFabricNodeUpdatedAttr(rName, rName, rName, fabDn4, rtrid, "config_issues", randomValue),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccFabricNodeWithInvalidRtr(rName, rName, rName, fabDn4, randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccFabricNodeUpdatedAttr(rName, rName, rName, fabDn4, rtrid, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccFabricNodeUpdatedAttr(rName, rName, rName, fabDn4, rtrid, "rtr_id_loop_back", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config: CreateAccFabricNodeConfig(rName, rName, rName, fabDn4, rtrid),
+			},
+		},
+	})
+}
+
+func testAccCheckAciFabricNodeExists(name string, logical_node_to_fabric_node *models.FabricNode) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Fabric Node %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Fabric Node dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		fabric_nodeFound := models.FabricNodeFromContainer(cont)
+		if fabric_nodeFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Fabric Node %s not found", rs.Primary.ID)
+		}
+		*logical_node_to_fabric_node = *fabric_nodeFound
+		return nil
+	}
+}
+
+func testAccCheckAciFabricNodeDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing logical_node_to_fabric_node destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_logical_node_to_fabric_node" {
+			cont, err := client.Get(rs.Primary.ID)
+			logical_node_to_fabric_node := models.FabricNodeFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Fabric Node %s Still exists", logical_node_to_fabric_node.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciFabricNodeIdEqual(m1, m2 *models.FabricNode) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("logical_node_to_fabric_node DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciFabricNodeIdNotEqual(m1, m2 *models.FabricNode) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("logical_node_to_fabric_node DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateFabricNodeWithoutRequired(fvTenantName, l3extOutName, l3extLNodePName, tDn, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing logical_node_to_fabric_node creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	`
+	switch attrName {
+	case "logical_node_profile_dn":
+		rBlock += `
+	resource "aci_logical_node_to_fabric_node" "test" {
+	#	logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+	}
+		`
+	case "tdn":
+		rBlock += `
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+	#	tdn  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, l3extOutName, l3extLNodePName, tDn)
+}
+
+func CreateAccFabricNodeConfigWithRequiredParams(prName, tDn, ip string) string {
+	fmt.Printf("=== STEP  testing logical_node_to_fabric_node creation with parent resource name %s and tdn %s\n", prName, tDn)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+	}
+	`, prName, prName, prName, tDn, ip)
+	return resource
+}
+
+func CreateAccFabricNodeConfig(fvTenantName, l3extOutName, l3extLNodePName, tDn, ip string) string {
+	fmt.Println("=== STEP  testing logical_node_to_fabric_node creation with required arguments and rtr_id")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, tDn, ip)
+	return resource
+}
+
+func CreateAccFabricNodeWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing logical_node_to_fabric_node creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_tenant.test.id
+		tdn  = aci_tenant.test.id
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccFabricNodeConfigWithOptionalValues(fvTenantName, l3extOutName, l3extLNodePName, tDn, ip string) string {
+	fmt.Println("=== STEP  Basic: testing logical_node_to_fabric_node creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = "${aci_logical_node_profile.test.id}"
+		tdn  = "%s"
+		annotation = "orchestrator:terraform_testacc"
+		config_issues = "anchor-node-mismatch"
+		rtr_id = "%s"
+		rtr_id_loop_back = "no"
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, tDn, ip)
+
+	return resource
+}
+
+func CreateAccFabricNodeRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing logical_node_to_fabric_node updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_logical_node_to_fabric_node" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_fabric_node"
+		config_issues = ["anchor-node-mismatch"]
+		rtr_id = ""
+		rtr_id_loop_back = "no"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccFabricNodeWithInvalidRtr(fvTenantName, l3extOutName, l3extLNodePName, tDn, value string) string {
+	fmt.Println("=== STEP  testing logical_node_to_fabric_node attribute: rtr_id =", value)
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, tDn, value)
+	return resource
+}
+
+func CreateAccFabricNodeUpdatedAttr(fvTenantName, l3extOutName, l3extLNodePName, tDn, ip, attribute, value string) string {
+	fmt.Printf("=== STEP  testing logical_node_to_fabric_node attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+		%s = "%s"
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, tDn, ip, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_vmmusraccp_test.go
+++ b/testacc/resource_aci_vmmusraccp_test.go
@@ -358,7 +358,7 @@ func CreateAccVMMCredentialConfigWithOptionalValues(vmmDomPName, rName string) s
 }
 
 func CreateAccVMMCredentialRemovingRequiredField() string {
-	fmt.Println("=== STEP  Basic: testing vmm_credential updation with required parameters")
+	fmt.Println("=== STEP  Basic: testing vmm_credential updation without required parameters")
 	resource := fmt.Sprintf(`
 	resource "aci_vmm_credential" "test" {
 		description = "created while acceptance testing"

--- a/website/docs/d/cloud_context_profile.html.markdown
+++ b/website/docs/d/cloud_context_profile.html.markdown
@@ -33,3 +33,6 @@ data "aci_cloud_context_profile" "sample_prof" {
 - `id` - Attribute id set to the Dn of the Cloud Context profile.
 - `description` - Description of object Cloud Context profile.
 - `annotation` - Annotation for object Cloud Context profile.
+- `type` - The specific type of the object or component. Allowed values are "regular", "shadow", "hosted" and "container-overlay". Default is "regular".
+- `primary_cidr` - Primary CIDR block of Cloud Context profile. 
+- `region` - AWS region in which profile is created.

--- a/website/docs/r/leaf_profile.html.markdown
+++ b/website/docs/r/leaf_profile.html.markdown
@@ -56,11 +56,13 @@ resource "aci_leaf_profile" "example" {
 
 - `leaf_selector` - (Optional) Leaf Selector block to attach with the leaf profile.
 - `leaf_selector.name` - (Required) Name of the leaf selector.
+- `leaf_selector.description` - (Required) Description of the leaf selector.
 - `leaf_selector.switch_association_type` - (Required) Type of switch association.
   Allowed values: "ALL", "range", "ALL_IN_POD"
 
 - `leaf_selector.node_block` - (Optional) Node block to attach with leaf selector.
 - `leaf_selector.node_block.name` - (Required) Name of the node block.
+- `leaf_selector.node_block.description` - (Required) Description of the node block.
 - `leaf_selector.node_block.from_` - (Optional) Start of Node Block range. Range from 1 to 16000. Default value is "1".
 - `leaf_selector.node_block.to_` - (Optional) End of Node Block range. Range from 1 to 16000. Default value is "1".
 


### PR DESCRIPTION
$ go test -v -run TestAccAciFabricNode -timeout=60m
=== RUN   TestAccAciFabricNodeDataSource_Basic
=== STEP  Basic: testing fabric_node Data Source without  logical_node_profile_dn
=== STEP  Basic: testing fabric_node Data Source without  tdn
=== STEP  testing fabric_node Data Source with required arguments only
=== STEP  testing fabric_node Data Source with random attribute
=== STEP  testing fabric_node Data Source with Invalid Parent Dn
=== STEP  testing fabric_node Data Source with updated resource
=== PAUSE TestAccAciFabricNodeDataSource_Basic
=== RUN   TestAccAciFabricNode_Basic
=== STEP  Basic: testing logical_node_to_fabric_node creation without  logical_node_profile_dn
=== STEP  Basic: testing logical_node_to_fabric_node creation without  tdn
=== STEP  testing logical_node_to_fabric_node creation with required arguments and rtr_id
=== STEP  Basic: testing logical_node_to_fabric_node creation with optional parameters
=== STEP  Basic: testing logical_node_to_fabric_node updation without required parameters
=== STEP  testing logical_node_to_fabric_node attribute: config_issues = bd-profile-missmatch
=== STEP  testing logical_node_to_fabric_node attribute: config_issues = loopback-ip-missing
=== STEP  testing logical_node_to_fabric_node attribute: config_issues = missing-mpls-infra-l3out
=== STEP  testing logical_node_to_fabric_node attribute: config_issues = missing-rs-export-route-profile
=== STEP  testing logical_node_to_fabric_node attribute: config_issues = node-path-misconfig
=== STEP  testing logical_node_to_fabric_node attribute: config_issues = node-vlif-misconfig
=== STEP  testing logical_node_to_fabric_node attribute: config_issues = routerid-not-changable-with-mcast
=== STEP  testing logical_node_to_fabric_node attribute: config_issues = subnet-mismatch
=== STEP  testing logical_node_to_fabric_node creation with parent resource name acctest_d6xge and tdn topology/pod-1/node-201
=== STEP  testing logical_node_to_fabric_node creation with required arguments and rtr_id
=== STEP  testing logical_node_to_fabric_node creation with parent resource name acctest_f1rsr and tdn topology/pod-1/node-111
=== PAUSE TestAccAciFabricNode_Basic
=== RUN   TestAccAciFabricNode_Negative
=== STEP  testing logical_node_to_fabric_node creation with required arguments and rtr_id
=== STEP  Negative Case: testing logical_node_to_fabric_node creation with invalid parent Dn
=== STEP  testing logical_node_to_fabric_node attribute: annotation = zcvu0h26qzv4aezqe3vzjgd2xiwfg7ncneqe8xv1yj0un979qhjodlqkcd2b2l9pm9dgdiaeobumvvo4y8rzd2agsjpcaehrgvewugpbnsyx6tlmkmnuyijie23xyerpb
=== STEP  testing logical_node_to_fabric_node attribute: config_issues = 10qtq
=== STEP  testing logical_node_to_fabric_node attribute: rtr_id = 10qtq
=== STEP  testing logical_node_to_fabric_node attribute: qxyfz = 10qtq
=== STEP  testing logical_node_to_fabric_node attribute: rtr_id_loop_back = 10qtq
=== STEP  testing logical_node_to_fabric_node creation with required arguments and rtr_id
=== PAUSE TestAccAciFabricNode_Negative
=== CONT  TestAccAciFabricNodeDataSource_Basic
=== CONT  TestAccAciFabricNode_Negative
=== CONT  TestAccAciFabricNode_Basic
=== STEP  testing logical_node_to_fabric_node destroy
--- PASS: TestAccAciFabricNodeDataSource_Basic (41.13s)
=== STEP  testing logical_node_to_fabric_node destroy
--- PASS: TestAccAciFabricNode_Negative (60.94s)
=== STEP  testing logical_node_to_fabric_node destroy
--- PASS: TestAccAciFabricNode_Basic (170.08s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   171.423s
$ go test -v -run TestAccAciNodeBlock -timeout=60m
=== RUN   TestAccAciNodeBlockDataSource_Basic
=== STEP  Basic: testing node_block Data Source without  switch_association_dn
=== STEP  Basic: testing node_block Data Source without  name
=== STEP  testing node_block Data Source with required arguments only
=== STEP  testing node_block Data Source with random attribute
=== STEP  testing node_block Data Source with invalid name
=== STEP  testing node_block Data Source with updated resource
=== PAUSE TestAccAciNodeBlockDataSource_Basic
=== RUN   TestAccAciNodeBlock_Basic
=== STEP  Basic: testing node_block creation without  switch_association_dn
=== STEP  Basic: testing node_block creation without  name
=== STEP  testing node_block creation with required arguments only
=== STEP  Basic: testing node_block creation with optional parameters
=== STEP  testing node_block creation with invalid name =  zih02h2zkbw4ixbwdn2x9qqzvmuldl0kx77tjss74m7bz8ix422vnmbxs34jl4bpo
=== STEP  Basic: testing node_block updation without required parameters
=== STEP  testing node_block creation with parent resource name acctest_uahtz and resource name acctest_78ate
=== STEP  testing node_block creation with required arguments only
=== STEP  testing node_block creation with parent resource name acctest_78ate and resource name acctest_uahtz
=== PAUSE TestAccAciNodeBlock_Basic
=== RUN   TestAccAciNodeBlock_Update
=== STEP  testing node_block creation with required arguments only
=== STEP  testing node_block attribute: to_ = 8000
=== STEP  testing node_block attribute: from_ = 8000
=== PAUSE TestAccAciNodeBlock_Update
=== RUN   TestAccAciNodeBlock_Negative
=== STEP  testing node_block creation with required arguments only
=== STEP  Negative Case: testing node_block creation with invalid parent Dn
=== STEP  testing node_block attribute: description = s044nuc8fo2hnukpiequa2z9bauzkng1benbb09i2cck3povdjx349bxp6hfo7thl6w4pixgajw6by2gxrojrur82dvyyn9kzqeg26qf76qj2lopav0b4gv0bx4w3ekur
=== STEP  testing node_block attribute: annotation = wf66p9dc3x0qyibpioiodpfi6yc38ql3fanynblm0ijb1assmx39noo76ps47bpxaok8zhdgi1bfyiepvwdzl0ivuewku4kztm6d1panrge7aplnrt4hnh6pikfldlv1p
=== STEP  testing node_block attribute: name_alias = tx3vi913i4ntv6xnq6thmbz93hpie1o6aql9d2d8fzjdlx346vdc6dqvfh4hzxz7
=== STEP  testing node_block attribute: from_ = 0
=== STEP  testing node_block attribute: from_ = 16001
=== STEP  testing node_block attribute: to_ = 0
=== STEP  testing node_block attribute: to_ = 16001
=== STEP  testing node_block attribute: eiwmv = grtce
=== STEP  testing node_block attribute: to_ = 100
=== STEP  testing node_block attribute: from_ = 200
=== STEP  testing node_block creation with required arguments only
=== PAUSE TestAccAciNodeBlock_Negative
=== RUN   TestAccAciNodeBlock_MultipleCreateDelete
=== STEP  testing multiple node_block creation with required arguments only
=== PAUSE TestAccAciNodeBlock_MultipleCreateDelete
=== CONT  TestAccAciNodeBlockDataSource_Basic
=== CONT  TestAccAciNodeBlock_Negative
=== CONT  TestAccAciNodeBlock_Update
=== CONT  TestAccAciNodeBlock_Basic
=== CONT  TestAccAciNodeBlock_MultipleCreateDelete
=== STEP  testing node_block destroy
--- PASS: TestAccAciNodeBlock_MultipleCreateDelete (31.57s)
=== STEP  testing node_block destroy
--- PASS: TestAccAciNodeBlockDataSource_Basic (65.01s)
=== STEP  testing node_block destroy
--- PASS: TestAccAciNodeBlock_Update (66.53s)
=== STEP  testing node_block destroy
--- PASS: TestAccAciNodeBlock_Basic (122.94s)
=== STEP  testing node_block destroy
--- PASS: TestAccAciNodeBlock_Negative (143.98s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   147.320s
$ go test -v -run TestAccAciLeafProfile -timeout=60m
=== RUN   TestAccAciLeafProfileDataSource_Basic
=== STEP  Basic: testing leaf_profile Data Source without  name
=== STEP  testing leaf_profile Data Source with required arguments only
=== STEP  testing leaf_profile Data Source with random attribute
=== STEP  testing leaf_profile Data Source with invalid name
=== STEP  testing leaf_profile Data Source with updated resource
=== PAUSE TestAccAciLeafProfileDataSource_Basic
=== RUN   TestAccAciLeafProfile_Basic
=== STEP  Basic: testing leaf_profile creation without  name
=== STEP  testing leaf_profile creation with required arguments only
=== STEP  Basic: testing leaf_profile creation with optional parameters of leaf_profile
=== STEP  Basic: testing leaf_profile creation with optional parameters
=== STEP  Basic: testing leaf_profile update without required parameters
=== STEP  Basic: testing leaf_profile without leaf_selector's name
=== STEP  Basic: testing leaf_profile without leaf_selector's switch_association_type
=== STEP  Basic: testing leaf_profile without leaf_selector's switch_association_type
=== STEP  Basic: testing leaf_profile creation with optional parameters of leaf_selector and node block
=== STEP  testing leaf_profile creation with required arguments only
=== STEP  testing leaf_profile creation with required arguments only
=== PAUSE TestAccAciLeafProfile_Basic
=== RUN   TestAccAciLeafProfile_Update
=== STEP  testing leaf_profile creation with required arguments only
=== STEP  testing leaf_profile's leaf_selector for switch_association_type = ALL_IN_POD
=== STEP  testing leaf_profile's node_block attribute: to_=8000
=== STEP  testing leaf_profile's node_block attribute: from_=8000
=== PAUSE TestAccAciLeafProfile_Update
=== RUN   TestAccAciLeafProfile_Negative
=== STEP  testing leaf_profile creation with required arguments only
=== STEP  testing leaf_profile attribute: description=ao8ob9x3lni6h06fxq9tn3b3r0t82gpa73nkjelf8g7atqzh3o2ifgesadca39bb0nrqwigsz9ubqda2bt0ug7mw1tr93kkmgvjs31bspylsgar30mk2s4bk9ndc9yg7v
=== STEP  testing leaf_profile attribute: annotation=43exgt7jnvze3rwbt7e6l3frcub9zeuhipem39r8762sp1zjw6qeyeqkju3zek989hv2ifra0d1fzl6zpdmbyg7wezlqp4hr1l14rivhow4qkf7fafc1pmtm9f3tugswe
=== STEP  testing leaf_profile attribute: name_alias=npel1m6n3i4qt82urh6vrm6oythydhep4pvpy4zgj8ivmaaxwwpj2ndy9osowxle
=== STEP  testing leaf_profile attribute: edbpx=acctest_8otyc
=== STEP  testing leaf_profile's leaf_selector attribute: description=fh6f4hcax7b2maqikhuh7h47keuwczf6h39b0mt2zhq3umlxhpfdaqk7ca7ug9q91ppdntizdohe19rnrm90kjz6adrz2j7j6ws0qxulckbfbbf6tf211twwi91ychj96
=== STEP  testing leaf_profile's leaf_selector for switch_association_type = acctest_8otyc
=== STEP  testing leaf_profile's leaf_selector attribute: edbpx=acctest_8otyc
=== STEP  testing leaf_profile's node_block attribute: description=inilv0jijrlf4am6cwaeggsixeuf3qb9zpadiveip1z9cio4bep2r8ccf3397126dj7h2h7eh2v2rhylr2h2ngfpj8zs8w8swo2muagmmlps8ax6b0eewoyyw9nqlg2bp
=== STEP  testing leaf_profile's node_block attribute: from_=0
=== STEP  testing leaf_profile's node_block attribute: to_=0
=== STEP  testing leaf_profile's node_block attribute: from_=16001
=== STEP  testing leaf_profile's node_block attribute: to_=16001
=== STEP  testing leaf_profile's node_block attribute: edbpx=acctest_8otyc
=== STEP  testing leaf_profile's node_block attribute: to_=100
=== STEP  testing leaf_profile's node_block attribute: from_=200
=== PAUSE TestAccAciLeafProfile_Negative
=== RUN   TestAccAciLeafProfile_MultipleCreateDelete
=== STEP  testing multiple leaf_profile creation with required arguments only
=== PAUSE TestAccAciLeafProfile_MultipleCreateDelete
=== CONT  TestAccAciLeafProfileDataSource_Basic
=== CONT  TestAccAciLeafProfile_Negative
=== CONT  TestAccAciLeafProfile_Basic
=== CONT  TestAccAciLeafProfile_Update
=== CONT  TestAccAciLeafProfile_MultipleCreateDelete
=== STEP  testing leaf_profile destroy
--- PASS: TestAccAciLeafProfile_MultipleCreateDelete (28.04s)
=== STEP  testing leaf_profile destroy
--- PASS: TestAccAciLeafProfileDataSource_Basic (51.22s)
=== STEP  testing leaf_profile destroy
--- PASS: TestAccAciLeafProfile_Update (81.30s)
=== STEP  testing leaf_profile destroy
--- PASS: TestAccAciLeafProfile_Basic (114.34s)
=== STEP  testing leaf_profile destroy
--- PASS: TestAccAciLeafProfile_Negative (119.90s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   123.047s
$ go test -v -run TestAccAciSwitchAssociation -timeout=60m
=== RUN   TestAccAciSwitchAssociationDataSource_Basic
=== STEP  Basic: testing switch_association Data Source without  leaf_profile_dn
=== STEP  Basic: testing switch_association Data Source without  name
=== STEP  Basic: testing switch_association Data Source without  switch_association_type
=== STEP  testing switch_association Data Source with required arguments only
=== STEP  testing switch_association Data Source with random attribute
=== STEP  testing switch_association Data Source with invalid name
=== STEP  testing switch_association Data Source with updated resource
=== PAUSE TestAccAciSwitchAssociationDataSource_Basic
=== RUN   TestAccAciSwitchAssociation_Basic
=== STEP  Basic: testing leaf_selector creation without  leaf_profile_dn
=== STEP  Basic: testing leaf_selector creation without  name
=== STEP  Basic: testing leaf_selector creation without  switch_association_type
=== STEP  testing leaf_selector creation with required arguments only
=== STEP  Basic: testing leaf_selector creation with optional parameters
=== STEP  testing leaf_selector creation with invalid name =  u9i1zfqkb0kpgrgwrtv36nq8j0rzxq4s8zccnrlj8a8bfdqz8zns4mnq4vgf64a8z
=== STEP  Basic: testing leaf_selector updation without required parameters
=== STEP  testing leaf_selector creation with parent resource name acctest_hpd92, resource name acctest_fmcy1 and switch_association_type ALL
=== STEP  testing leaf_selector creation with required arguments only
=== STEP  testing leaf_selector creation with parent resource name acctest_fmcy1, resource name acctest_hpd92 and switch_association_type ALL
=== STEP  testing leaf_selector creation with required arguments only
=== STEP  testing leaf_selector creation with parent resource name acctest_fmcy1, resource name acctest_fmcy1 and switch_association_type range
=== PAUSE TestAccAciSwitchAssociation_Basic
=== RUN   TestAccAciSwitchAssociation_Update
=== STEP  testing leaf_selector creation with required arguments only
=== PAUSE TestAccAciSwitchAssociation_Update
=== RUN   TestAccAciSwitchAssociation_Negative
=== STEP  testing leaf_selector creation with required arguments only
=== STEP  testing leaf_selector creation with required arguments only
=== STEP  Negative Case: testing leaf_selector creation with invalid parent Dn
=== STEP  testing leaf_selector attribute: description = ps1ajx7etcmiodpo7yuqwmezwfca4rf9tuk93xwblqi8cyc47dwkwxentkhmfx89z3zgmzaap6ctch6agj3tfeubcnu2rbjaisscdubrv1gxfj6mjugepv3v9f6r3fgi6
=== STEP  testing leaf_selector attribute: annotation = 7rtkkydtlt9e2hck42aute6f4kw0nubtry9f9z9swseo6gb7zz9tdtqrgm4kcpy24ghw967rcj3rw0q1jli7wqruz8etb4z1bs8kuzwbcmrx7n41qyqv20kguqndczgpu
=== STEP  testing leaf_selector attribute: name_alias = zt7vp0c4he6q9abyaa3z0azxzz7hyprv9kn046nnhvh070qkribn8lmqqd3hpohp
=== STEP  testing leaf_selector attribute: yekaj = js9yw
=== STEP  testing leaf_selector creation with required arguments only
=== PAUSE TestAccAciSwitchAssociation_Negative
=== RUN   TestAccAciSwitchAssociation_MultipleCreateDelete
=== STEP  testing multiple leaf_selector creation with required arguments only
=== PAUSE TestAccAciSwitchAssociation_MultipleCreateDelete
=== CONT  TestAccAciSwitchAssociationDataSource_Basic
=== CONT  TestAccAciSwitchAssociation_Negative
=== CONT  TestAccAciSwitchAssociation_Update
=== CONT  TestAccAciSwitchAssociation_MultipleCreateDelete
=== CONT  TestAccAciSwitchAssociation_Basic
=== STEP  testing leaf_selector destroy
=== STEP  testing leaf_selector destroy
--- PASS: TestAccAciSwitchAssociation_Update (29.50s)
--- PASS: TestAccAciSwitchAssociation_MultipleCreateDelete (30.88s)
=== STEP  testing leaf_selector destroy
--- PASS: TestAccAciSwitchAssociationDataSource_Basic (55.93s)
=== STEP  testing leaf_selector destroy
--- PASS: TestAccAciSwitchAssociation_Negative (78.97s)
=== STEP  testing leaf_selector destroy
--- PASS: TestAccAciSwitchAssociation_Basic (140.80s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   143.670s
$ go test -v -run TestAccAciCloudEPg -timeout=60m
=== RUN   TestAccAciCloudEPgDataSource_Basic
=== STEP  Basic: testing cloud_epg Data Source without  cloud_applicationcontainer_dn
=== STEP  Basic: testing cloud_epg Data Source without  name
=== STEP  testing cloud_epg Data Source with required arguments only
=== STEP  testing cloud_epg Data Source with random attribute
=== STEP  testing cloud_epg Data Source with invalid name
=== STEP  testing cloud_epg Data Source with updated resource
=== PAUSE TestAccAciCloudEPgDataSource_Basic
=== RUN   TestAccAciCloudEPg_Basic
=== STEP  Basic: testing cloud_epg creation without  cloud_applicationcontainer_dn
=== STEP  Basic: testing cloud_epg creation without  name
=== STEP  testing cloud_epg creation with required arguments only
=== STEP  Basic: testing cloud_epg creation with optional parameters
=== STEP  testing cloud_epg creation with invalid name =  gzezpm6aqilo628qekhrx2a1xtrn94a9r9ijrrswgp3ip46ed2mnjj3tirg4axb34
=== STEP  Basic: testing cloud_epg updation without required parameters
=== STEP  testing cloud_epg creation with parent resource name acctest_4tk8n and resource name acctest_tn6xc
=== STEP  testing cloud_epg creation with required arguments only
=== STEP  testing cloud_epg creation with parent resource name acctest_tn6xc and resource name acctest_4tk8n
=== PAUSE TestAccAciCloudEPg_Basic
=== RUN   TestAccAciCloudEPg_Update
=== STEP  testing cloud_epg creation with required arguments only
=== STEP  testing cloud_epg attribute: match_t = AtmostOne
=== STEP  testing cloud_epg attribute: match_t = None
=== STEP  testing cloud_epg attribute: prio = level2
=== STEP  testing cloud_epg attribute: prio = level3
=== STEP  testing cloud_epg attribute: prio = level4
=== STEP  testing cloud_epg attribute: prio = level5
=== STEP  testing cloud_epg attribute: prio = level6
=== STEP  testing cloud_epg creation with required arguments only
=== PAUSE TestAccAciCloudEPg_Update
=== RUN   TestAccAciCloudEPg_Negative
=== STEP  testing cloud_epg creation with required arguments only
=== STEP  Negative Case: testing cloud_epg creation with invalid parent Dn
=== STEP  testing cloud_epg attribute: description = yuza1skt4o0s691s7wi1wugma6yy0qlypd8cd9eblwsbmn7c6f32px0dedveueg8l1wden4b8dhng16g83qcocqif89skmc1pcvbva3s6lyb6tr7otgwrij7fbzmjrzbj
=== STEP  testing cloud_epg attribute: annotation = 707hkrwvoa2i374eqft47h8ldb1mjvnw7nax7mluvxzdw8x3vfp2amgtnmi4x978d0go1otmayrmr74mdhrv6k4hwk8lbmjhtn131219bd2dqg6taur4hf26gzu4b760s
=== STEP  testing cloud_epg attribute: name_alias = rmozhtxscu4wcxq249p7gig842qyp9llbs3pt6pyx4hhamn1adwi8qaos6r2a8eu
=== STEP  testing cloud_epg attribute: flood_on_encap = qbb9n
=== STEP  testing cloud_epg attribute: match_t = qbb9n
=== STEP  testing cloud_epg attribute: pref_gr_memb = qbb9n
=== STEP  testing cloud_epg attribute: prio = qbb9n
=== STEP  testing cloud_epg attribute: prio = qbb9n
=== STEP  testing cloud_epg attribute: prio = qbb9n
=== STEP  testing cloud_epg attribute: zzlhi = qbb9n
=== STEP  testing cloud_epg creation with required arguments only
=== PAUSE TestAccAciCloudEPg_Negative
=== RUN   TestAccAciCloudEPg_MultipleCreateDelete
=== STEP  testing multiple cloud_epg creation with required arguments only
=== PAUSE TestAccAciCloudEPg_MultipleCreateDelete
=== CONT  TestAccAciCloudEPgDataSource_Basic
=== CONT  TestAccAciCloudEPg_Negative
=== CONT  TestAccAciCloudEPg_MultipleCreateDelete
=== CONT  TestAccAciCloudEPg_Update
=== CONT  TestAccAciCloudEPg_Basic
=== STEP  testing cloud_epg destroy
--- PASS: TestAccAciCloudEPg_MultipleCreateDelete (42.30s)
=== STEP  testing cloud_epg destroy
--- PASS: TestAccAciCloudEPgDataSource_Basic (85.25s)
=== STEP  testing cloud_epg destroy
--- PASS: TestAccAciCloudEPg_Negative (110.32s)
=== STEP  testing cloud_epg destroy
--- PASS: TestAccAciCloudEPg_Basic (178.07s)
=== STEP  testing cloud_epg destroy
--- PASS: TestAccAciCloudEPg_Update (251.18s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   253.959s
$ go test -v -run TestAccAciPeerConnectivityProfile -timeout=60m
=== RUN   TestAccAciPeerConnectivityProfileDataSource_Basic
=== STEP  Basic: testing peer_connectivity_profile creation without  parent_dn
=== STEP  Basic: testing peer_connectivity_profile creation without  addr
=== STEP  testing peer_connectivity_profile Data Source with required arguments only
=== STEP  testing peer_connectivity_profile Data Source with random attribute
=== STEP  testing peer_connectivity_profile Data Source with Invalid Parent Dn
=== STEP  testing peer_connectivity_profile Data Source with updated resource
=== PAUSE TestAccAciPeerConnectivityProfileDataSource_Basic
=== RUN   TestAccAciPeerConnectivityProfile_Basic
=== STEP  Basic: testing peer_connectivity_profile creation without  parent_dn
=== STEP  Basic: testing peer_connectivity_profile creation without  addr
=== STEP  testing peer_connectivity_profile creation with required arguments only
=== STEP  Basic: testing peer_connectivity_profile creation with optional parameters
=== STEP  testing peer_connectivity_profile creation with invalid IP
=== STEP  Basic: testing peer_connectivity_profile creation with optional parameters
=== STEP  testing peer_connectivity_profile creation with parent resource name acctest_gb638 and address 10.0.250.41/16
=== STEP  testing peer_connectivity_profile creation with required arguments only
=== STEP  testing peer_connectivity_profile creation with parent resource name acctest_tpy2i and address 10.0.63.190/16
=== PAUSE TestAccAciPeerConnectivityProfile_Basic
=== RUN   TestAccAciPeerConnectivityProfile_Update
=== STEP  testing peer_connectivity_profile creation with required arguments only
=== STEP  testing peer_connectivity_profile attribute: addr_t_ctrl=["af-mcast"]
=== STEP  testing peer_connectivity_profile attribute: addr_t_ctrl=["af-mcast","af-ucast"]
=== STEP  testing peer_connectivity_profile attribute: addr_t_ctrl=["af-ucast"]
=== STEP  testing peer_connectivity_profile attribute: ctrl=["allow-self-as"]
=== STEP  testing peer_connectivity_profile attribute: ctrl=["send-ext-com","send-com","nh-self","dis-peer-as-check","as-override","allow-self-as"]
=== STEP  testing peer_connectivity_profile attribute: peer_ctrl=["bfd"]
=== STEP  testing peer_connectivity_profile attribute: peer_ctrl=["bfd","dis-conn-check"]
=== STEP  testing peer_connectivity_profile attribute: peer_ctrl=["dis-conn-check"]
=== STEP  testing peer_connectivity_profile attribute: peer_ctrl=["dis-conn-check","bfd"]
=== STEP  testing peer_connectivity_profile attribute: private_a_sctrl=["remove-all","remove-exclusive","replace-as"]
=== STEP  testing peer_connectivity_profile attribute: private_a_sctrl=["replace-as","remove-exclusive","remove-all"]
=== STEP  testing peer_connectivity_profile attribute: local_asn_propagate=no-prepend
=== STEP  testing peer_connectivity_profile attribute: local_asn_propagate=replace-as
=== STEP  testing peer_connectivity_profile creation with required arguments only
=== PAUSE TestAccAciPeerConnectivityProfile_Update
=== RUN   TestAccAciPeerConnectivityProfile_Negative
=== STEP  testing peer_connectivity_profile creation with required arguments only
=== STEP  Negative Case: testing peer_connectivity_profile creation with invalid parent Dn
=== STEP  testing peer_connectivity_profile attribute: description=zyznn74rb8ebudbzrzg2bv3eww7o7hldosfjzwxic8eejctudk4to7bvd84r9hywntwd2e69icgws9vdmfq8dyb47xq0b1rhvmdatj1rf6ebleq7qu63uj8bpnae0wkk1
=== STEP  testing peer_connectivity_profile attribute: annotation=9q4biknwdusolqmdfw2fjh8zipp24umx0wsk4imf6nu78zodkt1ysuajhe48edu7g6ha189349rmszpewdb0wteoalnfqx1m2p89bj4nn3k8brlz7krtlmvne804xg6ng
=== STEP  testing peer_connectivity_profile attribute: name_alias=ylok74gthnfgzx3ycv9xjkvtgp2rfcd04dt1jeoz3dheqgs94y0gtllsjsj9kwpg
=== STEP  testing peer_connectivity_profile attribute: addr_t_ctrl=["acctest_t8x2l"]
=== STEP  testing peer_connectivity_profile attribute: addr_t_ctrl=["af-mcast","af-mcast"]
=== STEP  testing peer_connectivity_profile attribute: admin_state=acctest_t8x2l
=== STEP  testing peer_connectivity_profile attribute: allowed_self_as_cnt=acctest_t8x2l
=== STEP  testing peer_connectivity_profile attribute: ctrl=["acctest_t8x2l"]
=== STEP  testing peer_connectivity_profile attribute: ctrl=["allow-self-as","allow-self-as"]
=== STEP  testing peer_connectivity_profile attribute: peer_ctrl=["acctest_t8x2l"]
=== STEP  testing peer_connectivity_profile attribute: peer_ctrl=["bfd","bfd"]
=== STEP  testing peer_connectivity_profile attribute: private_a_sctrl=["acctest_t8x2l"]
=== STEP  testing peer_connectivity_profile attribute: private_a_sctrl=["remove-all","remove-all"]
=== STEP  testing peer_connectivity_profile attribute: local_asn_propagate=acctest_t8x2l
=== STEP  testing peer_connectivity_profile attribute: ttl=acctest_t8x2l
=== STEP  testing peer_connectivity_profile attribute: weight=acctest_t8x2l
=== STEP  testing peer_connectivity_profile attribute: jkujz=acctest_t8x2l
=== STEP  testing peer_connectivity_profile creation with required arguments only
=== PAUSE TestAccAciPeerConnectivityProfile_Negative
=== CONT  TestAccAciPeerConnectivityProfileDataSource_Basic
=== CONT  TestAccAciPeerConnectivityProfile_Update
=== CONT  TestAccAciPeerConnectivityProfile_Basic
=== CONT  TestAccAciPeerConnectivityProfile_Negative
=== STEP  testing peer_connectivity_profile destroy
--- PASS: TestAccAciPeerConnectivityProfileDataSource_Basic (60.11s)
=== STEP  testing peer_connectivity_profile destroy
--- PASS: TestAccAciPeerConnectivityProfile_Basic (115.26s)
=== STEP  testing peer_connectivity_profile destroy
--- PASS: TestAccAciPeerConnectivityProfile_Negative (125.59s)
=== STEP  testing peer_connectivity_profile destroy
--- PASS: TestAccAciPeerConnectivityProfile_Update (208.54s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   210.004s
$ go test -v -run TestAccAciCloudProviderProfileDataSource -timeout=60m
=== RUN   TestAccAciCloudProviderProfileDataSource_Basic
=== STEP  Basic: testing cloud_provider_profile Data Source without  vendor
=== STEP  testing cloud_provider_profile Data Source with required arguments only
=== STEP  testing cloud_provider_profile Data Source with random attribute
=== STEP  testing cloud_provider_profile Data Source with required arguments only
=== PAUSE TestAccAciCloudProviderProfileDataSource_Basic
=== CONT  TestAccAciCloudProviderProfileDataSource_Basic
--- PASS: TestAccAciCloudProviderProfileDataSource_Basic (28.59s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   31.619s
$ go test -v -run TestAccAciCloudProvidersRegionDataSource_Basic -timeout=60m
=== RUN   TestAccAciCloudProvidersRegionDataSource_Basic
=== STEP  Basic: testing cloud_providers_region Data Source without  cloud_provider_profile_dn
=== STEP  Basic: testing cloud_providers_region Data Source without  name
=== STEP  testing cloud_providers_region Data Source with required arguments only
=== STEP  testing cloud_providers_region Data Source with random attribute
=== STEP  testing cloud_providers_region Data Source with invalid name
=== STEP  testing cloud_providers_region Data Source with required arguments only
=== PAUSE TestAccAciCloudProvidersRegionDataSource_Basic
=== CONT  TestAccAciCloudProvidersRegionDataSource_Basic
--- PASS: TestAccAciCloudProvidersRegionDataSource_Basic (28.18s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   30.883s
