### PR TITLE
Epgs using function

### DIFF
--- a/testacc/data_source_aci_infrarsfunctoepg_test.go
+++ b/testacc/data_source_aci_infrarsfunctoepg_test.go
@@ -1,0 +1,304 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciEPGsUsingFunctionDataSource_Basic(t *testing.T) {
+	resourceName := "aci_epgs_using_function.test"
+	dataSourceName := "data.aci_epgs_using_function.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	tDn := makeTestVariable(acctest.RandString(5))
+	infraAttEntityPName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciEPGsUsingFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateEPGsUsingFunctionDSWithoutRequired(infraAttEntityPName, tDn, "access_generic_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateEPGsUsingFunctionDSWithoutRequired(infraAttEntityPName, tDn, "tdn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			// {
+			// 	Config:      CreateEPGsUsingFunctionDSWithoutRequired(infraAttEntityPName, tDn, "encap"),
+			// 	ExpectError: regexp.MustCompile(`Missing required argument`),
+			// },
+			{
+				Config: CreateAccEPGsUsingFunctionConfigDataSource(infraAttEntityPName, tDn),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "access_generic_dn", resourceName, "access_generic_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tdn", resourceName, "tdn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "encap", resourceName, "encap"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "instr_imedcy", resourceName, "instr_imedcy"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "mode", resourceName, "mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "primary_encap", resourceName, "primary_encap"),
+				),
+			},
+			{
+				Config:      CreateAccEPGsUsingFunctionDataSourceUpdate(infraAttEntityPName, tDn, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccEPGsUsingFunctionDSWithInvalidParentDn(infraAttEntityPName, tDn),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccEPGsUsingFunctionDataSourceUpdatedResource(infraAttEntityPName, tDn, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccEPGsUsingFunctionConfigDataSource(infraAttEntityPName, tDn string) string {
+	fmt.Println("=== STEP  testing epgs_using_function Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+	resource "aci_application_epg" "test" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_attachable_access_entity_profile" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_access_generic" "test" {
+		attachable_access_entity_profile_dn = aci_attachable_access_entity_profile.test.id
+		name = "default"
+	}
+
+	resource "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_epg.test.id
+		encap = "vlan-1"
+	}
+
+	data "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_epgs_using_function.test.access_generic_dn
+		tdn  = aci_epgs_using_function.test.tdn
+		encap = aci_epgs_using_function.test.encap
+		depends_on = [ aci_epgs_using_function.test ]
+	}
+	`, infraAttEntityPName, infraAttEntityPName, infraAttEntityPName, infraAttEntityPName)
+	return resource
+}
+
+func CreateEPGsUsingFunctionDSWithoutRequired(infraAttEntityPName, tDn, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing epgs_using_function creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+	resource "aci_application_epg" "test" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_attachable_access_entity_profile" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_access_generic" "test" {
+		attachable_access_entity_profile_dn = aci_attachable_access_entity_profile.test.id
+		name = "default"
+	}
+
+	resource "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_epg.test.id
+		encap = "vlan-1"
+	}
+	`
+	switch attrName {
+	case "access_generic_dn":
+		rBlock += `
+	data "aci_epgs_using_function" "test" {
+	#	access_generic_dn  = aci_epgs_using_function.test.access_generic_dn
+		tdn  = aci_epgs_using_function.test.tdn
+		encap = aci_epgs_using_function.test.encap
+		depends_on = [ aci_epgs_using_function.test ]
+	}
+		`
+	case "tdn":
+		rBlock += `
+	data "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_epgs_using_function.test.access_generic_dn
+	#	tdn  = aci_epgs_using_function.test.tdn
+		encap = aci_epgs_using_function.test.encap
+		depends_on = [ aci_epgs_using_function.test ]
+	}
+	`
+	case "encap":
+		rBlock += `
+	data "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_epgs_using_function.test.access_generic_dn
+		tdn  = aci_epgs_using_function.test.tdn
+	#	encap = aci_epgs_using_function.test.encap
+		depends_on = [ aci_epgs_using_function.test ]
+	}
+	`
+	}
+	return fmt.Sprintf(rBlock, infraAttEntityPName, infraAttEntityPName, infraAttEntityPName, infraAttEntityPName)
+}
+
+func CreateAccEPGsUsingFunctionDSWithInvalidParentDn(infraAttEntityPName, tDn string) string {
+	fmt.Println("=== STEP  testing epgs_using_function Data Source with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+	resource "aci_application_epg" "test" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_attachable_access_entity_profile" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_access_generic" "test" {
+		attachable_access_entity_profile_dn = aci_attachable_access_entity_profile.test.id
+		name = "default"
+	}
+
+	resource "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_epg.test.id
+		encap = "vlan-1"
+	}
+
+	data "aci_epgs_using_function" "test" {
+		access_generic_dn  = "${aci_epgs_using_function.test.access_generic_dn}_invalid"
+		tdn  = aci_epgs_using_function.test.tdn
+		encap = aci_epgs_using_function.test.encap
+		depends_on = [ aci_epgs_using_function.test ]
+	}
+	`, infraAttEntityPName, infraAttEntityPName, infraAttEntityPName, infraAttEntityPName)
+	return resource
+}
+
+func CreateAccEPGsUsingFunctionDataSourceUpdate(infraAttEntityPName, tDn, key, value string) string {
+	fmt.Println("=== STEP  testing epgs_using_function Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+	resource "aci_application_epg" "test" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_attachable_access_entity_profile" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_access_generic" "test" {
+		attachable_access_entity_profile_dn = aci_attachable_access_entity_profile.test.id
+		name = "default"
+	}
+
+	resource "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_epg.test.id
+		encap = "vlan-1"
+	}
+
+	data "aci_epgs_using_function" "test" {
+		access_generic_dn  = "${aci_epgs_using_function.test.access_generic_dn}_invalid"
+		tdn  = aci_epgs_using_function.test.tdn
+		encap = aci_epgs_using_function.test.encap
+		%s = "%s"
+		depends_on = [ aci_epgs_using_function.test ]
+	}
+	`, infraAttEntityPName, infraAttEntityPName, infraAttEntityPName, infraAttEntityPName, key, value)
+	return resource
+}
+
+func CreateAccEPGsUsingFunctionDataSourceUpdatedResource(infraAttEntityPName, tDn, key, value string) string {
+	fmt.Println("=== STEP  testing epgs_using_function Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+	resource "aci_application_epg" "test" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_attachable_access_entity_profile" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_access_generic" "test" {
+		attachable_access_entity_profile_dn = aci_attachable_access_entity_profile.test.id
+		name = "default"
+	}
+
+	resource "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_epg.test.id
+		encap = "vlan-1"
+		%s = "%s"
+	}
+
+	data "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_epgs_using_function.test.access_generic_dn
+		tdn  = aci_epgs_using_function.test.tdn
+		encap = aci_epgs_using_function.test.encap
+		depends_on = [ aci_epgs_using_function.test ]
+	}
+	`, infraAttEntityPName, infraAttEntityPName, infraAttEntityPName, infraAttEntityPName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_vmmvswitchpolicycont_test.go
+++ b/testacc/data_source_aci_vmmvswitchpolicycont_test.go
@@ -1,0 +1,160 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciVSwitchPolicyDataSource_Basic(t *testing.T) {
+	resourceName := "aci_vswitch_policy.test"
+	dataSourceName := "data.aci_vswitch_policy.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVSwitchPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateVSwitchPolicyDSWithoutRequired(rName, rName, "vmm_domain_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			}, {
+				Config: CreateAccVSwitchPolicyConfigDataSource(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "vmm_domain_dn", resourceName, "vmm_domain_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+				),
+			},
+			{
+				Config:      CreateAccVSwitchPolicyDataSourceUpdate(rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccVSwitchPolicyDSWithInvalidParentDn(rName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccVSwitchPolicyDataSourceUpdatedResource(rName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccVSwitchPolicyConfigDataSource(vmmProvPName, vmmDomPName string) string {
+	fmt.Println("=== STEP  testing vswitch_policy Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	
+	resource "aci_vswitch_policy" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+	}
+
+	data "aci_vswitch_policy" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		depends_on = [ aci_vswitch_policy.test ]
+	}
+	`, vmmDomPName)
+	return resource
+}
+
+func CreateVSwitchPolicyDSWithoutRequired(vmmProvPName, vmmDomPName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing vswitch_policy Data Source without ", attrName)
+	rBlock := `
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	
+	resource "aci_vswitch_policy" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+	}
+	`
+	switch attrName {
+	case "vmm_domain_dn":
+		rBlock += `
+	data "aci_vswitch_policy" "test" {
+	#	vmm_domain_dn  = aci_vmm_domain.test.id
+		depends_on = [ aci_vswitch_policy.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, vmmDomPName)
+}
+
+func CreateAccVSwitchPolicyDSWithInvalidParentDn(vmmProvPName, vmmDomPName string) string {
+	fmt.Println("=== STEP  testing vswitch_policy Data Source with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	resource "aci_vswitch_policy" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+	}
+
+	data "aci_vswitch_policy" "test" {
+		vmm_domain_dn  = "${aci_vmm_domain.test.id}_invalid"
+		depends_on = [ aci_vswitch_policy.test ]
+	}
+	`, vmmDomPName)
+	return resource
+}
+
+func CreateAccVSwitchPolicyDataSourceUpdate(vmmProvPName, vmmDomPName, key, value string) string {
+	fmt.Println("=== STEP  testing vswitch_policy Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	resource "aci_vswitch_policy" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+	}
+
+	data "aci_vswitch_policy" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		%s = "%s"
+		depends_on = [ aci_vswitch_policy.test ]
+	}
+	`, vmmDomPName, key, value)
+	return resource
+}
+
+func CreateAccVSwitchPolicyDataSourceUpdatedResource(vmmProvPName, vmmDomPName, key, value string) string {
+	fmt.Println("=== STEP  testing vswitch_policy Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+
+	resource "aci_vswitch_policy" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		%s = "%s"
+	}
+
+	data "aci_vswitch_policy" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		depends_on = [ aci_vswitch_policy.test ]
+	}
+	`, vmmDomPName, key, value)
+	return resource
+}

