### PR TITLE
bug fixes

### DIFF
--- a/testacc/data_source_aci_firmwarefwgrp_test.go
+++ b/testacc/data_source_aci_firmwarefwgrp_test.go
@@ -40,7 +40,10 @@ func TestAccAciFirmwareGroupDataSource_Basic(t *testing.T) {
 				Config:      CreateAccFirmwareGroupDataSourceUpdate(rName, randomParameter, randomValue),
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
 			},
-
+			{
+				Config:      CreateAccFirmwareGroupDSConfigWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
 			{
 				Config: CreateAccFirmwareGroupDataSourceUpdate(rName, "annotation", "orchestrator:terraform-testacc"),
 				Check: resource.ComposeTestCheckFunc(
@@ -104,6 +107,21 @@ func CreateFirmwareGroupDSWithoutRequired(rName string) string {
 			aci_firmware_group.test
 		]
 	  }
+	`, rName)
+	return resource
+}
+
+func CreateAccFirmwareGroupDSConfigWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing firmware_group data source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_firmware_group" "test" {
+		name  = "%s"
+	}
+
+	data "aci_firmware_group" "test" {
+		name  = "${aci_firmware_group.test.name}xyz"
+	}
 	`, rName)
 	return resource
 }

--- a/testacc/resource_aci_firmwarefwgrp_test.go
+++ b/testacc/resource_aci_firmwarefwgrp_test.go
@@ -63,6 +63,11 @@ func TestAccAciFirmwareGroup_Basic(t *testing.T) {
 			},
 
 			{
+				Config:      CreateAccFirmwareGroupRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+
+			{
 				Config: CreateAccFirmwareGroupConfigWithRequiredParams(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciFirmwareGroupExists(resourceName, &firmware_group_updated),
@@ -154,6 +159,20 @@ func TestAccAciFirmwareGroup_Negative(t *testing.T) {
 			},
 			{
 				Config: CreateAccFirmwareGroupConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciFirmwareGroup_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFirmwareGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccFirmwareGroupConfigMultiple(rName),
 			},
 		},
 	})
@@ -315,5 +334,24 @@ func CreateAccFirmwareGroupConfigUpdatedName(longerName string) string {
 	name  = "%s"
 	}
 	`, longerName)
+	return resource
+}
+
+func CreateAccFirmwareGroupConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple firmware_group creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_firmware_group" "test1" {
+		name  = "%s"
+	}
+
+	resource "aci_firmware_group" "test2" {
+		name  = "%s"
+	}
+
+	resource "aci_firmware_group" "test3" {
+		name  = "%s"
+	}
+	`, rName+"1", rName+"2", rName+"3")
 	return resource
 }


### PR DESCRIPTION
$ go test -v -run TestAccAciFirmwareGroup -timeout=20m
=== RUN   TestAccAciFirmwareGroupDataSource_Basic
=== STEP  Basic: testing firmware_group data source reading without giving name
=== STEP  testing firmware_group creation with required arguements only
=== STEP  testing firmware_group creation with required arguements only
=== STEP  testing firmware_group data source with invalid name
=== STEP  testing firmware_group creation with required arguements only
=== PAUSE TestAccAciFirmwareGroupDataSource_Basic
=== RUN   TestAccAciFirmwareGroup_Basic
=== STEP  Basic: testing firmware_group creation without  name
=== STEP  testing firmware_group creation with required arguements only
=== STEP  Basic: testing firmware_group creation with optional parameters
=== STEP  Basic: testing Firmware Group creation with invalid name with long length
=== STEP  Basic: testing firmware_group creation with optional parameters
=== STEP  testing firmware_group creation with required arguements only
=== PAUSE TestAccAciFirmwareGroup_Basic
=== RUN   TestAccAciFirmwareGroup_Update
=== STEP  testing firmware_group creation with required arguements only
=== STEP  testing firmware_group attribute: firmware_group_type=ALL_IN_POD
=== STEP  testing firmware_group attribute: firmware_group_type=range
=== STEP  testing firmware_group creation with required arguements only
=== PAUSE TestAccAciFirmwareGroup_Update
=== RUN   TestAccAciFirmwareGroup_Negative
=== STEP  testing firmware_group creation with required arguements only
=== STEP  testing firmware_group attribute: description=etg4nld2jvbxoxdpbkft6vd0d9o0lfl1m02blz8hjx9tkmtuox30ya1dnfnj09191ikeypxdbjd4bjj4obl3ynj8u9k928di2rmj097jbv82nf2aqyg04abwb71kgyiki
=== STEP  testing firmware_group attribute: annotation=bdyrhx8ymxxwh4lhv8snx3xjzk86iyhrx982prk8geg0awxnq0mfuh9ei06qodmnyb4wzt9soq1nkzwvfgr64zk8iq1e1evusxgzornrnotpfglmc66tueg4kh9bog1io
=== STEP  testing firmware_group attribute: name_alias=dl9eim38lcx13olcxutyjywgf2670gar2ca6tnmvc19mvdvl4a6guealxaoomztx
=== STEP  testing firmware_group attribute: firmware_group_type=acctest_1knvh
=== STEP  testing firmware_group attribute: bakaj=acctest_1knvh
=== STEP  testing firmware_group creation with required arguements only
=== PAUSE TestAccAciFirmwareGroup_Negative
=== RUN   TestAccAciFirmwareGroup_MultipleCreateDelete
=== STEP  testing multiple firmware_group creation with required arguments only
=== PAUSE TestAccAciFirmwareGroup_MultipleCreateDelete
=== CONT  TestAccAciFirmwareGroupDataSource_Basic
=== CONT  TestAccAciFirmwareGroup_Negative
=== CONT  TestAccAciFirmwareGroup_MultipleCreateDelete
=== CONT  TestAccAciFirmwareGroup_Update
=== CONT  TestAccAciFirmwareGroup_Basic
=== STEP  testing firmware_group destroy
--- PASS: TestAccAciFirmwareGroup_MultipleCreateDelete (50.30s)
=== STEP  testing firmware_group destroy
--- PASS: TestAccAciFirmwareGroupDataSource_Basic (104.94s)
=== STEP  testing firmware_group destroy
--- PASS: TestAccAciFirmwareGroup_Negative (139.11s)
=== STEP  testing firmware_group destroy
--- PASS: TestAccAciFirmwareGroup_Update (148.00s)
=== STEP  testing firmware_group destroy
--- PASS: TestAccAciFirmwareGroup_Basic (156.61s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   158.073s