### PR TITLE
added test script for cloud related resources

### DIFF
--- a/aci/resource_aci_cloudsubnet.go
+++ b/aci/resource_aci_cloudsubnet.go
@@ -204,6 +204,10 @@ func resourceAciCloudSubnetCreate(ctx context.Context, d *schema.ResourceData, m
 		for _, val := range Scope.([]interface{}) {
 			scopeList = append(scopeList, val.(string))
 		}
+		err := checkDuplicate(scopeList)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 		Scope := strings.Join(scopeList, ",")
 		cloudSubnetAttr.Scope = Scope
 	}
@@ -287,6 +291,10 @@ func resourceAciCloudSubnetUpdate(ctx context.Context, d *schema.ResourceData, m
 		scopeList := make([]string, 0, 1)
 		for _, val := range Scope.([]interface{}) {
 			scopeList = append(scopeList, val.(string))
+		}
+		err := checkDuplicate(scopeList)
+		if err != nil {
+			return diag.FromErr(err)
 		}
 		Scope := strings.Join(scopeList, ",")
 		cloudSubnetAttr.Scope = Scope

--- a/testacc/data_source_aci_cloudextepg_test.go
+++ b/testacc/data_source_aci_cloudextepg_test.go
@@ -1,0 +1,220 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciCloudExternalEPgDataSource_Basic(t *testing.T) {
+	resourceName := "aci_cloud_external_epg.test"
+	dataSourceName := "data.aci_cloud_external_epg.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudExternalEPgDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateCloudExternalEPgDSWithoutRequired(rName, rName, rName, "cloud_applicationcontainer_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateCloudExternalEPgDSWithoutRequired(rName, rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudExternalEPgConfigDataSource(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "cloud_applicationcontainer_dn", resourceName, "cloud_applicationcontainer_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "flood_on_encap", resourceName, "flood_on_encap"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "match_t", resourceName, "match_t"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "pref_gr_memb", resourceName, "pref_gr_memb"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "prio", resourceName, "prio"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "route_reachability", resourceName, "route_reachability"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "exception_tag", resourceName, "exception_tag"),
+				),
+			},
+			{
+				Config:      CreateAccCloudExternalEPgDataSourceUpdate(rName, rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccCloudExternalEPgDSWithInvalidName(rName, rName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+
+			{
+				Config: CreateAccCloudExternalEPgDataSourceUpdatedResource(rName, rName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccCloudExternalEPgConfigDataSource(fvTenantName, cloudAppName, rName string) string {
+	fmt.Println("=== STEP  testing cloud_external_epg Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+	}
+
+	data "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = aci_cloud_external_epg.test.name
+		depends_on = [ aci_cloud_external_epg.test ]
+	}
+	`, fvTenantName, cloudAppName, rName)
+	return resource
+}
+
+func CreateCloudExternalEPgDSWithoutRequired(fvTenantName, cloudAppName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_external_epg Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "cloud_applicationcontainer_dn":
+		rBlock += `
+	data "aci_cloud_external_epg" "test" {
+	#	cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = aci_cloud_external_epg.test.name
+		depends_on = [ aci_cloud_external_epg.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+	#	name  = aci_cloud_external_epg.test.name
+		depends_on = [ aci_cloud_external_epg.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, cloudAppName, rName)
+}
+
+func CreateAccCloudExternalEPgDSWithInvalidName(fvTenantName, cloudAppName, rName string) string {
+	fmt.Println("=== STEP  testing cloud_external_epg Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+	}
+
+	data "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "${aci_cloud_external_epg.test.name}_invalid"
+		depends_on = [ aci_cloud_external_epg.test ]
+	}
+	`, fvTenantName, cloudAppName, rName)
+	return resource
+}
+
+func CreateAccCloudExternalEPgDataSourceUpdate(fvTenantName, cloudAppName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing cloud_external_epg Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+	}
+
+	data "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = aci_cloud_external_epg.test.name
+		%s = "%s"
+		depends_on = [ aci_cloud_external_epg.test ]
+	}
+	`, fvTenantName, cloudAppName, rName, key, value)
+	return resource
+}
+
+func CreateAccCloudExternalEPgDataSourceUpdatedResource(fvTenantName, cloudAppName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing cloud_external_epg Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = aci_cloud_external_epg.test.name
+		depends_on = [ aci_cloud_external_epg.test ]
+	}
+	`, fvTenantName, cloudAppName, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_cloudrouterp_test.go
+++ b/testacc/data_source_aci_cloudrouterp_test.go
@@ -1,0 +1,256 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciCloudVpnGatewayDataSource_Basic(t *testing.T) {
+	resourceName := "aci_cloud_vpn_gateway.test"
+	dataSourceName := "data.aci_cloud_vpn_gateway.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	cidr, _ := acctest.RandIpAddress("10.203.0.0/16")
+	cidr = fmt.Sprintf("%s/16", cidr)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudVpnGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateCloudVpnGatewayDSWithoutRequired(rName, rName, cidr, rName, "cloud_context_profile_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateCloudVpnGatewayDSWithoutRequired(rName, rName, cidr, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudVpnGatewayConfigDataSource(rName, rName, cidr, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "cloud_context_profile_dn", resourceName, "cloud_context_profile_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "num_instances", resourceName, "num_instances"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cloud_router_profile_type", resourceName, "cloud_router_profile_type"),
+				),
+			},
+			{
+				Config:      CreateAccCloudVpnGatewayDataSourceUpdate(rName, rName, cidr, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccCloudVpnGatewayDSWithInvalidParentDn(rName, rName, cidr, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+
+			{
+				Config: CreateAccCloudVpnGatewayDataSourceUpdatedResource(rName, rName, cidr, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccCloudVpnGatewayConfigDataSource(fvTenantName, cloudCtxProfileName, cidr, rName string) string {
+	fmt.Println("=== STEP  testing cloud_vpn_gateway Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "us-west-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	
+	resource "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+		name  = "%s"
+	}
+
+	data "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+		name  = aci_cloud_vpn_gateway.test.name
+		depends_on = [ aci_cloud_vpn_gateway.test ]
+	}
+	`, fvTenantName, fvTenantName, cloudCtxProfileName, cidr, rName)
+	return resource
+}
+
+func CreateCloudVpnGatewayDSWithoutRequired(fvTenantName, cloudCtxProfileName, cidr, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_vpn_gateway Data Source without ", attrName)
+	rBlock := `
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "us-west-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	
+	resource "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "cloud_context_profile_dn":
+		rBlock += `
+	data "aci_cloud_vpn_gateway" "test" {
+	#	cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+		name  = aci_cloud_vpn_gateway.test.name
+		depends_on = [ aci_cloud_vpn_gateway.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+	#	name  = aci_cloud_vpn_gateway.test.name
+		depends_on = [ aci_cloud_vpn_gateway.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, fvTenantName, cloudCtxProfileName, cidr, rName)
+}
+
+func CreateAccCloudVpnGatewayDSWithInvalidParentDn(fvTenantName, cloudCtxProfileName, cidr, rName string) string {
+	fmt.Println("=== STEP  testing cloud_vpn_gateway Data Source with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "us-west-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	
+	resource "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+		name  = "%s"
+	}
+
+	data "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+		name  = "${aci_cloud_vpn_gateway.test.name}_invalid"
+		depends_on = [ aci_cloud_vpn_gateway.test ]
+	}
+	`, fvTenantName, fvTenantName, cloudCtxProfileName, cidr, rName)
+	return resource
+}
+
+func CreateAccCloudVpnGatewayDataSourceUpdate(fvTenantName, cloudCtxProfileName, cidr, rName, key, value string) string {
+	fmt.Println("=== STEP  testing cloud_vpn_gateway Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "us-west-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	
+	resource "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+		name  = "%s"
+	}
+
+
+	data "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+		name  = aci_cloud_vpn_gateway.test.name
+		%s = "%s"
+		depends_on = [ aci_cloud_vpn_gateway.test ]
+	}
+	`, fvTenantName, fvTenantName, cloudCtxProfileName, cidr, rName, key, value)
+	return resource
+}
+
+func CreateAccCloudVpnGatewayDataSourceUpdatedResource(fvTenantName, cloudCtxProfileName, cidr, rName, key, value string) string {
+	fmt.Println("=== STEP  testing cloud_vpn_gateway Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "us-west-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	
+	resource "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+		name  = aci_cloud_vpn_gateway.test.name
+		depends_on = [ aci_cloud_vpn_gateway.test ]
+	}
+	`, fvTenantName, fvTenantName, cloudCtxProfileName, cidr, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_cloudsubnet_test.go
+++ b/testacc/data_source_aci_cloudsubnet_test.go
@@ -1,0 +1,289 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciCloudSubnetDataSource_Basic(t *testing.T) {
+	resourceName := "aci_cloud_subnet.test"
+	dataSourceName := "data.aci_cloud_subnet.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	ip, _ := acctest.RandIpAddress("45.1.0.0/16")
+	ip = fmt.Sprintf("%s/16", ip)
+	ipOther, _ := acctest.RandIpAddress("45.2.0.0/17")
+	ipOther = fmt.Sprintf("%s/17", ipOther)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudSubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateCloudSubnetDSWithoutRequired(rName, ip, "ip"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateCloudSubnetDSWithoutRequired(rName, ip, "cloud_cidr_pool_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudSubnetConfigDataSource(rName, ip),
+				Check: resource.ComposeTestCheckFunc(
+
+					resource.TestCheckResourceAttrPair(dataSourceName, "ip", resourceName, "ip"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cloud_cidr_pool_dn", resourceName, "cloud_cidr_pool_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "scope.#", resourceName, "scope.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "scope.0", resourceName, "scope.0"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "usage", resourceName, "usage"),
+				),
+			},
+			{
+				Config:      CreateAccCloudSubnetDataSourceUpdate(rName, ip, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccCloudSubnetDSWithInvalidParentDn(rName, ip, ipOther),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccCloudSubnetDataSourceUpdatedResource(rName, ip, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccCloudSubnetConfigDataSource(rName, ip string) string {
+	fmt.Println("=== STEP  testing cloud_subnet Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		primary_cidr = "%s"
+		name = "%s"
+		region = "us-east-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+
+	resource "aci_cloud_cidr_pool" "test" {
+		cloud_context_profile_dn = aci_cloud_context_profile.test.id
+		addr = "%s"
+	}
+
+	resource "aci_cloud_subnet" "test" {
+		cloud_cidr_pool_dn = aci_cloud_cidr_pool.test.id
+		ip  = "%s"
+		zone = "uni/clouddomp/provp-aws/region-us-east-1/zone-us-east-1a"
+	}
+
+	data "aci_cloud_subnet" "test" {
+		ip  = aci_cloud_subnet.test.ip
+		cloud_cidr_pool_dn = aci_cloud_subnet.test.cloud_cidr_pool_dn
+		depends_on = [ aci_cloud_subnet.test ]
+	}
+	`, rName, rName, ip, rName, ip, ip)
+	return resource
+}
+
+func CreateCloudSubnetDSWithoutRequired(rName, ip, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_subnet Data Source without ", attrName)
+	rBlock := `
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		primary_cidr = "%s"
+		name = "%s"
+		region = "us-east-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+
+	resource "aci_cloud_cidr_pool" "test" {
+		cloud_context_profile_dn = aci_cloud_context_profile.test.id
+		addr = "%s"
+	}
+
+	resource "aci_cloud_subnet" "test" {
+		cloud_cidr_pool_dn = aci_cloud_cidr_pool.test.id
+		ip  = "%s"
+		zone = "uni/clouddomp/provp-aws/region-us-east-1/zone-us-east-1a"
+	}
+	`
+	switch attrName {
+	case "ip":
+		rBlock += `
+	data "aci_cloud_subnet" "test" {
+	#	ip  = "%s"
+		cloud_cidr_pool_dn = aci_cloud_subnet.test.cloud_cidr_pool_dn
+		depends_on = [ aci_cloud_subnet.test ]
+	}
+		`
+	case "cloud_cidr_pool_dn":
+		rBlock += `
+	data "aci_cloud_subnet" "test" {
+		ip  = aci_cloud_subnet.test.ip
+	#	cloud_cidr_pool_dn = aci_cloud_subnet.test.cloud_cidr_pool_dn
+		depends_on = [ aci_cloud_subnet.test ]
+	}
+		`
+
+	}
+	return fmt.Sprintf(rBlock, rName, rName, ip, ip, ip)
+}
+
+func CreateAccCloudSubnetDSWithInvalidParentDn(rName, ip, ipOther string) string {
+	fmt.Println("=== STEP  testing cloud_subnet Data Source with invalid ip")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		primary_cidr = "%s"
+		name = "%s"
+		region = "us-east-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+
+	resource "aci_cloud_cidr_pool" "test" {
+		cloud_context_profile_dn = aci_cloud_context_profile.test.id
+		addr = "%s"
+	}
+
+	resource "aci_cloud_subnet" "test" {
+		cloud_cidr_pool_dn = aci_cloud_cidr_pool.test.id
+		ip  = "%s"
+		zone = "uni/clouddomp/provp-aws/region-us-east-1/zone-us-east-1a"
+	}
+
+	data "aci_cloud_subnet" "test" {
+		ip  = "%s"
+		cloud_cidr_pool_dn = aci_cloud_subnet.test.cloud_cidr_pool_dn
+		depends_on = [ aci_cloud_subnet.test ]
+	}
+	`, rName, rName, ip, rName, ip, ip, ipOther)
+	return resource
+}
+
+func CreateAccCloudSubnetDataSourceUpdate(rName, ip, key, value string) string {
+	fmt.Println("=== STEP  testing cloud_subnet Data Source with random attribute")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		primary_cidr = "%s"
+		name = "%s"
+		region = "us-east-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+
+	resource "aci_cloud_cidr_pool" "test" {
+		cloud_context_profile_dn = aci_cloud_context_profile.test.id
+		addr = "%s"
+	}
+
+	resource "aci_cloud_subnet" "test" {
+		cloud_cidr_pool_dn = aci_cloud_cidr_pool.test.id
+		ip  = "%s"
+		zone = "uni/clouddomp/provp-aws/region-us-east-1/zone-us-east-1a"
+	}
+
+	data "aci_cloud_subnet" "test" {
+		ip  = aci_cloud_subnet.test.ip
+		cloud_cidr_pool_dn = aci_cloud_subnet.test.cloud_cidr_pool_dn
+		%s = "%s"
+		depends_on = [ aci_cloud_subnet.test ]
+	}
+	`, rName, rName, ip, rName, ip, ip, key, value)
+	return resource
+}
+
+func CreateAccCloudSubnetDataSourceUpdatedResource(rName, ip, key, value string) string {
+	fmt.Println("=== STEP  testing cloud_subnet Data Source with updated resource")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		primary_cidr = "%s"
+		name = "%s"
+		region = "us-east-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+
+	resource "aci_cloud_cidr_pool" "test" {
+		cloud_context_profile_dn = aci_cloud_context_profile.test.id
+		addr = "%s"
+	}
+
+	resource "aci_cloud_subnet" "test" {
+		cloud_cidr_pool_dn = aci_cloud_cidr_pool.test.id
+		ip  = "%s"
+		%s = "%s"
+		zone = "uni/clouddomp/provp-aws/region-us-east-1/zone-us-east-1a"
+	}
+
+	data "aci_cloud_subnet" "test" {
+		ip  = aci_cloud_subnet.test.ip
+		cloud_cidr_pool_dn = aci_cloud_subnet.test.cloud_cidr_pool_dn
+		depends_on = [ aci_cloud_subnet.test ]
+	}
+	`, rName, rName, ip, rName, ip, ip, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_cloudzone_test.go
+++ b/testacc/data_source_aci_cloudzone_test.go
@@ -1,0 +1,108 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const cloudProviderRegion = "uni/clouddomp/provp-aws/region-us-east-1"
+const zoneName = "us-east-1a"
+
+func TestAccAciCloudAvailabilityZoneDataSource_Basic(t *testing.T) {
+	dataSourceName := "data.aci_cloud_availability_zone.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateCloudAvailabilityZoneDSWithoutRequired("cloud_providers_region_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateCloudAvailabilityZoneDSWithoutRequired("name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudAvailabilityZoneConfigDataSource(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "cloud_providers_region_dn", cloudProviderRegion),
+					resource.TestCheckResourceAttr(dataSourceName, "name", zoneName),
+				),
+			},
+			{
+				Config:      CreateAccCloudAvailabilityZoneDataSourceUpdate(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccCloudAvailabilityZoneDSWithInvalidName(),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+		},
+	})
+}
+
+func CreateAccCloudAvailabilityZoneConfigDataSource() string {
+	fmt.Println("=== STEP  testing cloud_availability_zone Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+
+	data "aci_cloud_availability_zone" "test" {
+		cloud_providers_region_dn  = "%s"
+		name  = "%s"
+	}
+	`, cloudProviderRegion, zoneName)
+	return resource
+}
+
+func CreateCloudAvailabilityZoneDSWithoutRequired(attrName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_availability_zone Data Source without ", attrName)
+	rBlock := `
+	`
+	switch attrName {
+	case "cloud_providers_region_dn":
+		rBlock += `
+	data "aci_cloud_availability_zone" "test" {
+	#	cloud_providers_region_dn  = "%s"
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_cloud_availability_zone" "test" {
+		cloud_providers_region_dn  = "%s"
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, cloudProviderRegion, zoneName)
+}
+
+func CreateAccCloudAvailabilityZoneDSWithInvalidName() string {
+	fmt.Println("=== STEP  testing cloud_availability_zone Data Source with invalid name")
+	resource := fmt.Sprintf(`
+
+	data "aci_cloud_availability_zone" "test" {
+		cloud_providers_region_dn  = "%s"
+		name  = "%sxyz"
+	}
+	`, cloudProviderRegion, zoneName)
+	return resource
+}
+
+func CreateAccCloudAvailabilityZoneDataSourceUpdate(key, value string) string {
+	fmt.Println("=== STEP  testing cloud_availability_zone Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	data "aci_cloud_availability_zone" "test" {
+		cloud_providers_region_dn  = "%s"
+		name  = "%s"
+		%s = "%s"
+	}
+	`, cloudProviderRegion, zoneName, key, value)
+	return resource
+}

--- a/testacc/resource_aci_cloudepg_test.go
+++ b/testacc/resource_aci_cloudepg_test.go
@@ -220,25 +220,15 @@ func TestAccAciCloudEPg_Negative(t *testing.T) {
 				Config:      CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "match_t", randomValue),
 				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
 			},
+			{
+				Config:      CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "prio", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
 
 			{
 				Config:      CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "pref_gr_memb", randomValue),
 				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
 			},
-
-			{
-				Config:      CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "prio", randomValue),
-				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
-			},
-			{
-				Config:      CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "prio", randomValue),
-				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
-			},
-			{
-				Config:      CreateAccCloudEPgUpdatedAttr(rName, rName, rName, "prio", randomValue),
-				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
-			},
-
 			{
 				Config:      CreateAccCloudEPgUpdatedAttr(rName, rName, rName, randomParameter, randomValue),
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
@@ -501,8 +491,6 @@ func CreateAccCloudEPgRemovingRequiredField() string {
 		description = "created while acceptance testing"
 		annotation = "orchestrator:terraform_testacc"
 		name_alias = "test_cloud_epg"
-		az_application_security_group = ""
-		az_network_security_group = ""
 		flood_on_encap = "enabled"
 		match_t = "All"
 		pref_gr_memb = "include"

--- a/testacc/resource_aci_cloudextepg_test.go
+++ b/testacc/resource_aci_cloudextepg_test.go
@@ -1,0 +1,585 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciCloudExternalEPg_Basic(t *testing.T) {
+	var cloud_external_epg_default models.CloudExternalEPg
+	var cloud_external_epg_updated models.CloudExternalEPg
+	resourceName := "aci_cloud_external_epg.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudExternalEPgDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateCloudExternalEPgWithoutRequired(rName, rName, rName, "cloud_applicationcontainer_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateCloudExternalEPgWithoutRequired(rName, rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudExternalEPgConfig(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_default),
+					resource.TestCheckResourceAttr(resourceName, "cloud_applicationcontainer_dn", fmt.Sprintf("uni/tn-%s/cloudapp-%s", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "exception_tag", ""),
+					resource.TestCheckResourceAttr(resourceName, "flood_on_encap", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "match_t", "AtleastOne"),
+					resource.TestCheckResourceAttr(resourceName, "pref_gr_memb", "exclude"),
+					resource.TestCheckResourceAttr(resourceName, "prio", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "route_reachability", "inter-site"),
+				),
+			},
+			{
+				Config: CreateAccCloudExternalEPgConfigWithOptionalValues(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "cloud_applicationcontainer_dn", fmt.Sprintf("uni/tn-%s/cloudapp-%s", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_cloud_external_epg"),
+					resource.TestCheckResourceAttr(resourceName, "flood_on_encap", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "match_t", "All"),
+					resource.TestCheckResourceAttr(resourceName, "pref_gr_memb", "include"),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level1"),
+					resource.TestCheckResourceAttr(resourceName, "exception_tag", "0"),
+					resource.TestCheckResourceAttr(resourceName, "route_reachability", "inter-site"),
+					testAccCheckAciCloudExternalEPgIdEqual(&cloud_external_epg_default, &cloud_external_epg_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccCloudExternalEPgConfigUpdatedName(rName, rName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccCloudExternalEPgRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudExternalEPgConfigWithRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "cloud_applicationcontainer_dn", fmt.Sprintf("uni/tn-%s/cloudapp-%s", rNameUpdated, rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciCloudExternalEPgIdNotEqual(&cloud_external_epg_default, &cloud_external_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudExternalEPgConfig(rName, rName, rName),
+			},
+			{
+				Config: CreateAccCloudExternalEPgConfigWithRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "cloud_applicationcontainer_dn", fmt.Sprintf("uni/tn-%s/cloudapp-%s", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciCloudExternalEPgIdNotEqual(&cloud_external_epg_default, &cloud_external_epg_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciCloudExternalEPg_Update(t *testing.T) {
+	var cloud_external_epg_default models.CloudExternalEPg
+	var cloud_external_epg_updated models.CloudExternalEPg
+	resourceName := "aci_cloud_external_epg.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rOther := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudExternalEPgDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccCloudExternalEPgConfig(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_default),
+				),
+			},
+			{
+				Config: CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "exception_tag", "512"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "exception_tag", "512"),
+					testAccCheckAciCloudExternalEPgIdEqual(&cloud_external_epg_default, &cloud_external_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "exception_tag", "256"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "exception_tag", "256"),
+					testAccCheckAciCloudExternalEPgIdEqual(&cloud_external_epg_default, &cloud_external_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "match_t", "AtmostOne"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "match_t", "AtmostOne"),
+					testAccCheckAciCloudExternalEPgIdEqual(&cloud_external_epg_default, &cloud_external_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "match_t", "None"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "match_t", "None"),
+					testAccCheckAciCloudExternalEPgIdEqual(&cloud_external_epg_default, &cloud_external_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "prio", "level2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level2"),
+					testAccCheckAciCloudExternalEPgIdEqual(&cloud_external_epg_default, &cloud_external_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "prio", "level3"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level3"),
+					testAccCheckAciCloudExternalEPgIdEqual(&cloud_external_epg_default, &cloud_external_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "prio", "level4"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level4"),
+					testAccCheckAciCloudExternalEPgIdEqual(&cloud_external_epg_default, &cloud_external_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "prio", "level5"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level5"),
+					testAccCheckAciCloudExternalEPgIdEqual(&cloud_external_epg_default, &cloud_external_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "prio", "level6"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "prio", "level6"),
+					testAccCheckAciCloudExternalEPgIdEqual(&cloud_external_epg_default, &cloud_external_epg_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rOther, "route_reachability", "internet"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "route_reachability", "internet"),
+				),
+			},
+			{
+				Config: CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "route_reachability", "site-ext"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "route_reachability", "site-ext"),
+				),
+			},
+			{
+				Config: CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rOther, "route_reachability", "unspecified"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "route_reachability", "unspecified"),
+				),
+			},
+			{
+				Config: CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "route_reachability", "inter-site-ext"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudExternalEPgExists(resourceName, &cloud_external_epg_updated),
+					resource.TestCheckResourceAttr(resourceName, "route_reachability", "inter-site-ext"),
+				),
+			},
+			{
+				Config: CreateAccCloudExternalEPgConfig(rName, rName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciCloudExternalEPg_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudExternalEPgDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccCloudExternalEPgConfig(rName, rName, rName),
+			},
+			{
+				Config:      CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "route_reachability", "internet"),
+				ExpectError: regexp.MustCompile(`Create-only and naming props cannot be modified after creation`),
+			},
+			{
+				Config:      CreateAccCloudExternalEPgWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "flood_on_encap", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "match_t", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "pref_gr_memb", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "prio", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, "route_reachability", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccCloudExternalEPgUpdatedAttr(rName, rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccCloudExternalEPgConfig(rName, rName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciCloudExternalEPg_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudExternalEPgDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccCloudExternalEPgConfigMultiple(rName, rName, rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciCloudExternalEPgExists(name string, cloud_external_epg *models.CloudExternalEPg) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Cloud External EPg %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Cloud External EPg dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		cloud_external_epgFound := models.CloudExternalEPgFromContainer(cont)
+		if cloud_external_epgFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Cloud External EPg %s not found", rs.Primary.ID)
+		}
+		*cloud_external_epg = *cloud_external_epgFound
+		return nil
+	}
+}
+
+func testAccCheckAciCloudExternalEPgDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing cloud_external_epg destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_cloud_external_epg" {
+			cont, err := client.Get(rs.Primary.ID)
+			cloud_external_epg := models.CloudExternalEPgFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Cloud External EPg %s Still exists", cloud_external_epg.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciCloudExternalEPgIdEqual(m1, m2 *models.CloudExternalEPg) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("cloud_external_epg DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciCloudExternalEPgIdNotEqual(m1, m2 *models.CloudExternalEPg) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("cloud_external_epg DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateCloudExternalEPgWithoutRequired(fvTenantName, cloudAppName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_external_epg creation without ", attrName)
+	rBlock := `
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	`
+	switch attrName {
+	case "cloud_applicationcontainer_dn":
+		rBlock += `
+	resource "aci_cloud_external_epg" "test" {
+	#	cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, cloudAppName, rName)
+}
+
+func CreateAccCloudExternalEPgConfigWithRequiredParams(prName, rName string) string {
+	fmt.Printf("=== STEP  testing cloud_external_epg creation with parent resource name %s and resource name %s\n", prName, rName)
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+	}
+	`, prName, prName, rName)
+	return resource
+}
+func CreateAccCloudExternalEPgConfigUpdatedName(fvTenantName, cloudAppName, rName string) string {
+	fmt.Println("=== STEP  testing cloud_external_epg creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, cloudAppName, rName)
+	return resource
+}
+
+func CreateAccCloudExternalEPgConfig(fvTenantName, cloudAppName, rName string) string {
+	fmt.Println("=== STEP  testing cloud_external_epg creation with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, cloudAppName, rName)
+	return resource
+}
+
+func CreateAccCloudExternalEPgConfigMultiple(fvTenantName, cloudAppName, rName string) string {
+	fmt.Println("=== STEP  testing multiple cloud_external_epg creation with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, fvTenantName, cloudAppName, rName)
+	return resource
+}
+
+func CreateAccCloudExternalEPgWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing cloud_external_epg creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccCloudExternalEPgConfigWithOptionalValues(fvTenantName, cloudAppName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_external_epg creation with optional parameters")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = "${aci_cloud_applicationcontainer.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_cloud_external_epg"
+		flood_on_encap = "enabled"
+		match_t = "All"
+		pref_gr_memb = "include"
+		prio = "level1"
+		route_reachability = "inter-site"
+		exception_tag = "0"
+	}
+	`, fvTenantName, cloudAppName, rName)
+
+	return resource
+}
+
+func CreateAccCloudExternalEPgRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing cloud_external_epg updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_cloud_external_epg" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_cloud_external_epg"
+		flood_on_encap = "enabled"
+		match_t = "All"
+		pref_gr_memb = "include"
+		prio = "level1"
+		route_reachability = "inter-site-ext"
+
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccCloudExternalEPgUpdatedAttr(fvTenantName, cloudAppName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing cloud_external_epg attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_cloud_applicationcontainer" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_cloud_external_epg" "test" {
+		cloud_applicationcontainer_dn  = aci_cloud_applicationcontainer.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, fvTenantName, cloudAppName, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_cloudrouterp_test.go
+++ b/testacc/resource_aci_cloudrouterp_test.go
@@ -1,0 +1,468 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciCloudVpnGateway_Basic(t *testing.T) {
+	var cloud_vpn_gateway_default models.CloudVpnGateway
+	var cloud_vpn_gateway_updated models.CloudVpnGateway
+	resourceName := "aci_cloud_vpn_gateway.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	cidr, _ := acctest.RandIpAddress("10.200.0.0/16")
+	cidr = fmt.Sprintf("%s/16", cidr)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudVpnGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateCloudVpnGatewayWithoutRequired(rName, rName, rName, cidr, "cloud_context_profile_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateCloudVpnGatewayWithoutRequired(rName, rName, rName, cidr, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudVpnGatewayConfig(rName, rName, cidr, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudVpnGatewayExists(resourceName, &cloud_vpn_gateway_default),
+					resource.TestCheckResourceAttr(resourceName, "cloud_context_profile_dn", fmt.Sprintf("uni/tn-%s/ctxprofile-%s", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "num_instances", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_router_profile_type", "vpn-gw"),
+				),
+			},
+			{
+				Config: CreateAccCloudVpnGatewayConfigWithOptionalValues(rName, rName, cidr, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudVpnGatewayExists(resourceName, &cloud_vpn_gateway_updated),
+					resource.TestCheckResourceAttr(resourceName, "cloud_context_profile_dn", fmt.Sprintf("uni/tn-%s/ctxprofile-%s", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_cloud_vpn_gateway"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_router_profile_type", "vpn-gw"),
+					resource.TestCheckResourceAttr(resourceName, "num_instances", "1"),
+					testAccCheckAciCloudVpnGatewayIdEqual(&cloud_vpn_gateway_default, &cloud_vpn_gateway_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccCloudVpnGatewayConfigUpdatedName(rName, rName, cidr, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccCloudVpnGatewayRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudVpnGatewayConfigWithRequiredParams(rNameUpdated, cidr, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudVpnGatewayExists(resourceName, &cloud_vpn_gateway_updated),
+					resource.TestCheckResourceAttr(resourceName, "cloud_context_profile_dn", fmt.Sprintf("uni/tn-%s/ctxprofile-%s", rNameUpdated, rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciCloudVpnGatewayIdNotEqual(&cloud_vpn_gateway_default, &cloud_vpn_gateway_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudVpnGatewayConfig(rName, rName, cidr, rName),
+			},
+			{
+				Config: CreateAccCloudVpnGatewayConfigWithRequiredParams(rName, cidr, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudVpnGatewayExists(resourceName, &cloud_vpn_gateway_updated),
+					resource.TestCheckResourceAttr(resourceName, "cloud_context_profile_dn", fmt.Sprintf("uni/tn-%s/ctxprofile-%s", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciCloudVpnGatewayIdNotEqual(&cloud_vpn_gateway_default, &cloud_vpn_gateway_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciCloudVpnGateway_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	cidr, _ := acctest.RandIpAddress("10.202.0.0/16")
+	cidr = fmt.Sprintf("%s/16", cidr)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudVpnGatewayDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccCloudVpnGatewayConfig(rName, rName, cidr, rName),
+			},
+			{
+				Config:      CreateAccCloudVpnGatewayWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccCloudVpnGatewayUpdatedAttr(rName, rName, cidr, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccCloudVpnGatewayUpdatedAttr(rName, rName, cidr, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccCloudVpnGatewayUpdatedAttr(rName, rName, cidr, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccCloudVpnGatewayUpdatedAttr(rName, rName, cidr, rName, "num_instances", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccCloudVpnGatewayUpdatedAttr(rName, rName, cidr, rName, "cloud_router_profile_type", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccCloudVpnGatewayUpdatedAttr(rName, rName, cidr, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccCloudVpnGatewayConfig(rName, rName, cidr, rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciCloudVpnGatewayExists(name string, cloud_vpn_gateway *models.CloudVpnGateway) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Cloud Vpn Gateway %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Cloud Vpn Gateway dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		cloud_vpn_gatewayFound := models.CloudVpnGatewayFromContainer(cont)
+		if cloud_vpn_gatewayFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Cloud Vpn Gateway %s not found", rs.Primary.ID)
+		}
+		*cloud_vpn_gateway = *cloud_vpn_gatewayFound
+		return nil
+	}
+}
+
+func testAccCheckAciCloudVpnGatewayDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing cloud_vpn_gateway destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_cloud_vpn_gateway" {
+			cont, err := client.Get(rs.Primary.ID)
+			cloud_vpn_gateway := models.CloudVpnGatewayFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Cloud Vpn Gateway %s Still exists", cloud_vpn_gateway.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciCloudVpnGatewayIdEqual(m1, m2 *models.CloudVpnGateway) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("cloud_vpn_gateway DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciCloudVpnGatewayIdNotEqual(m1, m2 *models.CloudVpnGateway) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("cloud_vpn_gateway DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateCloudVpnGatewayWithoutRequired(fvTenantName, cloudCtxProfileName, rName, cidr, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_vpn_gateway creation without ", attrName)
+	rBlock := `
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "us-west-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	
+	`
+	switch attrName {
+	case "cloud_context_profile_dn":
+		rBlock += `
+	resource "aci_cloud_vpn_gateway" "test" {
+	#	cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, fvTenantName, cloudCtxProfileName, cidr, rName)
+}
+
+func CreateAccCloudVpnGatewayConfigWithRequiredParams(prName, cidr, rName string) string {
+	fmt.Printf("=== STEP  testing cloud_vpn_gateway creation with parent resource name %s and resource name %s\n", prName, rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "us-west-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	
+	resource "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+		name  = "%s"
+	}
+	`, prName, prName, prName, cidr, rName)
+	return resource
+}
+func CreateAccCloudVpnGatewayConfigUpdatedName(fvTenantName, cloudCtxProfileName, cidr, rName string) string {
+	fmt.Println("=== STEP  testing cloud_vpn_gateway creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "us-west-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	
+	resource "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, fvTenantName, cloudCtxProfileName, cidr, rName)
+	return resource
+}
+
+func CreateAccCloudVpnGatewayConfigInfraTenant(rName, cidr string) string {
+	fmt.Println("=== STEP  testing cloud_vpn_gateway creation for cloud_router_profile_type = host-router")
+	resource := fmt.Sprintf(`
+	data "aci_tenant" "test" {
+		name 		= "infra"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = data.aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = data.aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "us-west-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	
+	resource "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+		name  = "%s"
+		cloud_router_profile_type = "host-router"
+	}
+	`, rName, rName, cidr, rName)
+	return resource
+}
+
+func CreateAccCloudVpnGatewayConfig(fvTenantName, cloudCtxProfileName, cidr, rName string) string {
+	fmt.Println("=== STEP  testing cloud_vpn_gateway creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "us-west-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	
+	resource "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, fvTenantName, cloudCtxProfileName, cidr, rName)
+	return resource
+}
+
+func CreateAccCloudVpnGatewayWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing cloud_vpn_gateway creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccCloudVpnGatewayConfigWithOptionalValues(fvTenantName, cloudCtxProfileName, cidr, rName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_vpn_gateway creation with optional parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "us-west-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	
+	resource "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = "${aci_cloud_context_profile.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_cloud_vpn_gateway"
+		num_instances = "1"
+		cloud_router_profile_type = "vpn-gw"
+		
+	}
+	`, fvTenantName, fvTenantName, cloudCtxProfileName, cidr, rName)
+
+	return resource
+}
+
+func CreateAccCloudVpnGatewayRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing cloud_vpn_gateway updation without required parameters")
+	resource := fmt.Sprintln(`
+	resource "aci_cloud_vpn_gateway" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_cloud_vpn_gateway"
+		cloud_router_profile_type = "host-router"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccCloudVpnGatewayUpdatedAttr(fvTenantName, cloudCtxProfileName, cidr, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing cloud_vpn_gateway attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "us-west-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	
+	resource "aci_cloud_vpn_gateway" "test" {
+		cloud_context_profile_dn  = aci_cloud_context_profile.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, fvTenantName, fvTenantName, cloudCtxProfileName, cidr, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_cloudsubnet_test.go
+++ b/testacc/resource_aci_cloudsubnet_test.go
@@ -1,0 +1,701 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciCloudSubnet_Basic(t *testing.T) {
+	var cloud_subnet_default models.CloudSubnet
+	var cloud_subnet_updated models.CloudSubnet
+	resourceName := "aci_cloud_subnet.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	ip, _ := acctest.RandIpAddress("45.3.0.0/16")
+	ipUpdated := fmt.Sprintf("%s/17", ip)
+	ip = fmt.Sprintf("%s/16", ip)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudSubnetDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateCloudSubnetWithoutRequired(rName, ip, "ip"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateCloudSubnetWithoutRequired(rName, ip, "cloud_cidr_pool_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudSubnetConfig(rName, ip),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudSubnetExists(resourceName, &cloud_subnet_default),
+					resource.TestCheckResourceAttr(resourceName, "ip", ip),
+					resource.TestCheckResourceAttr(resourceName, "cloud_cidr_pool_dn", fmt.Sprintf("uni/tn-%s/ctxprofile-%s/cidr-[%s]", rName, rName, ip)),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", ""),
+					resource.TestCheckResourceAttr(resourceName, "scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scope.0", "private"),
+					resource.TestCheckResourceAttr(resourceName, "usage", "user"),
+					resource.TestCheckResourceAttr(resourceName, "zone", "uni/clouddomp/provp-aws/region-us-east-1/zone-us-east-1a"),
+				),
+			},
+			{
+				Config: CreateAccCloudSubnetConfigWithOptionalValues(rName, ip),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudSubnetExists(resourceName, &cloud_subnet_updated),
+					resource.TestCheckResourceAttr(resourceName, "ip", ip),
+					resource.TestCheckResourceAttr(resourceName, "cloud_cidr_pool_dn", fmt.Sprintf("uni/tn-%s/ctxprofile-%s/cidr-[%s]", rName, rName, ip)),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_cloud_subnet"),
+					resource.TestCheckResourceAttr(resourceName, "name", "test_cloud_subnet_name"),
+					resource.TestCheckResourceAttr(resourceName, "scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scope.0", "public"),
+					resource.TestCheckResourceAttr(resourceName, "usage", "gateway"),
+					resource.TestCheckResourceAttr(resourceName, "zone", "uni/clouddomp/provp-aws/region-us-east-1/zone-us-east-1a"),
+					testAccCheckAciCloudSubnetIdEqual(&cloud_subnet_default, &cloud_subnet_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccCloudSubnetWithInavalidIP(rName, ip),
+				ExpectError: regexp.MustCompile(`Invalid RN`),
+			},
+			{
+				Config:      CreateAccCloudSubnetRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+
+			{
+				Config: CreateAccCloudSubnetConfigWithRequiredParams(rName, ip, ipUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudSubnetExists(resourceName, &cloud_subnet_updated),
+					resource.TestCheckResourceAttr(resourceName, "ip", ipUpdated),
+					resource.TestCheckResourceAttr(resourceName, "cloud_cidr_pool_dn", fmt.Sprintf("uni/tn-%s/ctxprofile-%s/cidr-[%s]", rName, rName, ip)),
+					testAccCheckAciCloudSubnetIdNotEqual(&cloud_subnet_default, &cloud_subnet_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudSubnetConfig(rName, ip),
+			},
+			{
+				Config: CreateAccCloudSubnetConfigWithRequiredParams(rNameUpdated, ip, ip),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudSubnetExists(resourceName, &cloud_subnet_updated),
+					resource.TestCheckResourceAttr(resourceName, "ip", ip),
+					resource.TestCheckResourceAttr(resourceName, "cloud_cidr_pool_dn", fmt.Sprintf("uni/tn-%s/ctxprofile-%s/cidr-[%s]", rNameUpdated, rNameUpdated, ip)),
+					testAccCheckAciCloudSubnetIdNotEqual(&cloud_subnet_default, &cloud_subnet_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciCloudSubnet_Update(t *testing.T) {
+	var cloud_subnet_default models.CloudSubnet
+	var cloud_subnet_updated models.CloudSubnet
+	resourceName := "aci_cloud_subnet.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	ip, _ := acctest.RandIpAddress("45.4.0.0/16")
+	ip = fmt.Sprintf("%s/16", ip)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudSubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccCloudSubnetConfig(rName, ip),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudSubnetExists(resourceName, &cloud_subnet_default),
+				),
+			},
+			{
+
+				Config: CreateAccCloudSubnetUpdatedAttrList(rName, ip, "scope", StringListtoString([]string{"private", "public"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudSubnetExists(resourceName, &cloud_subnet_updated),
+					resource.TestCheckResourceAttr(resourceName, "scope.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scope.0", "private"),
+					resource.TestCheckResourceAttr(resourceName, "scope.1", "public"),
+					testAccCheckAciCloudSubnetIdEqual(&cloud_subnet_default, &cloud_subnet_updated),
+				),
+			},
+			{
+
+				Config: CreateAccCloudSubnetUpdatedAttrList(rName, ip, "scope", StringListtoString([]string{"private", "public", "shared"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudSubnetExists(resourceName, &cloud_subnet_updated),
+					resource.TestCheckResourceAttr(resourceName, "scope.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "scope.0", "private"),
+					resource.TestCheckResourceAttr(resourceName, "scope.1", "public"),
+					resource.TestCheckResourceAttr(resourceName, "scope.2", "shared"),
+					testAccCheckAciCloudSubnetIdEqual(&cloud_subnet_default, &cloud_subnet_updated),
+				),
+			},
+			{
+
+				Config: CreateAccCloudSubnetUpdatedAttrList(rName, ip, "scope", StringListtoString([]string{"public", "shared"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudSubnetExists(resourceName, &cloud_subnet_updated),
+					resource.TestCheckResourceAttr(resourceName, "scope.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "scope.0", "public"),
+					resource.TestCheckResourceAttr(resourceName, "scope.1", "shared"),
+					testAccCheckAciCloudSubnetIdEqual(&cloud_subnet_default, &cloud_subnet_updated),
+				),
+			},
+			{
+
+				Config: CreateAccCloudSubnetUpdatedAttrList(rName, ip, "scope", StringListtoString([]string{"shared"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudSubnetExists(resourceName, &cloud_subnet_updated),
+					resource.TestCheckResourceAttr(resourceName, "scope.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scope.0", "shared"),
+					testAccCheckAciCloudSubnetIdEqual(&cloud_subnet_default, &cloud_subnet_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudSubnetUpdatedAttrList(rName, ip, "scope", StringListtoString([]string{"shared", "public", "private"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudSubnetExists(resourceName, &cloud_subnet_updated),
+					resource.TestCheckResourceAttr(resourceName, "scope.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "scope.0", "shared"),
+					resource.TestCheckResourceAttr(resourceName, "scope.1", "public"),
+					resource.TestCheckResourceAttr(resourceName, "scope.2", "private"),
+					testAccCheckAciCloudSubnetIdEqual(&cloud_subnet_default, &cloud_subnet_updated),
+				),
+			},
+			{
+
+				Config: CreateAccCloudSubnetUpdatedAttr(rName, ip, "usage", "infra-router"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudSubnetExists(resourceName, &cloud_subnet_updated),
+					resource.TestCheckResourceAttr(resourceName, "usage", "infra-router"),
+					testAccCheckAciCloudSubnetIdEqual(&cloud_subnet_default, &cloud_subnet_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciCloudSubnet_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	ip, _ := acctest.RandIpAddress("45.5.0.0/16")
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudSubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccCloudSubnetConfig(rName, ip),
+			},
+			{
+				Config:      CreateAccCloudSubnetConfigWithInvalidParentDn(rName, ip),
+				ExpectError: regexp.MustCompile(`Invalid DN`),
+			},
+			{
+				Config:      CreateAccCloudSubnetUpdatedAttr(rName, ip, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccCloudSubnetUpdatedAttr(rName, ip, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccCloudSubnetUpdatedAttr(rName, ip, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccCloudSubnetUpdatedAttr(rName, ip, "name", acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			{
+				Config:      CreateAccCloudSubnetUpdatedAttrList(rName, ip, "scope", StringListtoString([]string{randomValue})),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccCloudSubnetUpdatedAttrList(rName, ip, "scope", StringListtoString([]string{"private", "private"})),
+				ExpectError: regexp.MustCompile(`duplication is not supported in list`),
+			},
+			{
+				Config:      CreateAccCloudSubnetUpdatedAttr(rName, ip, "usage", randomValue),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccCloudSubnetWithInvalidZone(rName, ip, randomValue),
+				ExpectError: regexp.MustCompile(`Relation target dn (.)+ not found`),
+			},
+			{
+				Config:      CreateAccCloudSubnetUpdatedAttr(rName, ip, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccCloudSubnetConfig(rName, ip),
+			},
+		},
+	})
+}
+
+func TestAccAciCloudSubnet_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudSubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccCloudSubnetConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciCloudSubnetExists(name string, cloud_subnet *models.CloudSubnet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Cloud Subnet %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Cloud Subnet dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		cloud_subnetFound := models.CloudSubnetFromContainer(cont)
+		if cloud_subnetFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Cloud Subnet %s not found", rs.Primary.ID)
+		}
+		*cloud_subnet = *cloud_subnetFound
+		return nil
+	}
+}
+
+func testAccCheckAciCloudSubnetDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing cloud_subnet destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_cloud_subnet" {
+			cont, err := client.Get(rs.Primary.ID)
+			cloud_subnet := models.CloudSubnetFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Cloud Subnet %s Still exists", cloud_subnet.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciCloudSubnetIdEqual(m1, m2 *models.CloudSubnet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("cloud_subnet DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciCloudSubnetIdNotEqual(m1, m2 *models.CloudSubnet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("cloud_subnet DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateCloudSubnetWithoutRequired(rName, ip, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_subnet creation without ", attrName)
+	rBlock := `
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		primary_cidr = "%s"
+		name = "%s"
+		region = "us-east-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+
+	resource "aci_cloud_cidr_pool" "test" {
+		cloud_context_profile_dn = aci_cloud_context_profile.test.id
+		addr = "%s"
+	}
+	`
+	switch attrName {
+	case "ip":
+		rBlock += `
+	resource "aci_cloud_subnet" "test" {
+		cloud_cidr_pool_dn = aci_cloud_cidr_pool.test.id
+	#	ip  = "%s"
+	}
+		`
+	case "cloud_cidr_pool_dn":
+		rBlock += `
+	resource "aci_cloud_subnet" "test" {
+	#	cloud_cidr_pool_dn = aci_cloud_cidr_pool.test.id
+		ip  = "%s"
+	}
+		`
+
+	}
+	return fmt.Sprintf(rBlock, rName, rName, ip, rName, ip)
+}
+
+func CreateAccCloudSubnetConfigWithRequiredParams(rName, ip, ip_subnet string) string {
+	fmt.Printf("=== STEP  testing cloud_subnet creation with parent resource name %s, parent resource ip %s and subnet ip %s\n", rName, ip, ip_subnet)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		primary_cidr = "%s"
+		name = "%s"
+		region = "us-east-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+
+	resource "aci_cloud_cidr_pool" "test" {
+		cloud_context_profile_dn = aci_cloud_context_profile.test.id
+		addr = "%s"
+	}
+
+	resource "aci_cloud_subnet" "test" {
+		cloud_cidr_pool_dn = aci_cloud_cidr_pool.test.id
+		ip  = "%s"
+		zone = "uni/clouddomp/provp-aws/region-us-east-1/zone-us-east-1a"
+	}
+	`, rName, rName, ip, rName, ip, ip_subnet)
+	return resource
+}
+
+func CreateAccCloudSubnetConfig(rName, ip string) string {
+	fmt.Println("=== STEP  testing cloud_subnet creation with required arguments and zone")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		primary_cidr = "%s"
+		name = "%s"
+		region = "us-east-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+
+	resource "aci_cloud_cidr_pool" "test" {
+		cloud_context_profile_dn = aci_cloud_context_profile.test.id
+		addr = "%s"
+	}
+
+	resource "aci_cloud_subnet" "test" {
+		cloud_cidr_pool_dn = aci_cloud_cidr_pool.test.id
+		ip  = "%s"
+		zone = "uni/clouddomp/provp-aws/region-us-east-1/zone-us-east-1a"
+	}
+	`, rName, rName, ip, rName, ip, ip)
+	return resource
+}
+
+func CreateAccCloudSubnetConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple cloud_subnet creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		primary_cidr = "45.6.0.0/16"
+		name = "%s"
+		region = "us-east-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+
+	resource "aci_cloud_cidr_pool" "test" {
+		cloud_context_profile_dn = aci_cloud_context_profile.test.id
+		addr = "45.6.0.0/16"
+	}
+
+	resource "aci_cloud_subnet" "test" {
+		cloud_cidr_pool_dn = aci_cloud_cidr_pool.test.id
+		ip  = "45.6.${count.index+1}.0/24"
+		count = 5
+		zone = "uni/clouddomp/provp-aws/region-us-east-1/zone-us-east-1a"
+	}
+	`, rName, rName, rName)
+	return resource
+}
+
+func CreateAccCloudSubnetWithInavalidIP(rName, ip string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_subnet creation with invalid IP")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		primary_cidr = "%s"
+		name = "%s"
+		region = "us-east-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+
+	resource "aci_cloud_cidr_pool" "test" {
+		cloud_context_profile_dn = aci_cloud_context_profile.test.id
+		addr = "%s"
+	}
+
+	resource "aci_cloud_subnet" "test" {
+		cloud_cidr_pool_dn = aci_cloud_cidr_pool.test.id
+		name = "test_cloud_subnet_name"
+		ip  = "%s"
+		zone = "uni/clouddomp/provp-aws/region-us-east-1/zone-us-east-1a"
+	}
+	`, rName, rName, ip, rName, ip, rName)
+
+	return resource
+}
+
+func CreateAccCloudSubnetConfigWithOptionalValues(rName, ip string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_subnet creation with optional parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		primary_cidr = "%s"
+		name = "%s"
+		region = "us-east-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+
+	resource "aci_cloud_cidr_pool" "test" {
+		cloud_context_profile_dn = aci_cloud_context_profile.test.id
+		addr = "%s"
+	}
+
+	resource "aci_cloud_subnet" "test" {
+		cloud_cidr_pool_dn = aci_cloud_cidr_pool.test.id
+		name = "test_cloud_subnet_name"
+		ip  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_cloud_subnet"
+		scope = ["public"]
+		usage = "gateway"
+		zone = "uni/clouddomp/provp-aws/region-us-east-1/zone-us-east-1a"
+	}
+	`, rName, rName, ip, rName, ip, ip)
+
+	return resource
+}
+
+func CreateAccCloudSubnetRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing cloud_subnet updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_cloud_subnet" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_cloud_subnet"
+		scope = ["public"]
+		usage = "gateway"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccCloudSubnetConfigWithInvalidParentDn(rName, ip string) string {
+	fmt.Println("=== STEP  testing cloud_subnet with invalid parent dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_cloud_subnet" "test" {
+		cloud_cidr_pool_dn = aci_tenant.test.id
+		ip  = "%s"
+		zone = "uni/clouddomp/provp-aws/region-us-east-1/zone-us-east-1a"
+	}
+	`, rName, ip)
+	return resource
+}
+
+func CreateAccCloudSubnetWithInvalidZone(rName, ip, value string) string {
+	fmt.Printf("=== STEP  testing cloud_subnet attribute: zone = %s \n", value)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		primary_cidr = "%s"
+		name = "%s"
+		region = "us-east-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+
+	resource "aci_cloud_cidr_pool" "test" {
+		cloud_context_profile_dn = aci_cloud_context_profile.test.id
+		addr = "%s"
+	}
+
+	resource "aci_cloud_subnet" "test" {
+		cloud_cidr_pool_dn = aci_cloud_cidr_pool.test.id
+		ip  = "%s"
+		zone = "%s"
+	}
+	`, rName, rName, ip, rName, ip, ip, value)
+	return resource
+}
+
+func CreateAccCloudSubnetUpdatedAttr(rName, ip, attribute, value string) string {
+	fmt.Printf("=== STEP  testing cloud_subnet attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		primary_cidr = "%s"
+		name = "%s"
+		region = "us-east-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+
+	resource "aci_cloud_cidr_pool" "test" {
+		cloud_context_profile_dn = aci_cloud_context_profile.test.id
+		addr = "%s"
+	}
+
+	resource "aci_cloud_subnet" "test" {
+		cloud_cidr_pool_dn = aci_cloud_cidr_pool.test.id
+		ip  = "%s"
+		zone = "uni/clouddomp/provp-aws/region-us-east-1/zone-us-east-1a"
+		%s = "%s"
+	}
+	`, rName, rName, ip, rName, ip, ip, attribute, value)
+	return resource
+}
+
+func CreateAccCloudSubnetUpdatedAttrList(rName, ip, attribute, value string) string {
+	fmt.Printf("=== STEP  testing cloud_subnet attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		primary_cidr = "%s"
+		name = "%s"
+		region = "us-east-1"
+		cloud_vendor = "aws"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+
+	resource "aci_cloud_cidr_pool" "test" {
+		cloud_context_profile_dn = aci_cloud_context_profile.test.id
+		addr = "%s"
+	}
+
+	resource "aci_cloud_subnet" "test" {
+		cloud_cidr_pool_dn = aci_cloud_cidr_pool.test.id
+		name = "test_cloud_subnet_name"
+		ip  = "%s"
+		zone = "uni/clouddomp/provp-aws/region-us-east-1/zone-us-east-1a"
+		%s = %s
+	}
+	`, rName, rName, ip, rName, ip, ip, attribute, value)
+	return resource
+}


### PR DESCRIPTION
$ go test -v -run TestAccAciCloudExternalEPg -timeout=60m
=== RUN   TestAccAciCloudExternalEPgDataSource_Basic
=== STEP  Basic: testing cloud_external_epg Data Source without  cloud_applicationcontainer_dn
=== STEP  Basic: testing cloud_external_epg Data Source without  name
=== STEP  testing cloud_external_epg Data Source with required arguments only
=== STEP  testing cloud_external_epg Data Source with random attribute
=== STEP  testing cloud_external_epg Data Source with invalid name
=== STEP  testing cloud_external_epg Data Source with updated resource
=== PAUSE TestAccAciCloudExternalEPgDataSource_Basic
=== RUN   TestAccAciCloudExternalEPg_Basic
=== STEP  Basic: testing cloud_external_epg creation without  cloud_applicationcontainer_dn
=== STEP  Basic: testing cloud_external_epg creation without  name
=== STEP  testing cloud_external_epg creation with required arguments only
=== STEP  Basic: testing cloud_external_epg creation with optional parameters
=== STEP  testing cloud_external_epg creation with invalid name =  nbem6uzejavufely6kmt3nm6s2any7cyta7ot0w4ovwa1uk1eh1spc11w8gg62k39
=== STEP  Basic: testing cloud_external_epg updation without required parameters
=== STEP  testing cloud_external_epg creation with parent resource name acctest_co4hu and resource name acctest_sc2h9
=== STEP  testing cloud_external_epg creation with required arguments only
=== STEP  testing cloud_external_epg creation with parent resource name acctest_sc2h9 and resource name acctest_co4hu
=== PAUSE TestAccAciCloudExternalEPg_Basic
=== RUN   TestAccAciCloudExternalEPg_Update
=== STEP  testing cloud_external_epg creation with required arguments only
=== STEP  testing cloud_external_epg attribute: exception_tag = 512
=== STEP  testing cloud_external_epg attribute: exception_tag = 256
=== STEP  testing cloud_external_epg attribute: match_t = AtmostOne
=== STEP  testing cloud_external_epg attribute: match_t = None
=== STEP  testing cloud_external_epg attribute: prio = level2
=== STEP  testing cloud_external_epg attribute: prio = level3
=== STEP  testing cloud_external_epg attribute: prio = level4
=== STEP  testing cloud_external_epg attribute: prio = level5
=== STEP  testing cloud_external_epg attribute: prio = level6
=== STEP  testing cloud_external_epg attribute: route_reachability = internet
=== STEP  testing cloud_external_epg attribute: route_reachability = site-ext
=== STEP  testing cloud_external_epg attribute: route_reachability = unspecified
=== STEP  testing cloud_external_epg attribute: route_reachability = inter-site-ext
=== STEP  testing cloud_external_epg creation with required arguments only
=== PAUSE TestAccAciCloudExternalEPg_Update
=== RUN   TestAccAciCloudExternalEPg_Negative
=== STEP  testing cloud_external_epg creation with required arguments only
=== STEP  testing cloud_external_epg attribute: route_reachability = internet
=== STEP  Negative Case: testing cloud_external_epg creation with invalid parent Dn
=== STEP  testing cloud_external_epg attribute: description = wbaow2n79oiqeb9bk2j19m8fppqzyaxwfrg8qlqxsx38gcj1lngziwwj4sudiv4wnigrvphig09fg4rztddfn6nuskesomqdy7d8qvmntjl7oth0qi2le8erhyivacmmp
=== STEP  testing cloud_external_epg attribute: annotation = vkjxrzfxy8g18kganwcq8gkmp8mxqhir0wiu4afs9h2zmwdpxhp00dqf9mch6eqfgmtd4l3cz2qdzllflfs28b0bykxk6tu1s9ihzv3fwcy3mgoahdsavmqaxrvlmx9q9
=== STEP  testing cloud_external_epg attribute: name_alias = w94yqnamsuzluy7tug0kxzffifyj6mwmico46yf4xcbrfbkvc0dg9mtdacfnz3ho
=== STEP  testing cloud_external_epg attribute: flood_on_encap = 1c4e7
=== STEP  testing cloud_external_epg attribute: match_t = 1c4e7
=== STEP  testing cloud_external_epg attribute: pref_gr_memb = 1c4e7
=== STEP  testing cloud_external_epg attribute: prio = 1c4e7
=== STEP  testing cloud_external_epg attribute: route_reachability = 1c4e7
=== STEP  testing cloud_external_epg attribute: klyui = 1c4e7
=== STEP  testing cloud_external_epg creation with required arguments only
=== PAUSE TestAccAciCloudExternalEPg_Negative
=== RUN   TestAccAciCloudExternalEPg_MultipleCreateDelete
=== STEP  testing multiple cloud_external_epg creation with required arguments only
=== PAUSE TestAccAciCloudExternalEPg_MultipleCreateDelete
=== CONT  TestAccAciCloudExternalEPgDataSource_Basic
=== CONT  TestAccAciCloudExternalEPg_Negative
=== CONT  TestAccAciCloudExternalEPg_Update
=== CONT  TestAccAciCloudExternalEPg_Basic
=== CONT  TestAccAciCloudExternalEPg_MultipleCreateDelete
=== STEP  testing cloud_external_epg destroy
--- PASS: TestAccAciCloudExternalEPg_MultipleCreateDelete (62.70s)
=== STEP  testing cloud_external_epg destroy
--- PASS: TestAccAciCloudExternalEPgDataSource_Basic (111.57s)
=== STEP  testing cloud_external_epg destroy
--- PASS: TestAccAciCloudExternalEPg_Negative (152.46s)
=== STEP  testing cloud_external_epg destroy
--- PASS: TestAccAciCloudExternalEPg_Basic (214.09s)
=== STEP  testing cloud_external_epg destroy
--- PASS: TestAccAciCloudExternalEPg_Update (497.93s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   501.877s
$ go test -v -run TestAccAciCloudVpnGateway -timeout=60m
=== RUN   TestAccAciCloudVpnGatewayDataSource_Basic
=== STEP  Basic: testing cloud_vpn_gateway Data Source without  cloud_context_profile_dn
=== STEP  Basic: testing cloud_vpn_gateway Data Source without  name
=== STEP  testing cloud_vpn_gateway Data Source with required arguments only
=== STEP  testing cloud_vpn_gateway Data Source with random attribute
=== STEP  testing cloud_vpn_gateway Data Source with Invalid Parent Dn
=== STEP  testing cloud_vpn_gateway Data Source with updated resource
=== PAUSE TestAccAciCloudVpnGatewayDataSource_Basic
=== RUN   TestAccAciCloudVpnGateway_Basic
=== STEP  Basic: testing cloud_vpn_gateway creation without  cloud_context_profile_dn
=== STEP  Basic: testing cloud_vpn_gateway creation without  name
=== STEP  testing cloud_vpn_gateway creation with required arguments only
=== STEP  Basic: testing cloud_vpn_gateway creation with optional parameters
=== STEP  testing cloud_vpn_gateway creation with invalid name =  a1yfqcxub0z0uzkieyv969sva97rfd2onnz96ulf8m99b08tht9awbs29qrt7yl1u
=== STEP  Basic: testing cloud_vpn_gateway updation without required parameters
=== STEP  testing cloud_vpn_gateway creation with parent resource name acctest_d7onc and resource name acctest_lzibb
=== STEP  testing cloud_vpn_gateway creation with required arguments only
=== STEP  testing cloud_vpn_gateway creation with parent resource name acctest_lzibb and resource name acctest_d7onc
=== PAUSE TestAccAciCloudVpnGateway_Basic
=== RUN   TestAccAciCloudVpnGateway_Negative
=== STEP  testing cloud_vpn_gateway creation with required arguments only
=== STEP  Negative Case: testing cloud_vpn_gateway creation with invalid parent Dn
=== STEP  testing cloud_vpn_gateway attribute: description = 4ys2c164nvlen2iujgexafzawtxn3zghzvd8sak1uzxjqvjguzrxwqenc0y2pnrahmpvjdb0jdqejpwbbaaxzspyftg02goehtq7ecnsxrr9uw9rauy9yjexehm4x9ic0
=== STEP  testing cloud_vpn_gateway attribute: annotation = sai0rf08nyqna3fp2nzmqqcxh6az87nxmi6it7pb408qfhdkoljc1fntp8ruvhj92z8b3dz2rvdb9uehrz7zfy9bfs4vdq1p9zt1k2lnlz90mzh1fvb8bmkda7x7ajxch
=== STEP  testing cloud_vpn_gateway attribute: name_alias = 88atzd0vnxph1w84eeqga9wef66gp8nfh6gnqyoao078g0vo0ssaichakb9li9rt
=== STEP  testing cloud_vpn_gateway attribute: num_instances = 44e66
=== STEP  testing cloud_vpn_gateway attribute: cloud_router_profile_type = 44e66
=== STEP  testing cloud_vpn_gateway attribute: tygiv = 44e66
=== STEP  testing cloud_vpn_gateway creation with required arguments only
=== PAUSE TestAccAciCloudVpnGateway_Negative
=== CONT  TestAccAciCloudVpnGatewayDataSource_Basic
=== CONT  TestAccAciCloudVpnGateway_Negative
=== CONT  TestAccAciCloudVpnGateway_Basic
=== STEP  testing cloud_vpn_gateway destroy
--- PASS: TestAccAciCloudVpnGatewayDataSource_Basic (113.97s)
=== STEP  testing cloud_vpn_gateway destroy
--- PASS: TestAccAciCloudVpnGateway_Negative (171.84s)
=== STEP  testing cloud_vpn_gateway destroy
--- PASS: TestAccAciCloudVpnGateway_Basic (245.90s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   248.601s
$ go test -v -run TestAccAciCloudEPg_Negative -timeout=60m
=== RUN   TestAccAciCloudEPg_Negative
=== STEP  testing cloud_epg creation with required arguments only
=== STEP  Negative Case: testing cloud_epg creation with invalid parent Dn
=== STEP  testing cloud_epg attribute: description = qgzf060g1iaszinjpukytc97w47wtes2bxxjopa1lpgp3y3qho6elfwk3ev70nokvkerk3msx98oktfbqjsbmq2wikmf2864ozo8he1bwfhrr1lr38fm3npxbk414urje
=== STEP  testing cloud_epg attribute: annotation = 614er13pf627os0lsseyhq8f6t3geqjm6ftfgqu64re8l8bbawfpcu6pz1g3l8ay7qy7pufppoo2qc3wmr9yy34e1xe46alg0dndxolwd0otlqzjye16snn1v8azt6riw
=== STEP  testing cloud_epg attribute: name_alias = i28q3evkjbobcpvx6fwjsoydhcvomddhdbviqw3yl0idavv3hf3ejvryklvice08
=== STEP  testing cloud_epg attribute: flood_on_encap = 8ifgw
=== STEP  testing cloud_epg attribute: match_t = 8ifgw
=== STEP  testing cloud_epg attribute: prio = 8ifgw
=== STEP  testing cloud_epg attribute: pref_gr_memb = 8ifgw
=== STEP  testing cloud_epg attribute: cjauv = 8ifgw
=== STEP  testing cloud_epg creation with required arguments only
=== PAUSE TestAccAciCloudEPg_Negative
=== CONT  TestAccAciCloudEPg_Negative
=== STEP  testing cloud_epg destroy
--- PASS: TestAccAciCloudEPg_Negative (136.49s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   139.392s
$ go test -v -run TestAccAciCloudSubnet -timeout=60m
=== RUN   TestAccAciCloudSubnetDataSource_Basic
=== STEP  Basic: testing cloud_subnet Data Source without  ip
=== STEP  Basic: testing cloud_subnet Data Source without  cloud_cidr_pool_dn
=== STEP  testing cloud_subnet Data Source with required arguments only
=== STEP  testing cloud_subnet Data Source with random attribute
=== STEP  testing cloud_subnet Data Source with invalid ip
=== STEP  testing cloud_subnet Data Source with updated resource
=== PAUSE TestAccAciCloudSubnetDataSource_Basic
=== RUN   TestAccAciCloudSubnet_Basic
=== STEP  Basic: testing cloud_subnet creation without  ip
=== STEP  Basic: testing cloud_subnet creation without  cloud_cidr_pool_dn
=== STEP  testing cloud_subnet creation with required arguments and zone
=== STEP  Basic: testing cloud_subnet creation with optional parameters
=== STEP  Basic: testing cloud_subnet creation with invalid IP
=== STEP  Basic: testing cloud_subnet updation without required parameters
=== STEP  testing cloud_subnet creation with parent resource name acctest_zesr1, parent resource ip 45.3.247.147/16 and subnet ip 45.3.247.147/17
=== STEP  testing cloud_subnet creation with required arguments and zone
=== STEP  testing cloud_subnet creation with parent resource name acctest_furr7, parent resource ip 45.3.247.147/16 and subnet ip 45.3.247.147/16
=== PAUSE TestAccAciCloudSubnet_Basic
=== RUN   TestAccAciCloudSubnet_Update
=== STEP  testing cloud_subnet creation with required arguments and zone
=== STEP  testing cloud_subnet attribute: scope = ["private","public"]
=== STEP  testing cloud_subnet attribute: scope = ["private","public","shared"]
=== STEP  testing cloud_subnet attribute: scope = ["public","shared"]
=== STEP  testing cloud_subnet attribute: scope = ["shared"]
=== STEP  testing cloud_subnet attribute: scope = ["shared","public","private"]
=== STEP  testing cloud_subnet attribute: usage = infra-router
=== PAUSE TestAccAciCloudSubnet_Update
=== RUN   TestAccAciCloudSubnet_Negative
=== STEP  testing cloud_subnet creation with required arguments and zone
=== STEP  testing cloud_subnet with invalid parent dn
=== STEP  testing cloud_subnet attribute: description = da6tk4umnnljglk9dqfb4atq1rkdh3fzy4tt77uip3ao142r8hznc9kgg8lu8ftnqya8yji6v43a472bfn9b9boeesam8wrdazv1val6e3cd8s69c2uuqsfbweiaq19mw
=== STEP  testing cloud_subnet attribute: annotation = psgbxd9zmcbnbwg0gzijvdx4weuf8q7294orqjlp7scn6omluz2htl7ylzfef7b87097tqpdys803vtm3a0g2t8l8skn2eaps3bwrvas0denofxzpjmxzbsdy7dezfp07
=== STEP  testing cloud_subnet attribute: name_alias = js78lplj3ekiolidlunxiyjr8kzmwnh39tp18qmbjmjhenoiiuhlu1rbodbz8mps
=== STEP  testing cloud_subnet attribute: name = lckdnzbqgegwhbb0j3t7qffdx8u2zyiuxzqyirv2cp9cxiqzvmgsms18hxsviihz4
=== STEP  testing cloud_subnet attribute: scope = ["2qw7o"]
=== STEP  testing cloud_subnet attribute: scope = ["private","private"]
=== STEP  testing cloud_subnet attribute: usage = 2qw7o
=== STEP  testing cloud_subnet attribute: zone = 2qw7o
=== STEP  testing cloud_subnet attribute: qfrrs = 2qw7o
=== STEP  testing cloud_subnet creation with required arguments and zone
=== PAUSE TestAccAciCloudSubnet_Negative
=== RUN   TestAccAciCloudSubnet_MultipleCreateDelete
=== STEP  testing multiple cloud_subnet creation with required arguments only
=== PAUSE TestAccAciCloudSubnet_MultipleCreateDelete
=== CONT  TestAccAciCloudSubnetDataSource_Basic
=== CONT  TestAccAciCloudSubnet_Negative
=== CONT  TestAccAciCloudSubnet_Basic
=== CONT  TestAccAciCloudSubnet_MultipleCreateDelete
=== CONT  TestAccAciCloudSubnet_Update
=== STEP  testing cloud_subnet destroy
--- PASS: TestAccAciCloudSubnet_MultipleCreateDelete (51.92s)
=== STEP  testing cloud_subnet destroy
--- PASS: TestAccAciCloudSubnetDataSource_Basic (90.94s)
=== STEP  testing cloud_subnet destroy
--- PASS: TestAccAciCloudSubnet_Negative (221.59s)
=== STEP  testing cloud_subnet destroy
--- PASS: TestAccAciCloudSubnet_Basic (242.30s)
=== STEP  testing cloud_subnet destroy
--- PASS: TestAccAciCloudSubnet_Update (278.95s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   281.554s