--- a/testacc/resource_aci_infraaccbndlgrp_test.go
+++ b/testacc/resource_aci_infraaccbndlgrp_test.go
@@ -301,7 +301,7 @@ func CreateAccLeafAccessBundlePolicyGroupConfigWithOptionalValues(rName string) 
 }
 
 func CreateAccLeafAccessBundlePolicyGroupRemovingRequiredField() string {
-	fmt.Println("=== STEP  Basic: testing leaf_access_bundle_policy_group updation with required parameters")
+	fmt.Println("=== STEP  Basic: testing leaf_access_bundle_policy_group updation without required parameters")
 	resource := fmt.Sprintf(`
 	resource "aci_leaf_access_bundle_policy_group" "test" {
 		description = "created while acceptance testing"

--- a/testacc/resource_aci_infraaccportgrp_test.go
+++ b/testacc/resource_aci_infraaccportgrp_test.go
@@ -199,7 +199,7 @@ func CreateLeafAccessPortPolicyGroupWithoutRequired(rName, attrName string) stri
 }
 
 func CreateAccLeafAccessPortPolicyGroupConfigWithUpdatedRequiredParams(rName string) string {
-	fmt.Println("=== STEP  testing leaf_access_port_policy_group creation with updation required arguments ", rName)
+	fmt.Println("=== STEP  testing leaf_access_port_policy_group creation with updated required arguments ", rName)
 	resource := fmt.Sprintf(`
 	resource "aci_leaf_access_port_policy_group" "test" {
 		name  = "%s"
@@ -252,7 +252,7 @@ func CreateAccLeafAccessPortPolicyGroupConfigWithOptionalValues(rName string) st
 }
 
 func CreateAccLeafAccessPortPolicyGroupRemovingRequiredField() string {
-	fmt.Println("=== STEP  Basic: testing leaf_access_port_policy_group updation with required parameters")
+	fmt.Println("=== STEP  Basic: testing leaf_access_port_policy_group updation without required parameters")
 	resource := fmt.Sprintf(`
 	resource "aci_leaf_access_port_policy_group" "test" {
 		description = "created while acceptance testing"

--- a/testacc/resource_aci_infrarsfunctoepg_test.go
+++ b/testacc/resource_aci_infrarsfunctoepg_test.go
@@ -1,0 +1,706 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciEPGsUsingFunction_Basic(t *testing.T) {
+	var epgs_using_function_default models.EPGsUsingFunction
+	var epgs_using_function_updated models.EPGsUsingFunction
+	resourceName := "aci_epgs_using_function.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	tDn := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciEPGsUsingFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateEPGsUsingFunctionWithoutRequired(rName, tDn, "access_generic_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateEPGsUsingFunctionWithoutRequired(rName, tDn, "tdn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateEPGsUsingFunctionWithoutRequired(rName, tDn, "encap"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccEPGsUsingFunctionConfig(rName, tDn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciEPGsUsingFunctionExists(resourceName, &epgs_using_function_default),
+					resource.TestCheckResourceAttr(resourceName, "access_generic_dn", fmt.Sprintf("uni/infra/attentp-%s/gen-default", rName)),
+					resource.TestCheckResourceAttr(resourceName, "tdn", fmt.Sprintf("uni/tn-%s/ap-%s/epg-%s", rName, rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "encap", "vlan-1"),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "instr_imedcy", "lazy"),
+					resource.TestCheckResourceAttr(resourceName, "mode", "regular"),
+					resource.TestCheckResourceAttr(resourceName, "primary_encap", "unknown"),
+				),
+			},
+			{
+				Config: CreateAccEPGsUsingFunctionConfigWithOptionalValues(rName, tDn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciEPGsUsingFunctionExists(resourceName, &epgs_using_function_updated),
+					resource.TestCheckResourceAttr(resourceName, "access_generic_dn", fmt.Sprintf("uni/infra/attentp-%s/gen-default", rName)),
+					resource.TestCheckResourceAttr(resourceName, "tdn", fmt.Sprintf("uni/tn-%s/ap-%s/epg-%s", rName, rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "encap", "vlan-2"),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "instr_imedcy", "immediate"),
+					resource.TestCheckResourceAttr(resourceName, "mode", "native"),
+					resource.TestCheckResourceAttr(resourceName, "primary_encap", "vlan-2"),
+					testAccCheckAciEPGsUsingFunctionIdEqual(&epgs_using_function_default, &epgs_using_function_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccEPGsUsingFunctionRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccEPGsUsingFunctionConfigWithRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciEPGsUsingFunctionExists(resourceName, &epgs_using_function_updated),
+					resource.TestCheckResourceAttr(resourceName, "access_generic_dn", fmt.Sprintf("uni/infra/attentp-%s/gen-default", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "tdn", fmt.Sprintf("uni/tn-%s/ap-%s/epg-%s", rName, rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "encap", "vlan-1"),
+					testAccCheckAciEPGsUsingFunctionIdNotEqual(&epgs_using_function_default, &epgs_using_function_updated),
+				),
+			},
+			{
+				Config: CreateAccEPGsUsingFunctionConfig(rName, tDn),
+			},
+			{
+				Config: CreateAccEPGsUsingFunctionConfigWithRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciEPGsUsingFunctionExists(resourceName, &epgs_using_function_updated),
+					resource.TestCheckResourceAttr(resourceName, "access_generic_dn", fmt.Sprintf("uni/infra/attentp-%s/gen-default", rName)),
+					resource.TestCheckResourceAttr(resourceName, "tdn", fmt.Sprintf("uni/tn-%s/ap-%s/epg-%s", rNameUpdated, rNameUpdated, rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "encap", "vlan-1"),
+					testAccCheckAciEPGsUsingFunctionIdNotEqual(&epgs_using_function_default, &epgs_using_function_updated),
+				),
+			},
+			{
+				Config: CreateAccEPGsUsingFunctionConfig(rName, tDn),
+			},
+			{
+				Config: CreateAccEPGsUsingFunctionConfigWithUpdatedEncap(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciEPGsUsingFunctionExists(resourceName, &epgs_using_function_updated),
+					resource.TestCheckResourceAttr(resourceName, "access_generic_dn", fmt.Sprintf("uni/infra/attentp-%s/gen-default", rName)),
+					resource.TestCheckResourceAttr(resourceName, "tdn", fmt.Sprintf("uni/tn-%s/ap-%s/epg-%s", rName, rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "encap", "vlan-2"),
+					testAccCheckAciEPGsUsingFunctionIdEqual(&epgs_using_function_default, &epgs_using_function_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciEPGsUsingFunction_Update(t *testing.T) {
+	var epgs_using_function_default models.EPGsUsingFunction
+	var epgs_using_function_updated models.EPGsUsingFunction
+	resourceName := "aci_epgs_using_function.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	tDn := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciEPGsUsingFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccEPGsUsingFunctionConfig(rName, tDn),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciEPGsUsingFunctionExists(resourceName, &epgs_using_function_default),
+				),
+			},
+			{
+				Config: CreateAccEPGsUsingFunctionUpdatedAttr(rName, tDn, "mode", "untagged"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciEPGsUsingFunctionExists(resourceName, &epgs_using_function_updated),
+					resource.TestCheckResourceAttr(resourceName, "mode", "untagged"),
+					testAccCheckAciEPGsUsingFunctionIdEqual(&epgs_using_function_default, &epgs_using_function_updated),
+				),
+			},
+			{
+				Config: CreateAccEPGsUsingFunctionConfig(rName, tDn),
+			},
+		},
+	})
+}
+
+func TestAccAciEPGsUsingFunction_Negative(t *testing.T) {
+	tDn := makeTestVariable(acctest.RandString(5))
+	infraAttEntityPName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciEPGsUsingFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccEPGsUsingFunctionConfig(infraAttEntityPName, tDn),
+			},
+			{
+				Config:      CreateAccEPGsUsingFunctionWithInValidParentDn(infraAttEntityPName, tDn),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccEPGsUsingFunctionWithInValidTDn(infraAttEntityPName, tDn),
+				ExpectError: regexp.MustCompile(`Invalid target DN`),
+			},
+			{
+				Config:      CreateAccEPGsUsingFunctionWithInValidEncap(infraAttEntityPName, tDn, randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccEPGsUsingFunctionUpdatedAttr(infraAttEntityPName, tDn, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccEPGsUsingFunctionUpdatedAttr(infraAttEntityPName, tDn, "instr_imedcy", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccEPGsUsingFunctionUpdatedAttr(infraAttEntityPName, tDn, "mode", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccEPGsUsingFunctionUpdatedAttr(infraAttEntityPName, tDn, "primary_encap", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccEPGsUsingFunctionUpdatedAttr(infraAttEntityPName, tDn, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccEPGsUsingFunctionConfig(infraAttEntityPName, tDn),
+			},
+		},
+	})
+}
+
+func TestAccAciEPGsUsingFunction_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	tDn := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciEPGsUsingFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccEPGsUsingFunctionConfigMultiple(rName, tDn),
+			},
+		},
+	})
+}
+
+func testAccCheckAciEPGsUsingFunctionExists(name string, epgs_using_function *models.EPGsUsingFunction) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("EPGs Using Function %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No EPGs Using Function dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		epgs_using_functionFound := models.EPGsUsingFunctionFromContainer(cont)
+		if epgs_using_functionFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("EPGs Using Function %s not found", rs.Primary.ID)
+		}
+		*epgs_using_function = *epgs_using_functionFound
+		return nil
+	}
+}
+
+func testAccCheckAciEPGsUsingFunctionDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing epgs_using_function destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_epgs_using_function" {
+			cont, err := client.Get(rs.Primary.ID)
+			epgs_using_function := models.EPGsUsingFunctionFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("EPGs Using Function %s Still exists", epgs_using_function.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciEPGsUsingFunctionIdEqual(m1, m2 *models.EPGsUsingFunction) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("epgs_using_function DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciEPGsUsingFunctionIdNotEqual(m1, m2 *models.EPGsUsingFunction) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("epgs_using_function DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateEPGsUsingFunctionWithoutRequired(rName, tDn, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing epgs_using_function creation without ", attrName)
+	rBlock := `
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+	resource "aci_application_epg" "test" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_attachable_access_entity_profile" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_access_generic" "test" {
+		attachable_access_entity_profile_dn = aci_attachable_access_entity_profile.test.id
+		name = "default"
+	}
+	`
+	switch attrName {
+	case "access_generic_dn":
+		rBlock += `
+	resource "aci_epgs_using_function" "test" {
+	#	access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_epg.test.id
+		encap = "vlan-1"
+	}
+	`
+	case "tdn":
+		rBlock += `
+	resource "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_access_generic.test.id
+		#	tdn  = aci_application_epg.test.id
+		encap = "vlan-1"
+	}
+	`
+	case "encap":
+		rBlock += `
+	resource "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_epg.test.id
+	#	encap = "vlan-1"
+	}
+	`
+	}
+	return fmt.Sprintf(rBlock, rName, rName, rName, rName)
+}
+
+func CreateAccEPGsUsingFunctionConfigWithRequiredParams(rName, rName1 string) string {
+	fmt.Println("=== STEP  testing epgs_using_function creation with Updation required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+	resource "aci_application_epg" "test" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_attachable_access_entity_profile" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_access_generic" "test" {
+		attachable_access_entity_profile_dn = aci_attachable_access_entity_profile.test.id
+		name = "default"
+	}
+
+	resource "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_epg.test.id
+		encap = "vlan-1"
+	}
+	`, rName, rName, rName, rName1)
+	return resource
+}
+
+func CreateAccEPGsUsingFunctionConfigWithUpdatedEncap(rName, rName1 string) string {
+	fmt.Println("=== STEP  testing epgs_using_function creation with Updation of Encap")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+	resource "aci_application_epg" "test" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_attachable_access_entity_profile" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_access_generic" "test" {
+		attachable_access_entity_profile_dn = aci_attachable_access_entity_profile.test.id
+		name = "default"
+	}
+
+	resource "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_epg.test.id
+		encap = "vlan-2"
+	}
+	`, rName, rName, rName, rName1)
+	return resource
+}
+
+func CreateAccEPGsUsingFunctionConfig(rName, tDn string) string {
+	fmt.Println("=== STEP  testing epgs_using_function creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+	resource "aci_application_epg" "test" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_attachable_access_entity_profile" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_access_generic" "test" {
+		attachable_access_entity_profile_dn = aci_attachable_access_entity_profile.test.id
+		name = "default"
+	}
+
+	resource "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_epg.test.id
+		encap = "vlan-1"
+	}
+	`, rName, rName, rName, rName)
+	return resource
+}
+
+func CreateAccEPGsUsingFunctionConfigMultiple(rName, tDn string) string {
+	fmt.Println("=== STEP  testing multiple epgs_using_function creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+	resource "aci_application_epg" "test" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_application_epg" "test1" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_application_epg" "test2" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_application_epg" "test3" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_epg.test.id
+		encap = "vlan-1"
+	}
+
+	resource "aci_epgs_using_function" "test1" {
+		access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_epg.test1.id
+		encap = "vlan-1"
+	}
+
+	resource "aci_epgs_using_function" "test2" {
+		access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_epg.test2.id
+		encap = "vlan-1"
+	}
+
+	resource "aci_epgs_using_function" "test3" {
+		access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_epg.test3.id
+		encap = "vlan-1"
+	}
+	resource "aci_attachable_access_entity_profile" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_access_generic" "test" {
+		attachable_access_entity_profile_dn = aci_attachable_access_entity_profile.test.id
+		name = "default"
+	}
+
+	`, rName, rName, rName, rName+"1", rName+"2", rName+"3", rName)
+	return resource
+}
+
+func CreateAccEPGsUsingFunctionWithInValidParentDn(rName, tDn string) string {
+	fmt.Println("=== STEP  Negative Case: testing epgs_using_function creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+	resource "aci_application_epg" "test" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_attachable_access_entity_profile" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_access_generic" "test" {
+		attachable_access_entity_profile_dn = aci_attachable_access_entity_profile.test.id
+		name = "default"
+	}
+
+	resource "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_tenant.test.id
+		tdn  = aci_application_epg.test.id
+		encap = "vlan-1"
+	}
+	`, rName, rName, rName, rName)
+	return resource
+}
+
+func CreateAccEPGsUsingFunctionWithInValidTDn(rName, tDn string) string {
+	fmt.Println("=== STEP  Negative Case: testing epgs_using_function creation with invalid TDn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+	resource "aci_application_epg" "test" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_attachable_access_entity_profile" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_access_generic" "test" {
+		attachable_access_entity_profile_dn = aci_attachable_access_entity_profile.test.id
+		name = "default"
+	}
+
+	resource "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_profile.test.id
+		encap = "vlan-1"
+	}
+	`, rName, rName, rName, rName)
+	return resource
+}
+
+func CreateAccEPGsUsingFunctionWithInValidEncap(rName, tDn, encap string) string {
+	fmt.Println("=== STEP  Negative Case: testing epgs_using_function creation with invalid encap")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+	resource "aci_application_epg" "test" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_attachable_access_entity_profile" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_access_generic" "test" {
+		attachable_access_entity_profile_dn = aci_attachable_access_entity_profile.test.id
+		name = "default"
+	}
+
+	resource "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_profile.test.id
+		encap = "%s"
+	}
+	`, rName, rName, rName, rName, encap)
+	return resource
+}
+func CreateAccEPGsUsingFunctionConfigWithOptionalValues(rName, tDn string) string {
+	fmt.Println("=== STEP  Basic: testing epgs_using_function creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+	resource "aci_application_epg" "test" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_attachable_access_entity_profile" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_access_generic" "test" {
+		attachable_access_entity_profile_dn = aci_attachable_access_entity_profile.test.id
+		name = "default"
+	}
+
+	resource "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_epg.test.id
+		encap = "vlan-2"
+		annotation = "orchestrator:terraform_testacc"
+		instr_imedcy = "immediate"
+		mode = "native"
+		primary_encap = "vlan-2"
+	}
+	`, rName, rName, rName, rName)
+	return resource
+}
+
+func CreateAccEPGsUsingFunctionRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing epgs_using_function updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_epgs_using_function" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_epgs_using_function"
+		encap = ""
+		instr_imedcy = "immediate"
+		mode = "native"
+		primary_encap = ""
+	}
+	`)
+	return resource
+}
+
+func CreateAccEPGsUsingFunctionUpdatedAttr(rName, tDn, attribute, value string) string {
+	fmt.Printf("=== STEP  testing epgs_using_function attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	
+	resource "aci_application_epg" "test" {
+		application_profile_dn = aci_application_profile.test.id
+		name = "%s"
+	}
+
+	resource "aci_attachable_access_entity_profile" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_access_generic" "test" {
+		attachable_access_entity_profile_dn = aci_attachable_access_entity_profile.test.id
+		name = "default"
+	}
+
+	resource "aci_epgs_using_function" "test" {
+		access_generic_dn  = aci_access_generic.test.id
+		tdn  = aci_application_epg.test.id
+		encap = "vlan-1"
+		%s = "%s"
+	}
+	
+	`, rName, rName, rName, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_ospfifpol_test.go
+++ b/testacc/resource_aci_ospfifpol_test.go
@@ -268,6 +268,14 @@ func TestAccAciOSPFInterfacePolicy_Negative(t *testing.T) {
 				ExpectError: regexp.MustCompile(`unknown property value`),
 			},
 			{
+				Config:      CreateAccOSPFInterfacePolicyUpdatedAttr(fvTenantName, rName, "cost", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccOSPFInterfacePolicyUpdatedAttr(fvTenantName, rName, "cost", "65536"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
 				Config:      CreateAccOSPFInterfacePolicyUpdatedAttrList(fvTenantName, rName, "ctrl", StringListtoString([]string{randomValue})),
 				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got(.)+`),
 			},
