### PR TITLE
updated mgmtrsinbstnode

### DIFF
--- a/testacc/data_source_aci_mgmtrsinbstnode_test.go
+++ b/testacc/data_source_aci_mgmtrsinbstnode_test.go
@@ -38,7 +38,7 @@ func TestAccAciStaticNodeMgmtAddressDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "t_dn", resourceName, "t_dn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "type", resourceName, "type"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "addr", resourceName, "addr"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "gw", resourceName, "gw"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "v6_addr", resourceName, "v6_addr"),

--- a/testacc/resource_aci_infrafexbndlgrp_test.go
+++ b/testacc/resource_aci_infrafexbndlgrp_test.go
@@ -382,21 +382,3 @@ func CreateAccFexBundleGroupUpdatedAttr(infraFexPName, rName, attribute, value s
 	`, infraFexPName, rName, attribute, value)
 	return resource
 }
-
-func CreateAccFexBundleGroupUpdatedAttrList(infraFexPName, rName, attribute, value string) string {
-	fmt.Printf("=== STEP  testing fex_bundle_group attribute: %s = %s \n", attribute, value)
-	resource := fmt.Sprintf(`
-	
-	resource "aci_fex_profile" "test" {
-		name 		= "%s"
-	
-	}
-	
-	resource "aci_fex_bundle_group" "test" {
-		fex_profile_dn  = aci_fex_profile.test.id
-		name  = "%s"
-		%s = %s
-	}
-	`, infraFexPName, rName, attribute, value)
-	return resource
-}

--- a/testacc/resource_aci_mgmtrsinbstnode_test.go
+++ b/testacc/resource_aci_mgmtrsinbstnode_test.go
@@ -48,6 +48,7 @@ func TestAccAciStaticNodeMgmtAddress_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "gw", "0.0.0.0"),
 					resource.TestCheckResourceAttr(resourceName, "v6_addr", "::"),
 					resource.TestCheckResourceAttr(resourceName, "v6_gw", "::"),
+					resource.TestCheckResourceAttr(resourceName, "type", addrType),
 				),
 			},
 			{
@@ -60,6 +61,7 @@ func TestAccAciStaticNodeMgmtAddress_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
 					resource.TestCheckResourceAttr(resourceName, "addr", "1.0.0.1/24"),
 					resource.TestCheckResourceAttr(resourceName, "gw", "1.0.0.1"),
+					resource.TestCheckResourceAttr(resourceName, "type", addrType),
 					// resource.TestCheckResourceAttr(resourceName, "v6_addr", "2001:0db8:85a3:0000:0000:8a2e:0370:7334/64"),
 					// resource.TestCheckResourceAttr(resourceName, "v6_gw", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"),
 					testAccCheckAciStaticNodeMgmtAddressIdEqual(&static_node_mgmt_address_default, &static_node_mgmt_address_updated),


### PR DESCRIPTION
$ go test -v -run TestAccAciStaticNodeMgmtAddressDataSource_Basic -timeout=60m
=== RUN   TestAccAciStaticNodeMgmtAddressDataSource_Basic
=== STEP  Basic: testing static_node_mgmt_address creation without  management_epg_dn
=== STEP  Basic: testing static_node_mgmt_address creation without  t_dn
=== STEP  testing static_node_mgmt_address Data Source with required arguments only
=== STEP  testing static_node_mgmt_address Data Source with random attribute
=== STEP  testing static_node_mgmt_address Data Source with Invalid Parent Dn
=== STEP  testing static_node_mgmt_address Data Source with updated resource
=== PAUSE TestAccAciStaticNodeMgmtAddressDataSource_Basic
=== CONT  TestAccAciStaticNodeMgmtAddressDataSource_Basic
=== STEP  testing static_node_mgmt_address destroy
--- PASS: TestAccAciStaticNodeMgmtAddressDataSource_Basic (74.30s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   78.946s
$ go test -v -run TestAccAciStaticNodeMgmtAddress_Basic -timeout=60m
=== RUN   TestAccAciStaticNodeMgmtAddress_Basic
=== STEP  Basic: testing static_node_mgmt_address creation without  management_epg_dn
=== STEP  Basic: testing static_node_mgmt_address creation without  t_dn
=== STEP  testing static_node_mgmt_address creation with required arguments only
=== STEP  Basic: testing static_node_mgmt_address creation with optional parameters
=== STEP  Basic: testing static_node_mgmt_address updation without required parameters
=== STEP  testing static_node_mgmt_address creation with required arguments only
=== STEP  testing static_node_mgmt_address creation with required arguments only
=== STEP  testing static_node_mgmt_address creation with required arguments only
=== PAUSE TestAccAciStaticNodeMgmtAddress_Basic
=== CONT  TestAccAciStaticNodeMgmtAddress_Basic
=== STEP  testing static_node_mgmt_address destroy
--- PASS: TestAccAciStaticNodeMgmtAddress_Basic (108.17s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   110.889s
