### PR TITLE
updated typo

### DIFF
--- a/testacc/data_source_aci_firmwarefwgrp_test.go
+++ b/testacc/data_source_aci_firmwarefwgrp_test.go
@@ -72,7 +72,7 @@ func CreateAccFirmwareGroupConfigDataSource(rName string) string {
 }
 
 func CreateAccFirmwareGroupDataSourceUpdate(rName, key, value string) string {
-	fmt.Println("=== STEP  testing firmware_group creation with required arguements only")
+	fmt.Println("=== STEP  testing firmware_group Data Source with random attributes")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_firmware_group" "test" {
@@ -93,7 +93,7 @@ func CreateAccFirmwareGroupDataSourceUpdate(rName, key, value string) string {
 }
 
 func CreateFirmwareGroupDSWithoutRequired(rName string) string {
-	fmt.Println("=== STEP  Basic: testing firmware_group data source reading without giving name")
+	fmt.Println("=== STEP  Basic: testing firmware_group Data Source without name")
 	resource := fmt.Sprintf(`
 
 	resource "aci_firmware_group" "test" {

--- a/testacc/resource_aci_firmwarefwgrp_test.go
+++ b/testacc/resource_aci_firmwarefwgrp_test.go
@@ -58,7 +58,11 @@ func TestAccAciFirmwareGroup_Basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:      CreateAccFirmwareGroupConfigUpdatedName(acctest.RandString(65)),
+				Config:      CreateAccFirmwareGroupRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateAccFirmwareGroupConfigInvalidName(acctest.RandString(65)),
 				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
 			},
 
@@ -240,6 +244,18 @@ func CreateFirmwareGroupWithoutRequired(rName, attrName string) string {
 	return fmt.Sprintf(rBlock, rName)
 }
 
+func CreateAccFirmwareGroupConfigInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing firmware_group creation with invalid name =", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_firmware_group" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
 func CreateAccFirmwareGroupConfigWithRequiredParams(rName string) string {
 	fmt.Println("=== STEP  testing firmware_group creation with resource name =", rName)
 	resource := fmt.Sprintf(`
@@ -282,7 +298,7 @@ func CreateAccFirmwareGroupConfigWithOptionalValues(rName string) string {
 }
 
 func CreateAccFirmwareGroupRemovingRequiredField() string {
-	fmt.Println("=== STEP  Basic: testing firmware_group creation with optional parameters")
+	fmt.Println("=== STEP  Basic: testing firmware_group update without required parameters")
 	resource := fmt.Sprintf(`
 	resource "aci_firmware_group" "test" {
 		description = "created while acceptance testing"

--- a/testacc/resource_aci_vnslifctx_test.go
+++ b/testacc/resource_aci_vnslifctx_test.go
@@ -72,7 +72,10 @@ func TestAccAciLogicalInterfaceContext_Basic(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"logical_device_context_dn"},
 			},
-
+			{
+				Config:      CreateAccLogicalInterfaceContextConfigWithInvalidName(fvTenantName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
 			{
 				Config:      CreateAccLogicalInterfaceContextRemovingRequiredField(),
 				ExpectError: regexp.MustCompile(`Missing required argument`),
@@ -293,6 +296,31 @@ func CreateAccLogicalInterfaceContextConfigWithRequiredParams(fvTenantName, vnsL
 		conn_name_or_lbl  = "%s"
 	}
 	`, fvTenantName, vnsLDevCtxName, connNameOrLbl)
+	return resource
+}
+
+func CreateAccLogicalInterfaceContextConfigWithInvalidName(rName, connNameOrLbl string) string {
+	fmt.Println("=== STEP  testing logical_interface_context creation with invalid conn_name_or_lbl =", connNameOrLbl)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_logical_device_context" "test" {
+		tenant_dn = aci_tenant.test.id
+		ctrct_name_or_lbl  = "%s"
+		graph_name_or_lbl = "any"
+		node_name_or_lbl  = "any"
+	}
+	
+	resource "aci_logical_interface_context" "test" {
+		logical_device_context_dn  = aci_logical_device_context.test.id
+		conn_name_or_lbl  = "%s"
+
+	}
+	`, rName, rName, connNameOrLbl)
 	return resource
 }
 


### PR DESCRIPTION
$ go test -v -run TestAccAciLogicalInterfaceContext_Basic -timeout=60m
=== RUN   TestAccAciLogicalInterfaceContext_Basic
=== STEP  Basic: testing logical_interface_context creation without  logical_device_context_dn
=== STEP  Basic: testing logical_interface_context creation without  conn_name_or_lbl
=== STEP  testing logical_interface_context creation with required arguments only
=== STEP  Basic: testing logical_interface_context creation with optional parameters
=== STEP  testing logical_interface_context creation with invalid conn_name_or_lbl = eabmigm0hnse08jgns7a04c6af04bb7ayhnqvla6teqxa6dqi1c3pkcv10pj2c4xm
=== STEP  Basic: testing logical_interface_context updation without required parameters
=== STEP  testing logical_interface_context creation with updated naming arguments
=== STEP  testing logical_interface_context creation with required arguments only
=== STEP  testing logical_interface_context creation with updated naming arguments
=== PAUSE TestAccAciLogicalInterfaceContext_Basic
=== CONT  TestAccAciLogicalInterfaceContext_Basic
=== STEP  testing logical_interface_context destroy
--- PASS: TestAccAciLogicalInterfaceContext_Basic (240.47s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   244.105s