@@ -284,12 +292,20 @@ func TestAccAciOSPFInterfacePolicy_Negative(t *testing.T) {
 				ExpectError: regexp.MustCompile(`out of range`),
 			},
 			{
+				Config:      CreateAccOSPFInterfacePolicyUpdatedAttr(fvTenantName, rName, "dead_intvl", "65536"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
 				Config:      CreateAccOSPFInterfacePolicyUpdatedAttr(fvTenantName, rName, "hello_intvl", randomValue),
 				ExpectError: regexp.MustCompile(`unknown property value`),
 			},
 			{
 				Config:      CreateAccOSPFInterfacePolicyUpdatedAttr(fvTenantName, rName, "hello_intvl", "0"),
 				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccOSPFInterfacePolicyUpdatedAttr(fvTenantName, rName, "hello_intvl", "65536"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
 			},
 			{
 				Config:      CreateAccOSPFInterfacePolicyUpdatedAttr(fvTenantName, rName, "nw_t", randomValue),
@@ -304,6 +320,10 @@ func TestAccAciOSPFInterfacePolicy_Negative(t *testing.T) {
 				ExpectError: regexp.MustCompile(`unknown property value`),
 			},
 			{
+				Config:      CreateAccOSPFInterfacePolicyUpdatedAttr(fvTenantName, rName, "prio", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
 				Config:      CreateAccOSPFInterfacePolicyUpdatedAttr(fvTenantName, rName, "prio", "256"),
 				ExpectError: regexp.MustCompile(`unknown property value`),
 			},
@@ -314,6 +334,10 @@ func TestAccAciOSPFInterfacePolicy_Negative(t *testing.T) {
 			{
 				Config:      CreateAccOSPFInterfacePolicyUpdatedAttr(fvTenantName, rName, "rexmit_intvl", "0"),
 				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccOSPFInterfacePolicyUpdatedAttr(fvTenantName, rName, "rexmit_intvl", "65536"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
 			},
 			{
 				Config:      CreateAccOSPFInterfacePolicyUpdatedAttr(fvTenantName, rName, "xmit_delay", randomValue),

--- a/testacc/resource_aci_vmmvswitchpolicycont_test.go
+++ b/testacc/resource_aci_vmmvswitchpolicycont_test.go
@@ -1,0 +1,293 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciVSwitchPolicy_Basic(t *testing.T) {
+	var vswitch_policy_default models.VSwitchPolicyGroup
+	var vswitch_policy_updated models.VSwitchPolicyGroup
+	resourceName := "aci_vswitch_policy.test"
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	vmmDomPName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVSwitchPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateVSwitchPolicyWithoutRequired(vmmDomPName, "vmm_domain_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccVSwitchPolicyConfig(vmmDomPName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVSwitchPolicyExists(resourceName, &vswitch_policy_default),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("uni/vmmp-VMware/dom-%s", vmmDomPName)),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+				),
+			},
+			{
+				Config: CreateAccVSwitchPolicyConfigWithOptionalValues(vmmDomPName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVSwitchPolicyExists(resourceName, &vswitch_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("uni/vmmp-VMware/dom-%s", vmmDomPName)), resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_vswitch_policy"),
+					testAccCheckAciVSwitchPolicyIdEqual(&vswitch_policy_default, &vswitch_policy_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccVSwitchPolicyRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccVSwitchPolicyConfigWithRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVSwitchPolicyExists(resourceName, &vswitch_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("uni/vmmp-VMware/dom-%s", rNameUpdated)),
+					testAccCheckAciVSwitchPolicyIdNotEqual(&vswitch_policy_default, &vswitch_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccVSwitchPolicyConfig(vmmDomPName),
+			},
+		},
+	})
+}
+
+func TestAccAciVSwitchPolicy_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	vmmDomPName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVSwitchPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccVSwitchPolicyConfig(vmmDomPName),
+			},
+			{
+				Config:      CreateAccVSwitchPolicyWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccVSwitchPolicyUpdatedAttr(vmmDomPName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccVSwitchPolicyUpdatedAttr(vmmDomPName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccVSwitchPolicyUpdatedAttr(vmmDomPName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccVSwitchPolicyUpdatedAttr(vmmDomPName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccVSwitchPolicyConfig(vmmDomPName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciVSwitchPolicyExists(name string, vswitch_policy *models.VSwitchPolicyGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("VSwitch Policy %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No VSwitch Policy dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		vswitch_policyFound := models.VSwitchPolicyGroupFromContainer(cont)
+		if vswitch_policyFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("VSwitch Policy %s not found", rs.Primary.ID)
+		}
+		*vswitch_policy = *vswitch_policyFound
+		return nil
+	}
+}
+
+func testAccCheckAciVSwitchPolicyDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing vswitch_policy destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_vswitch_policy" {
+			cont, err := client.Get(rs.Primary.ID)
+			vswitch_policy := models.VSwitchPolicyGroupFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("VSwitch Policy %s Still exists", vswitch_policy.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciVSwitchPolicyIdEqual(m1, m2 *models.VSwitchPolicyGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("vswitch_policy DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciVSwitchPolicyIdNotEqual(m1, m2 *models.VSwitchPolicyGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("vswitch_policy DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateVSwitchPolicyWithoutRequired(vmmDomPName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing vswitch_policy creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	
+	`
+	switch attrName {
+	case "vmm_domain_dn":
+		rBlock += `
+	resource "aci_vswitch_policy" "test" {
+	#	vmm_domain_dn  = aci_vmm_domain.test.id
+	}
+		`
+
+	}
+	return fmt.Sprintf(rBlock, vmmDomPName)
+}
+
+func CreateAccVSwitchPolicyConfigWithRequiredParams(vmmDomPName string) string {
+	fmt.Println("=== STEP  testing vswitch_policy creation with Updated required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	
+	resource "aci_vswitch_policy" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+	}
+	`, vmmDomPName)
+	return resource
+}
+
+func CreateAccVSwitchPolicyConfig(vmmDomPName string) string {
+	fmt.Println("=== STEP  testing vswitch_policy creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	resource "aci_vswitch_policy" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+	}
+	`, vmmDomPName)
+	return resource
+}
+
+func CreateAccVSwitchPolicyWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing vswitch_policy creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_vswitch_policy" "test" {
+		vmm_domain_dn  = aci_tenant.test.id	
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccVSwitchPolicyConfigWithOptionalValues(vmmDomPName string) string {
+	fmt.Println("=== STEP  Basic: testing vswitch_policy creation with optional parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	
+	resource "aci_vswitch_policy" "test" {
+		vmm_domain_dn  = "${aci_vmm_domain.test.id}"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_vswitch_policy"
+		
+	}
+	`, vmmDomPName)
+
+	return resource
+}
+
+func CreateAccVSwitchPolicyRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing vswitch_policy updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_vswitch_policy" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_vswitch_policy"	
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccVSwitchPolicyUpdatedAttr(vmmDomPName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing vswitch_policy attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "uni/vmmp-VMware"
+	}
+	
+	resource "aci_vswitch_policy" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		%s = "%s"
+	}
+	`, vmmDomPName, attribute, value)
+	return resource
+}


### PR DESCRIPTION
$ go test -v -run TestAccAciVSwitchPolicy_Basic -timeout=60m
=== RUN   TestAccAciVSwitchPolicy_Basic
=== STEP  Basic: testing vswitch_policy creation without  vmm_domain_dn
=== STEP  testing vswitch_policy creation with required arguments only
=== STEP  Basic: testing vswitch_policy creation with optional parameters
=== STEP  Basic: testing vswitch_policy updation without required parameters
=== STEP  testing vswitch_policy creation with Updated required arguments only
=== STEP  testing vswitch_policy creation with required arguments only
=== PAUSE TestAccAciVSwitchPolicy_Basic
=== CONT  TestAccAciVSwitchPolicy_Basic
=== STEP  testing vswitch_policy destroy
--- PASS: TestAccAciVSwitchPolicy_Basic (435.79s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   438.097s

$ go test -v -run TestAccAciVSwitchPolicyDataSource_Basic -timeout=60m
=== RUN   TestAccAciVSwitchPolicyDataSource_Basic
=== STEP  Basic: testing vswitch_policy Data Source without  vmm_domain_dn
=== STEP  testing vswitch_policy Data Source with required arguments only
=== STEP  testing vswitch_policy Data Source with random attribute
=== STEP  testing vswitch_policy Data Source with Invalid Parent Dn
=== STEP  testing vswitch_policy Data Source with updated resource
=== PAUSE TestAccAciVSwitchPolicyDataSource_Basic
=== CONT  TestAccAciVSwitchPolicyDataSource_Basic
=== STEP  testing vswitch_policy destroy
--- PASS: TestAccAciVSwitchPolicyDataSource_Basic (219.63s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   221.947s

$ go test -v -run TestAccAciVSwitchPolicy_Negative -timeout=60m
=== RUN   TestAccAciVSwitchPolicy_Negative
=== STEP  testing vswitch_policy creation with required arguments only
=== STEP  Negative Case: testing vswitch_policy creation with invalid parent Dn
=== STEP  testing vswitch_policy attribute: description = sn7z7enkf714kin9ufcoseol3sq9x2wms1f6kfn7ddcsqe64891bjd3l8sg40dgc88hvkkw7dv6o1400wksv0xzsxrhsrqgcptf2c4tisokczixjy90wn8r1y8ly2v89o
=== STEP  testing vswitch_policy attribute: annotation = fqoicsxwv0m7iauoh3yg0rc10ycubil7ar4p1wv2qgcqidg0i4so1klbpteqtkqswhwoggk4oon6w9ouauwatmdbqpr32b7zhatbjc9nf6kgfvj8oqrxx39bpsslorvp9
=== STEP  testing vswitch_policy attribute: name_alias = hw7hv2ddwhvova0mfokvk4h98skxf7yisy02qcby7avltw2ct6ir3t2we2tusi9b
=== STEP  testing vswitch_policy attribute: sqtnj = tz0o2
=== STEP  testing vswitch_policy creation with required arguments only
=== PAUSE TestAccAciVSwitchPolicy_Negative
=== CONT  TestAccAciVSwitchPolicy_Negative
=== STEP  testing vswitch_policy destroy
--- PASS: TestAccAciVSwitchPolicy_Negative (370.35s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   372.949s


$ go test -v -run TestAccAciOSPFInterfacePolicy_Negative -timeout=60m
=== RUN   TestAccAciOSPFInterfacePolicy_Negative
=== STEP  testing ospf_interface_policy creation with required arguments only
=== STEP  Negative Case: testing ospf_interface_policy creation with invalid parent Dn
=== STEP  testing ospf_interface_policy attribute: description=l3z2o3ke98jgg97vk0u72kl61907q121a3mpall334xn11op7uj3wxsezl8xtc7vuejxszerz3cw168x2pdlj7tx9i70ydcbzxwxmnrytwpn7m7ygqn8gkyrp9n18ewna
=== STEP  testing ospf_interface_policy attribute: annotation=kqztcth8hzhgoxt6ywsy9sd0kus3g6l2lz3glg7o23q3rihhc43av0h7mukm9x3vi2w9th4hg9pbi8syxj8dduewpfk3quy7hwehpe19e2p8f6uotfknhomjewrnmrjno
=== STEP  testing ospf_interface_policy attribute: name_alias=s8l1aqoaas0qqoi2kw0k2rry7mqsuuht3acy3caeksin83ffmtg7yevpb3yek4wc
=== STEP  testing ospf_interface_policy attribute: cost=acctest_q2rou
=== STEP  testing ospf_interface_policy attribute: cost=-1
=== STEP  testing ospf_interface_policy attribute: cost=65536
=== STEP  testing ospf_interface_policy attribute: ctrl=["acctest_q2rou"]
=== STEP  testing ospf_interface_policy attribute: ctrl=["advert-subnet","advert-subnet"]
=== STEP  testing ospf_interface_policy attribute: dead_intvl=acctest_q2rou
=== STEP  testing ospf_interface_policy attribute: dead_intvl=0
=== STEP  testing ospf_interface_policy attribute: dead_intvl=65536
=== STEP  testing ospf_interface_policy attribute: hello_intvl=acctest_q2rou
=== STEP  testing ospf_interface_policy attribute: hello_intvl=0
=== STEP  testing ospf_interface_policy attribute: hello_intvl=65536
=== STEP  testing ospf_interface_policy attribute: nw_t=acctest_q2rou
=== STEP  testing ospf_interface_policy attribute: pfx_suppress=acctest_q2rou
=== STEP  testing ospf_interface_policy attribute: prio=acctest_q2rou
=== STEP  testing ospf_interface_policy attribute: prio=-1
=== STEP  testing ospf_interface_policy attribute: prio=256
=== STEP  testing ospf_interface_policy attribute: rexmit_intvl=acctest_q2rou
=== STEP  testing ospf_interface_policy attribute: rexmit_intvl=0
=== STEP  testing ospf_interface_policy attribute: rexmit_intvl=65536
=== STEP  testing ospf_interface_policy attribute: xmit_delay=acctest_q2rou
=== STEP  testing ospf_interface_policy attribute: xmit_delay=0
=== STEP  testing ospf_interface_policy attribute: xmit_delay=451
=== STEP  testing ospf_interface_policy attribute: vffeb=acctest_q2rou
=== STEP  testing ospf_interface_policy creation with required arguments only
=== PAUSE TestAccAciOSPFInterfacePolicy_Negative
=== CONT  TestAccAciOSPFInterfacePolicy_Negative
=== STEP  testing ospf_interface_policy destroy
--- PASS: TestAccAciOSPFInterfacePolicy_Negative (828.13s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   830.511s

$ go test -v -run TestAccAciEPGsUsingFunction_Basic -timeout=60m
=== RUN   TestAccAciEPGsUsingFunction_Basic
=== STEP  Basic: testing epgs_using_function creation without  access_generic_dn
=== STEP  Basic: testing epgs_using_function creation without  tdn
=== STEP  Basic: testing epgs_using_function creation without  encap
=== STEP  testing epgs_using_function creation with required arguments only
=== STEP  Basic: testing epgs_using_function creation with optional parameters
=== STEP  Basic: testing epgs_using_function updation without required parameters
=== STEP  testing epgs_using_function creation with Updation required arguments only
=== STEP  testing epgs_using_function creation with required arguments only
=== STEP  testing epgs_using_function creation with Updation required arguments only
=== STEP  testing epgs_using_function creation with required arguments only
=== STEP  testing epgs_using_function creation with Updation of Encap
=== PAUSE TestAccAciEPGsUsingFunction_Basic
=== CONT  TestAccAciEPGsUsingFunction_Basic
=== STEP  testing epgs_using_function destroy
--- PASS: TestAccAciEPGsUsingFunction_Basic (460.03s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   462.499s

$ go test -v -run TestAccAciEPGsUsingFunctionDataSource_Basic -timeout=60m
=== RUN   TestAccAciEPGsUsingFunctionDataSource_Basic
=== STEP  Basic: testing epgs_using_function creation without  access_generic_dn
=== STEP  Basic: testing epgs_using_function creation without  tdn
=== STEP  testing epgs_using_function Data Source with required arguments only
=== STEP  testing epgs_using_function Data Source with random attribute
=== STEP  testing epgs_using_function Data Source with Invalid Parent Dn
=== STEP  testing epgs_using_function Data Source with updated resource
=== PAUSE TestAccAciEPGsUsingFunctionDataSource_Basic
=== CONT  TestAccAciEPGsUsingFunctionDataSource_Basic
=== STEP  testing epgs_using_function destroy
--- PASS: TestAccAciEPGsUsingFunctionDataSource_Basic (139.68s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   141.943s

$ go test -v -run TestAccAciEPGsUsingFunction_Update -timeout=60m
=== RUN   TestAccAciEPGsUsingFunction_Update
=== STEP  testing epgs_using_function creation with required arguments only
=== STEP  testing epgs_using_function attribute: mode = untagged
=== STEP  testing epgs_using_function creation with required arguments only
=== PAUSE TestAccAciEPGsUsingFunction_Update
=== CONT  TestAccAciEPGsUsingFunction_Update
=== STEP  testing epgs_using_function destroy
--- PASS: TestAccAciEPGsUsingFunction_Update (159.78s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   161.504s

$ go test -v -run TestAccAciEPGsUsingFunction_Negative -timeout=60m
=== RUN   TestAccAciEPGsUsingFunction_Negative
=== STEP  testing epgs_using_function creation with required arguments only
=== STEP  Negative Case: testing epgs_using_function creation with invalid parent Dn
=== STEP  Negative Case: testing epgs_using_function creation with invalid TDn
=== STEP  Negative Case: testing epgs_using_function creation with invalid encap
=== STEP  testing epgs_using_function attribute: annotation = a4scppbicqzowue7ul6svpbyl23wae0ys68mybfk1iae13dlculqpoyjh3fqin6gl6xyhypafqzwpdpvjxhcej3cixf1z6xcqdhqulg41z0zkc9pa7u39fu8ci1diyt04
=== STEP  testing epgs_using_function attribute: instr_imedcy = cm306
=== STEP  testing epgs_using_function attribute: mode = cm306
=== STEP  testing epgs_using_function attribute: primary_encap = cm306
=== STEP  testing epgs_using_function attribute: pgvfb = cm306
=== STEP  testing epgs_using_function creation with required arguments only
=== PAUSE TestAccAciEPGsUsingFunction_Negative
=== CONT  TestAccAciEPGsUsingFunction_Negative
=== STEP  testing epgs_using_function destroy
--- PASS: TestAccAciEPGsUsingFunction_Negative (206.13s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   208.487s

$ go test -v -run TestAccAciEPGsUsingFunction_MultipleCreateDelete -timeout=60m
=== RUN   TestAccAciEPGsUsingFunction_MultipleCreateDelete
=== STEP  testing multiple epgs_using_function creation with required arguments only
=== PAUSE TestAccAciEPGsUsingFunction_MultipleCreateDelete
=== CONT  TestAccAciEPGsUsingFunction_MultipleCreateDelete
=== STEP  testing epgs_using_function destroy
--- PASS: TestAccAciEPGsUsingFunction_MultipleCreateDelete (89.70s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   92.314s