### PR TITLE
updated files 12-01-22

### DIFF
--- a/testacc/data_source_aci_aaaconsoleauth_test.go
+++ b/testacc/data_source_aci_aaaconsoleauth_test.go
@@ -35,11 +35,6 @@ func TestAccAciConsoleAuthenticationDataSource_Basic(t *testing.T) {
 				Config:      CreateAccConsoleAuthenticationDataSourceUpdate(randomParameter, randomValue),
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
 			},
-
-			{
-				Config:      CreateAccConsoleAuthenticationDSWithInvalidName(),
-				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
-			},
 			{
 				Config: CreateAccConsoleAuthenticationDataSourceUpdatedResource("annotation", "orchestrator:terraform-testacc"),
 				Check: resource.ComposeTestCheckFunc(
@@ -77,22 +72,6 @@ func CreateConsoleAuthenticationDSWithoutRequired(attrName string) string {
 	}
 	`
 	return fmt.Sprintf(rBlock)
-}
-
-func CreateAccConsoleAuthenticationDSWithInvalidName() string {
-	fmt.Println("=== STEP  testing console_authentication Data Source with required arguments only")
-	resource := fmt.Sprintf(`
-	
-	resource "aci_console_authentication" "test" {
-	
-	}
-
-	data "aci_console_authentication" "test" {
-	
-		depends_on = [ aci_console_authentication.test ]
-	}
-	`)
-	return resource
 }
 
 func CreateAccConsoleAuthenticationDataSourceUpdate(key, value string) string {

--- a/testacc/data_source_aci_aaadefaultauth_test.go
+++ b/testacc/data_source_aci_aaadefaultauth_test.go
@@ -36,11 +36,6 @@ func TestAccAciDefaultAuthenticationDataSource_Basic(t *testing.T) {
 				Config:      CreateAccDefaultAuthenticationDataSourceUpdate(randomParameter, randomValue),
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
 			},
-
-			{
-				Config:      CreateAccDefaultAuthenticationDSWithInvalidName(),
-				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
-			},
 			{
 				Config: CreateAccDefaultAuthenticationDataSourceUpdatedResource("annotation", "orchestrator:terraform-testacc"),
 				Check: resource.ComposeTestCheckFunc(
@@ -80,22 +75,6 @@ func CreateDefaultAuthenticationDSWithoutRequired(attrName string) string {
 	}
 	`
 	return fmt.Sprintf(rBlock)
-}
-
-func CreateAccDefaultAuthenticationDSWithInvalidName() string {
-	fmt.Println("=== STEP  testing default_authentication Data Source with required arguments only")
-	resource := fmt.Sprintf(`
-	
-	resource "aci_default_authentication" "test" {
-	
-	}
-
-	data "aci_default_authentication" "test" {
-	
-		depends_on = [ aci_default_authentication.test ]
-	}
-	`)
-	return resource
 }
 
 func CreateAccDefaultAuthenticationDataSourceUpdate(key, value string) string {

--- a/testacc/data_source_aci_aaaduoprovidergroup_test.go
+++ b/testacc/data_source_aci_aaaduoprovidergroup_test.go
@@ -101,7 +101,7 @@ func CreateDuoProviderGroupDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccDuoProviderGroupDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing duo_provider_group Data Source with required arguments only")
+	fmt.Println("=== STEP  testing duo_provider_group Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_duo_provider_group" "test" {
@@ -112,7 +112,6 @@ func CreateAccDuoProviderGroupDSWithInvalidName(rName string) string {
 	data "aci_duo_provider_group" "test" {
 	
 		name  = "${aci_duo_provider_group.test.name}_invalid"
-		name  = aci_duo_provider_group.test.name
 		depends_on = [ aci_duo_provider_group.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_aaaldapgroupmaprule_test.go
+++ b/testacc/data_source_aci_aaaldapgroupmaprule_test.go
@@ -97,7 +97,7 @@ func CreateLDAPGroupMapRuleDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccLDAPGroupMapRuleDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing ldap_group_map_rule Data Source with required arguments only")
+	fmt.Println("=== STEP  testing ldap_group_map_rule Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_ldap_group_map_rule" "test" {
@@ -108,7 +108,6 @@ func CreateAccLDAPGroupMapRuleDSWithInvalidName(rName string) string {
 	data "aci_ldap_group_map_rule" "test" {
 	
 		name  = "${aci_ldap_group_map_rule.test.name}_invalid"
-		name  = aci_ldap_group_map_rule.test.name
 		depends_on = [ aci_ldap_group_map_rule.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_aaaldapprovider_test.go
+++ b/testacc/data_source_aci_aaaldapprovider_test.go
@@ -109,7 +109,7 @@ func CreateLDAPProviderDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccLDAPProviderDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing ldap_provider Data Source with required arguments only")
+	fmt.Println("=== STEP  testing ldap_provider Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_ldap_provider" "test" {
@@ -120,7 +120,6 @@ func CreateAccLDAPProviderDSWithInvalidName(rName string) string {
 	data "aci_ldap_provider" "test" {
 	
 		name  = "${aci_ldap_provider.test.name}_invalid"
-		name  = aci_ldap_provider.test.name
 		depends_on = [ aci_ldap_provider.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_aaalogindomain_test.go
+++ b/testacc/data_source_aci_aaalogindomain_test.go
@@ -96,7 +96,7 @@ func CreateLoginDomainDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccLoginDomainDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing login_domain Data Source with required arguments only")
+	fmt.Println("=== STEP  testing login_domain Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_login_domain" "test" {
@@ -107,7 +107,6 @@ func CreateAccLoginDomainDSWithInvalidName(rName string) string {
 	data "aci_login_domain" "test" {
 	
 		name  = "${aci_login_domain.test.name}_invalid"
-		name  = aci_login_domain.test.name
 		depends_on = [ aci_login_domain.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_aaaradiusprovider_test.go
+++ b/testacc/data_source_aci_aaaradiusprovider_test.go
@@ -42,9 +42,7 @@ func TestAccAciRadiusProviderDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "auth_port", resourceName, "auth_port"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "auth_protocol", resourceName, "auth_protocol"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "key", resourceName, "key"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "monitor_server", resourceName, "monitor_server"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "monitoring_password", resourceName, "monitoring_password"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "monitoring_user", resourceName, "monitoring_user"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "retries", resourceName, "retries"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "timeout", resourceName, "timeout"),
@@ -79,7 +77,7 @@ func TestAccAciRadiusProviderDataSource_Basic(t *testing.T) {
 				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
 			},
 			{
-				Config:      CreateAccRadiusProviderConfigDataSource(rName, acctest.RandString(5)),
+				Config:      CreateAccRadiusProviderConfigDataSourceWithInvalidType(rName, acctest.RandString(5)),
 				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
 			},
 			{
@@ -90,6 +88,27 @@ func TestAccAciRadiusProviderDataSource_Basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func CreateAccRadiusProviderConfigDataSourceWithInvalidType(rName, providerType string) string {
+	fmt.Println("=== STEP  testing radius_provider Data Source with invalid type")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_radius_provider" "test" {
+	
+		name  = "%s"
+		type  = "duo"
+		timeout = 60
+	}
+
+	data "aci_radius_provider" "test" {
+	
+		name  = aci_radius_provider.test.name
+		type  = "%s"
+		depends_on = [ aci_radius_provider.test ]
+	}
+	`, rName, providerType)
+	return resource
 }
 
 func CreateAccRadiusProviderConfigDataSource(rName, providerType string) string {
@@ -147,7 +166,7 @@ func CreateRadiusProviderDSWithoutRequired(rName, providerType, attrName string)
 }
 
 func CreateAccRadiusProviderDSWithInvalidName(rName, providerType string) string {
-	fmt.Println("=== STEP  testing radius_provider Data Source with required arguments only")
+	fmt.Println("=== STEP  testing radius_provider Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_radius_provider" "test" {

--- a/testacc/data_source_aci_aaaradiusprovidergroup_test.go
+++ b/testacc/data_source_aci_aaaradiusprovidergroup_test.go
@@ -96,7 +96,7 @@ func CreateRadiusProviderGroupDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccRadiusProviderGroupDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing radius_provider_group Data Source with required arguments only")
+	fmt.Println("=== STEP  testing radius_provider_group Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_radius_provider_group" "test" {
@@ -107,7 +107,6 @@ func CreateAccRadiusProviderGroupDSWithInvalidName(rName string) string {
 	data "aci_radius_provider_group" "test" {
 	
 		name  = "${aci_radius_provider_group.test.name}_invalid"
-		name  = aci_radius_provider_group.test.name
 		depends_on = [ aci_radius_provider_group.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_aaarsaprovider_test.go
+++ b/testacc/data_source_aci_aaarsaprovider_test.go
@@ -104,7 +104,7 @@ func CreateRsaProviderDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccRsaProviderDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing rsa_provider Data Source with required arguments only")
+	fmt.Println("=== STEP  testing rsa_provider Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_rsa_provider" "test" {
@@ -115,7 +115,6 @@ func CreateAccRsaProviderDSWithInvalidName(rName string) string {
 	data "aci_rsa_provider" "test" {
 	
 		name  = "${aci_rsa_provider.test.name}_invalid"
-		name  = aci_rsa_provider.test.name
 		depends_on = [ aci_rsa_provider.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_aaasamlenccert_test.go
+++ b/testacc/data_source_aci_aaasamlenccert_test.go
@@ -96,7 +96,7 @@ func CreateSAMLCertificateDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccSAMLCertificateDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing saml_certificate Data Source with required arguments only")
+	fmt.Println("=== STEP  testing saml_certificate Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_saml_certificate" "test" {
@@ -107,7 +107,6 @@ func CreateAccSAMLCertificateDSWithInvalidName(rName string) string {
 	data "aci_saml_certificate" "test" {
 	
 		name  = "${aci_saml_certificate.test.name}_invalid"
-		name  = aci_saml_certificate.test.name
 		depends_on = [ aci_saml_certificate.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_aaasamlprovider_test.go
+++ b/testacc/data_source_aci_aaasamlprovider_test.go
@@ -113,7 +113,7 @@ func CreateSAMLProviderDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccSAMLProviderDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing saml_provider Data Source with required arguments only")
+	fmt.Println("=== STEP  testing saml_provider Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_saml_provider" "test" {
@@ -124,7 +124,6 @@ func CreateAccSAMLProviderDSWithInvalidName(rName string) string {
 	data "aci_saml_provider" "test" {
 	
 		name  = "${aci_saml_provider.test.name}_invalid"
-		name  = aci_saml_provider.test.name
 		depends_on = [ aci_saml_provider.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_aaasamlprovidergroup_test.go
+++ b/testacc/data_source_aci_aaasamlprovidergroup_test.go
@@ -96,7 +96,7 @@ func CreateSAMLProviderGroupDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccSAMLProviderGroupDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing saml_provider_group Data Source with required arguments only")
+	fmt.Println("=== STEP  testing saml_provider_group Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_saml_provider_group" "test" {
@@ -107,7 +107,6 @@ func CreateAccSAMLProviderGroupDSWithInvalidName(rName string) string {
 	data "aci_saml_provider_group" "test" {
 	
 		name  = "${aci_saml_provider_group.test.name}_invalid"
-		name  = aci_saml_provider_group.test.name
 		depends_on = [ aci_saml_provider_group.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_aaatacacsplusprovider_test.go
+++ b/testacc/data_source_aci_aaatacacsplusprovider_test.go
@@ -104,7 +104,7 @@ func CreateTACACSProviderDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccTACACSProviderDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing tacacs_provider Data Source with required arguments only")
+	fmt.Println("=== STEP  testing tacacs_provider Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tacacs_provider" "test" {
@@ -115,7 +115,6 @@ func CreateAccTACACSProviderDSWithInvalidName(rName string) string {
 	data "aci_tacacs_provider" "test" {
 	
 		name  = "${aci_tacacs_provider.test.name}_invalid"
-		name  = aci_tacacs_provider.test.name
 		depends_on = [ aci_tacacs_provider.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_aaatacacsplusprovidergroup_test.go
+++ b/testacc/data_source_aci_aaatacacsplusprovidergroup_test.go
@@ -96,7 +96,7 @@ func CreateTACACSProviderGroupDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccTACACSProviderGroupDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing tacacs_provider_group Data Source with required arguments only")
+	fmt.Println("=== STEP  testing tacacs_provider_group Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tacacs_provider_group" "test" {
@@ -107,7 +107,6 @@ func CreateAccTACACSProviderGroupDSWithInvalidName(rName string) string {
 	data "aci_tacacs_provider_group" "test" {
 	
 		name  = "${aci_tacacs_provider_group.test.name}_invalid"
-		name  = aci_tacacs_provider_group.test.name
 		depends_on = [ aci_tacacs_provider_group.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_aaauserep_test.go
+++ b/testacc/data_source_aci_aaauserep_test.go
@@ -65,7 +65,7 @@ func CreateAccGlobalSecurityConfigDataSource() string {
 }
 
 func CreateAccGlobalSecurityDSWithInvalidName() string {
-	fmt.Println("=== STEP  testing global_security Data Source with required arguments only")
+	fmt.Println("=== STEP  testing global_security Data Source with invalid name")
 	resource := `
 	
 	resource "aci_global_security" "test" {

--- a/testacc/data_source_aci_bgpctxafpol_test.go
+++ b/testacc/data_source_aci_bgpctxafpol_test.go
@@ -123,7 +123,7 @@ func CreateBGPAddressFamilyContextDSWithoutRequired(fvTenantName, rName, attrNam
 }
 
 func CreateAccBGPAddressFamilyContextDSWithInvalidName(fvTenantName, rName string) string {
-	fmt.Println("=== STEP  testing bgp_address_family_context Data Source with Invalid Parent Dn")
+	fmt.Println("=== STEP  testing bgp_address_family_context Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {

--- a/testacc/data_source_aci_configexportp_test.go
+++ b/testacc/data_source_aci_configexportp_test.go
@@ -102,7 +102,7 @@ func CreateConfigurationExportPolicyDSWithoutRequired(rName, attrName string) st
 }
 
 func CreateAccConfigurationExportPolicyDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing configuration_export_policy Data Source with required arguments only")
+	fmt.Println("=== STEP  testing configuration_export_policy Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_configuration_export_policy" "test" {

--- a/testacc/data_source_aci_configimportp_test.go
+++ b/testacc/data_source_aci_configimportp_test.go
@@ -104,7 +104,7 @@ func CreateConfigurationImportPolicyDSWithoutRequired(rName, attrName string) st
 }
 
 func CreateAccConfigurationImportPolicyDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing configuration_import_policy Data Source with required arguments only")
+	fmt.Println("=== STEP  testing configuration_import_policy Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_configuration_import_policy" "test" {

--- a/testacc/data_source_aci_cooppol_test.go
+++ b/testacc/data_source_aci_cooppol_test.go
@@ -97,7 +97,7 @@ func CreateCoopPolicyDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccCoopPolicyDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing coop_policy Data Source with required arguments only")
+	fmt.Println("=== STEP  testing coop_policy Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_coop_policy" "test" {
@@ -108,7 +108,6 @@ func CreateAccCoopPolicyDSWithInvalidName(rName string) string {
 	data "aci_coop_policy" "test" {
 	
 		name  = "${aci_coop_policy.test.name}_invalid"
-		name  = aci_coop_policy.test.name
 		depends_on = [ aci_coop_policy.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_edrerrdisrecoverpol_test.go
+++ b/testacc/data_source_aci_edrerrdisrecoverpol_test.go
@@ -97,7 +97,7 @@ func CreateErrorDisableRecoveryDSWithoutRequired(rName, attrName string) string 
 }
 
 func CreateAccErrorDisableRecoveryDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing error_disable_recovery Data Source with required arguments only")
+	fmt.Println("=== STEP  testing error_disable_recovery Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_error_disable_recovery" "test" {
@@ -108,7 +108,6 @@ func CreateAccErrorDisableRecoveryDSWithInvalidName(rName string) string {
 	data "aci_error_disable_recovery" "test" {
 	
 		name  = "${aci_error_disable_recovery.test.name}_invalid"
-		name  = aci_error_disable_recovery.test.name
 		depends_on = [ aci_error_disable_recovery.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_epcontrolp_test.go
+++ b/testacc/data_source_aci_epcontrolp_test.go
@@ -100,7 +100,7 @@ func CreateEndpointControlsDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccEndpointControlsDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing endpoint_controls Data Source with required arguments only")
+	fmt.Println("=== STEP  testing endpoint_controls Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_endpoint_controls" "test" {
@@ -111,7 +111,6 @@ func CreateAccEndpointControlsDSWithInvalidName(rName string) string {
 	data "aci_endpoint_controls" "test" {
 	
 		name  = "${aci_endpoint_controls.test.name}_invalid"
-		name  = aci_endpoint_controls.test.name
 		depends_on = [ aci_endpoint_controls.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_eploopprotectp_test.go
+++ b/testacc/data_source_aci_eploopprotectp_test.go
@@ -101,7 +101,7 @@ func CreateEndpointLoopProtectionDSWithoutRequired(rName, attrName string) strin
 }
 
 func CreateAccEndpointLoopProtectionDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing endpoint_loop_protection Data Source with required arguments only")
+	fmt.Println("=== STEP  testing endpoint_loop_protection Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_endpoint_loop_protection" "test" {
@@ -112,7 +112,6 @@ func CreateAccEndpointLoopProtectionDSWithInvalidName(rName string) string {
 	data "aci_endpoint_loop_protection" "test" {
 	
 		name  = "${aci_endpoint_loop_protection.test.name}_invalid"
-		name  = aci_endpoint_loop_protection.test.name
 		depends_on = [ aci_endpoint_loop_protection.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_fabricexplicitgep_test.go
+++ b/testacc/data_source_aci_fabricexplicitgep_test.go
@@ -97,7 +97,7 @@ func CreateVPCExplicitProtectionGroupDSWithoutRequired(rName, attrName string) s
 }
 
 func CreateAccVPCExplicitProtectionGroupDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing vpc_explicit_protection_group Data Source with required arguments only")
+	fmt.Println("=== STEP  testing vpc_explicit_protection_group Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_vpc_explicit_protection_group" "test" {
@@ -108,7 +108,6 @@ func CreateAccVPCExplicitProtectionGroupDSWithInvalidName(rName string) string {
 	data "aci_vpc_explicit_protection_group" "test" {
 	
 		name  = "${aci_vpc_explicit_protection_group.test.name}_invalid"
-		name  = aci_vpc_explicit_protection_group.test.name
 		depends_on = [ aci_vpc_explicit_protection_group.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_fabricnodecontrol_test.go
+++ b/testacc/data_source_aci_fabricnodecontrol_test.go
@@ -99,7 +99,7 @@ func CreateFabricNodeControlDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccFabricNodeControlDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing fabric_node_control Data Source with required arguments only")
+	fmt.Println("=== STEP  testing fabric_node_control Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_fabric_node_control" "test" {
@@ -110,7 +110,6 @@ func CreateAccFabricNodeControlDSWithInvalidName(rName string) string {
 	data "aci_fabric_node_control" "test" {
 	
 		name  = "${aci_fabric_node_control.test.name}_invalid"
-		name  = aci_fabric_node_control.test.name
 		depends_on = [ aci_fabric_node_control.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_fabricrsoospath_test.go
+++ b/testacc/data_source_aci_fabricrsoospath_test.go
@@ -52,7 +52,7 @@ func TestAccAciOutofServiceFabricPathlistDataSource_Basic(t *testing.T) {
 			},
 
 			{
-				Config:      CreateAccInterfaceBlacklistDSWithInvalidName(podId, nodeId, interfaceName),
+				Config:      CreateAccInterfaceBlacklistDSWithInvalidPodID(podId, nodeId, interfaceName),
 				ExpectError: regexp.MustCompile(`Object may not exists`),
 			},
 			{
@@ -133,7 +133,7 @@ func CreateInterfaceBlacklistDSWithoutRequired(podId, nodeId, interfaceName, att
 	return fmt.Sprintf(rBlock, podId, nodeId, interfaceName)
 }
 
-func CreateAccInterfaceBlacklistDSWithInvalidName(podId, nodeId, interfaceName string) string {
+func CreateAccInterfaceBlacklistDSWithInvalidPodID(podId, nodeId, interfaceName string) string {
 	fmt.Println("=== STEP  testing interface_blacklist Data Source with invalid pod_id")
 	resource := fmt.Sprintf(`
 	

--- a/testacc/data_source_aci_fcdomp_test.go
+++ b/testacc/data_source_aci_fcdomp_test.go
@@ -95,7 +95,7 @@ func CreateFCDomainDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccFCDomainDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing fc_domain Data Source with required arguments only")
+	fmt.Println("=== STEP  testing fc_domain Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_fc_domain" "test" {

--- a/testacc/data_source_aci_fileremotepath_test.go
+++ b/testacc/data_source_aci_fileremotepath_test.go
@@ -105,7 +105,7 @@ func CreateFileRemotePathDSWithoutRequired(rName, host, attrName string) string 
 }
 
 func CreateAccFileRemotePathDSWithInvalidName(rName, host string) string {
-	fmt.Println("=== STEP  testing file_remote_path Data Source with required arguments only")
+	fmt.Println("=== STEP  testing file_remote_path Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_file_remote_path" "test" {

--- a/testacc/data_source_aci_firmwarefwp_test.go
+++ b/testacc/data_source_aci_firmwarefwp_test.go
@@ -103,7 +103,7 @@ func CreateFirmwarePolicyDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccFirmwarePolicyDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing firmware_policy Data Source with required arguments only")
+	fmt.Println("=== STEP  testing firmware_policy Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_firmware_policy" "test" {

--- a/testacc/data_source_aci_firmwareosource_test.go
+++ b/testacc/data_source_aci_firmwareosource_test.go
@@ -108,7 +108,7 @@ func CreateFirmwareDownloadTaskDSWithoutRequired(rName, attrName string) string 
 }
 
 func CreateAccFirmwareDownloadTaskDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing firmware_download_task Data Source with required arguments only")
+	fmt.Println("=== STEP  testing firmware_download_task Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_firmware_download_task" "test" {

--- a/testacc/data_source_aci_fvnsvsaninstp_test.go
+++ b/testacc/data_source_aci_fvnsvsaninstp_test.go
@@ -116,7 +116,7 @@ func CreateVsanPoolDSWithoutRequired(rName, allocMode, attrName string) string {
 }
 
 func CreateAccVsanPoolDSWithInvalidName(rName, allocMode string) string {
-	fmt.Println("=== STEP  testing vsan_pool Data Source with required arguments only")
+	fmt.Println("=== STEP  testing vsan_pool Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_vsan_pool" "test" {
@@ -128,7 +128,6 @@ func CreateAccVsanPoolDSWithInvalidName(rName, allocMode string) string {
 	data "aci_vsan_pool" "test" {
 	
 		name  = "${aci_vsan_pool.test.name}_invalid"
-		name  = aci_vsan_pool.test.name
 		alloc_mode  = aci_vsan_pool.test.allocMode
 		depends_on = [ aci_vsan_pool.test ]
 	}

--- a/testacc/data_source_aci_infraaccnodepgrp_test.go
+++ b/testacc/data_source_aci_infraaccnodepgrp_test.go
@@ -96,7 +96,7 @@ func CreateAccessSwitchPolicyGroupDSWithoutRequired(rName, attrName string) stri
 }
 
 func CreateAccAccessSwitchPolicyGroupDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing access_switch_policy_group Data Source with required arguments only")
+	fmt.Println("=== STEP  testing access_switch_policy_group Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_access_switch_policy_group" "test" {

--- a/testacc/data_source_aci_infrafexp_test.go
+++ b/testacc/data_source_aci_infrafexp_test.go
@@ -96,7 +96,7 @@ func CreateFexProfileDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccFexProfileDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing fex_profile Data Source with required arguments only")
+	fmt.Println("=== STEP  testing fex_profile Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_fex_profile" "test" {

--- a/testacc/data_source_aci_infrageneric_test.go
+++ b/testacc/data_source_aci_infrageneric_test.go
@@ -83,7 +83,7 @@ func CreateAccAccessGenericConfigDataSource(infraAttEntityPName, rName string) s
 }
 
 func CreateAccessGenericDSWithoutRequired(infraAttEntityPName, rName, attrName string) string {
-	fmt.Println("=== STEP  Basic: testing access_generic creation without ", attrName)
+	fmt.Println("=== STEP  Basic: testing access_generic Data Source without ", attrName)
 	rBlock := `
 	
 	resource "aci_attachable_access_entity_profile" "test" {

--- a/testacc/data_source_aci_infraporttrackpol_test.go
+++ b/testacc/data_source_aci_infraporttrackpol_test.go
@@ -100,7 +100,7 @@ func CreatePortTrackingDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccPortTrackingDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing port_tracking Data Source with required arguments only")
+	fmt.Println("=== STEP  testing port_tracking Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_port_tracking" "test" {
@@ -111,7 +111,6 @@ func CreateAccPortTrackingDSWithInvalidName(rName string) string {
 	data "aci_port_tracking" "test" {
 	
 		name  = "${aci_port_tracking.test.name}_invalid"
-		name  = aci_port_tracking.test.name
 		depends_on = [ aci_port_tracking.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_infrasetpol_test.go
+++ b/testacc/data_source_aci_infrasetpol_test.go
@@ -44,11 +44,6 @@ func TestAccAciFabricWideSettingsDataSource_Basic(t *testing.T) {
 				Config:      CreateAccFabricWideSettingsDataSourceUpdate(randomParameter, randomValue),
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
 			},
-
-			{
-				Config:      CreateAccFabricWideSettingsDSWithInvalidName(),
-				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
-			},
 			{
 				Config: CreateAccFabricWideSettingsDataSourceUpdatedResource("annotation", "orchestrator:terraform-testacc"),
 				Check: resource.ComposeTestCheckFunc(
@@ -60,22 +55,6 @@ func TestAccAciFabricWideSettingsDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccFabricWideSettingsConfigDataSource() string {
-	fmt.Println("=== STEP  testing fabric_wide_settings Data Source with required arguments only")
-	resource := fmt.Sprintf(`
-	
-	resource "aci_fabric_wide_settings" "test" {
-	
-	}
-
-	data "aci_fabric_wide_settings" "test" {
-	
-		depends_on = [ aci_fabric_wide_settings.test ]
-	}
-	`)
-	return resource
-}
-
-func CreateAccFabricWideSettingsDSWithInvalidName() string {
 	fmt.Println("=== STEP  testing fabric_wide_settings Data Source with required arguments only")
 	resource := fmt.Sprintf(`
 	

--- a/testacc/data_source_aci_infraspaccportgrp_test.go
+++ b/testacc/data_source_aci_infraspaccportgrp_test.go
@@ -96,7 +96,7 @@ func CreateSpinePortPolicyGroupDSWithoutRequired(rName, attrName string) string 
 }
 
 func CreateAccSpinePortPolicyGroupDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing spine_port_policy_group Data Source with required arguments only")
+	fmt.Println("=== STEP  testing spine_port_policy_group Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_spine_port_policy_group" "test" {

--- a/testacc/data_source_aci_infraspaccportp_test.go
+++ b/testacc/data_source_aci_infraspaccportp_test.go
@@ -96,7 +96,7 @@ func CreateSpineInterfaceProfileDSWithoutRequired(rName, attrName string) string
 }
 
 func CreateAccSpineInterfaceProfileDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing spine_interface_profile Data Source with required arguments only")
+	fmt.Println("=== STEP  testing spine_interface_profile Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_spine_interface_profile" "test" {

--- a/testacc/data_source_aci_infraspineaccnodepgrp_test.go
+++ b/testacc/data_source_aci_infraspineaccnodepgrp_test.go
@@ -95,7 +95,7 @@ func CreateSpineSwitchPolicyGroupDSWithoutRequired(rName, attrName string) strin
 }
 
 func CreateAccSpineSwitchPolicyGroupDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing spine_switch_policy_group Data Source with required arguments only")
+	fmt.Println("=== STEP  testing spine_switch_policy_group Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_spine_switch_policy_group" "test" {

--- a/testacc/data_source_aci_infraspinep_test.go
+++ b/testacc/data_source_aci_infraspinep_test.go
@@ -96,7 +96,7 @@ func CreateSpineProfileDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccSpineProfileDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing spine_profile Data Source with required arguments only")
+	fmt.Println("=== STEP  testing spine_profile Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_spine_profile" "test" {

--- a/testacc/data_source_aci_iproutep_test.go
+++ b/testacc/data_source_aci_iproutep_test.go
@@ -142,8 +142,8 @@ func CreateL3outStaticRouteDSWithoutRequired(rName, tdn, ip, attrName string) st
 	case "fabric_node_dn":
 		rBlock += `
 	data "aci_l3out_static_route" "test" {
-	#	ip  = aci_l3out_static_route.test.ip
-		fabric_node_dn = aci_l3out_static_route.test.fabric_node_dn
+		ip  = aci_l3out_static_route.test.ip
+	#	fabric_node_dn = aci_l3out_static_route.test.fabric_node_dn
 		depends_on = [ aci_l3out_static_route.test ]
 	}
 		`

--- a/testacc/data_source_aci_isisdompol_test.go
+++ b/testacc/data_source_aci_isisdompol_test.go
@@ -35,6 +35,7 @@ func TestAccAciISISDomainPolicyDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "isis_level_name", resourceName, "isis_level_name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "mtu", resourceName, "mtu"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "redistrib_metric", resourceName, "redistrib_metric"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "isis_level_type", resourceName, "isis_level_type"),
@@ -72,20 +73,6 @@ func CreateAccISISDomainPolicyConfigDataSource() string {
 	}
 
 	data "aci_isis_domain_policy" "test" {
-	}
-	`)
-	return resource
-}
-
-func CreateAccISISDomainPolicyDSWithInvalidName() string {
-	fmt.Println("=== STEP  testing isis_domain_policy Data Source with required arguments only")
-	resource := fmt.Sprintf(`
-	
-	resource "aci_isis_domain_policy" "test" {
-	}
-
-	data "aci_isis_domain_policy" "test" {
-		depends_on = [ aci_isis_domain_policy.test ]
 	}
 	`)
 	return resource

--- a/testacc/data_source_aci_l2extdomp_test.go
+++ b/testacc/data_source_aci_l2extdomp_test.go
@@ -96,7 +96,7 @@ func CreateL2DomainDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccL2DomainDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing l2_domain Data Source with required arguments only")
+	fmt.Println("=== STEP  testing l2_domain Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_l2_domain" "test" {

--- a/testacc/data_source_aci_l2extinstp_test.go
+++ b/testacc/data_source_aci_l2extinstp_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func TestAccAciL2OutExtepgDataSource_Basic(t *testing.T) {
-	resourceName := "aci_l2_out_extepg.test"
-	dataSourceName := "data.aci_l2_out_extepg.test"
+	resourceName := "aci_l2out_extepg.test"
+	dataSourceName := "data.aci_l2out_extepg.test"
 	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
 	randomValue := acctest.RandString(10)
 	rName := makeTestVariable(acctest.RandString(5))
@@ -42,6 +42,7 @@ func TestAccAciL2OutExtepgDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "pref_gr_memb", resourceName, "pref_gr_memb"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "prio", resourceName, "prio"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "target_dscp", resourceName, "target_dscp"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "exception_tag", resourceName, "exception_tag"),
 				),
 			},
 			{
@@ -65,7 +66,7 @@ func TestAccAciL2OutExtepgDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccL2OutExtepgConfigDataSource(fvTenantName, l2extOutName, rName string) string {
-	fmt.Println("=== STEP  testing l2_out_extepg Data Source with required arguments only")
+	fmt.Println("=== STEP  testing l2out_extepg Data Source with required arguments only")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {
@@ -78,22 +79,22 @@ func CreateAccL2OutExtepgConfigDataSource(fvTenantName, l2extOutName, rName stri
 		tenant_dn = aci_tenant.test.id
 	}
 	
-	resource "aci_l2_out_extepg" "test" {
+	resource "aci_l2out_extepg" "test" {
 		l2_outside_dn  = aci_l2_outside.test.id
 		name  = "%s"
 	}
 
-	data "aci_l2_out_extepg" "test" {
+	data "aci_l2out_extepg" "test" {
 		l2_outside_dn  = aci_l2_outside.test.id
-		name  = aci_l2_out_extepg.test.name
-		depends_on = [ aci_l2_out_extepg.test ]
+		name  = aci_l2out_extepg.test.name
+		depends_on = [ aci_l2out_extepg.test ]
 	}
 	`, fvTenantName, l2extOutName, rName)
 	return resource
 }
 
 func CreateL2OutExtepgDSWithoutRequired(fvTenantName, l2extOutName, rName, attrName string) string {
-	fmt.Println("=== STEP  Basic: testing l2_out_extepg Data Source without ", attrName)
+	fmt.Println("=== STEP  Basic: testing l2out_extepg Data Source without ", attrName)
 	rBlock := `
 	
 	resource "aci_tenant" "test" {
@@ -106,7 +107,7 @@ func CreateL2OutExtepgDSWithoutRequired(fvTenantName, l2extOutName, rName, attrN
 		tenant_dn = aci_tenant.test.id
 	}
 	
-	resource "aci_l2_out_extepg" "test" {
+	resource "aci_l2out_extepg" "test" {
 		l2_outside_dn  = aci_l2_outside.test.id
 		name  = "%s"
 	}
@@ -114,18 +115,18 @@ func CreateL2OutExtepgDSWithoutRequired(fvTenantName, l2extOutName, rName, attrN
 	switch attrName {
 	case "l2_outside_dn":
 		rBlock += `
-	data "aci_l2_out_extepg" "test" {
+	data "aci_l2out_extepg" "test" {
 	#	l2_outside_dn  = aci_l2_outside.test.id
-		name  = aci_l2_out_extepg.test.name
-		depends_on = [ aci_l2_out_extepg.test ]
+		name  = aci_l2out_extepg.test.name
+		depends_on = [ aci_l2out_extepg.test ]
 	}
 		`
 	case "name":
 		rBlock += `
-	data "aci_l2_out_extepg" "test" {
+	data "aci_l2out_extepg" "test" {
 		l2_outside_dn  = aci_l2_outside.test.id
-	#	name  = aci_l2_out_extepg.test.name
-		depends_on = [ aci_l2_out_extepg.test ]
+	#	name  = aci_l2out_extepg.test.name
+		depends_on = [ aci_l2out_extepg.test ]
 	}
 		`
 	}
@@ -133,7 +134,7 @@ func CreateL2OutExtepgDSWithoutRequired(fvTenantName, l2extOutName, rName, attrN
 }
 
 func CreateAccL2OutExtepgDSWithInvalidParentDn(fvTenantName, l2extOutName, rName string) string {
-	fmt.Println("=== STEP  testing l2_out_extepg Data Source with Invalid Parent Dn")
+	fmt.Println("=== STEP  testing l2out_extepg Data Source with Invalid Parent Dn")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {
@@ -146,22 +147,22 @@ func CreateAccL2OutExtepgDSWithInvalidParentDn(fvTenantName, l2extOutName, rName
 		tenant_dn = aci_tenant.test.id
 	}
 	
-	resource "aci_l2_out_extepg" "test" {
+	resource "aci_l2out_extepg" "test" {
 		l2_outside_dn  = aci_l2_outside.test.id
 		name  = "%s"
 	}
 
-	data "aci_l2_out_extepg" "test" {
+	data "aci_l2out_extepg" "test" {
 		l2_outside_dn  = aci_l2_outside.test.id
-		name  = "${aci_l2_out_extepg.test.name}_invalid"
-		depends_on = [ aci_l2_out_extepg.test ]
+		name  = "${aci_l2out_extepg.test.name}_invalid"
+		depends_on = [ aci_l2out_extepg.test ]
 	}
 	`, fvTenantName, l2extOutName, rName)
 	return resource
 }
 
 func CreateAccL2OutExtepgDataSourceUpdate(fvTenantName, l2extOutName, rName, key, value string) string {
-	fmt.Println("=== STEP  testing l2_out_extepg Data Source with random attribute")
+	fmt.Println("=== STEP  testing l2out_extepg Data Source with random attribute")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {
@@ -174,23 +175,23 @@ func CreateAccL2OutExtepgDataSourceUpdate(fvTenantName, l2extOutName, rName, key
 		tenant_dn = aci_tenant.test.id
 	}
 	
-	resource "aci_l2_out_extepg" "test" {
+	resource "aci_l2out_extepg" "test" {
 		l2_outside_dn  = aci_l2_outside.test.id
 		name  = "%s"
 	}
 
-	data "aci_l2_out_extepg" "test" {
+	data "aci_l2out_extepg" "test" {
 		l2_outside_dn  = aci_l2_outside.test.id
-		name  = aci_l2_out_extepg.test.name
+		name  = aci_l2out_extepg.test.name
 		%s = "%s"
-		depends_on = [ aci_l2_out_extepg.test ]
+		depends_on = [ aci_l2out_extepg.test ]
 	}
 	`, fvTenantName, l2extOutName, rName, key, value)
 	return resource
 }
 
 func CreateAccL2OutExtepgDataSourceUpdatedResource(fvTenantName, l2extOutName, rName, key, value string) string {
-	fmt.Println("=== STEP  testing l2_out_extepg Data Source with updated resource")
+	fmt.Println("=== STEP  testing l2out_extepg Data Source with updated resource")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {
@@ -203,16 +204,16 @@ func CreateAccL2OutExtepgDataSourceUpdatedResource(fvTenantName, l2extOutName, r
 		tenant_dn = aci_tenant.test.id
 	}
 	
-	resource "aci_l2_out_extepg" "test" {
+	resource "aci_l2out_extepg" "test" {
 		l2_outside_dn  = aci_l2_outside.test.id
 		name  = "%s"
 		%s = "%s"
 	}
 
-	data "aci_l2_out_extepg" "test" {
+	data "aci_l2out_extepg" "test" {
 		l2_outside_dn  = aci_l2_outside.test.id
-		name  = aci_l2_out_extepg.test.name
-		depends_on = [ aci_l2_out_extepg.test ]
+		name  = aci_l2out_extepg.test.name
+		depends_on = [ aci_l2out_extepg.test ]
 	}
 	`, fvTenantName, l2extOutName, rName, key, value)
 	return resource

--- a/testacc/data_source_aci_l3ifpol_test.go
+++ b/testacc/data_source_aci_l3ifpol_test.go
@@ -97,7 +97,7 @@ func CreateL3InterfacePolicyDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccL3InterfacePolicyDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing l3_interface_policy Data Source with required arguments only")
+	fmt.Println("=== STEP  testing l3_interface_policy Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_l3_interface_policy" "test" {

--- a/testacc/data_source_aci_maintmaintgrp_test.go
+++ b/testacc/data_source_aci_maintmaintgrp_test.go
@@ -98,7 +98,7 @@ func CreatePodMaintenanceGroupDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccPodMaintenanceGroupDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing pod_maintenance_group Data Source with required arguments only")
+	fmt.Println("=== STEP  testing pod_maintenance_group Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_pod_maintenance_group" "test" {
@@ -109,7 +109,6 @@ func CreateAccPodMaintenanceGroupDSWithInvalidName(rName string) string {
 	data "aci_pod_maintenance_group" "test" {
 	
 		name  = "${aci_pod_maintenance_group.test.name}_invalid"
-		name  = aci_pod_maintenance_group.test.name
 		depends_on = [ aci_pod_maintenance_group.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_maintmaintp_test.go
+++ b/testacc/data_source_aci_maintmaintp_test.go
@@ -35,14 +35,11 @@ func TestAccAciMaintenancePolicyDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "admin_st", resourceName, "admin_st"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "download_st", resourceName, "download_st"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "graceful", resourceName, "graceful"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "ignore_compat", resourceName, "ignore_compat"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "internal_label", resourceName, "internal_label"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "notif_cond", resourceName, "notif_cond"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "run_mode", resourceName, "run_mode"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "sr_upgrade", resourceName, "sr_upgrade"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "sr_version", resourceName, "sr_version"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "version", resourceName, "version"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "version_check_override", resourceName, "version_check_override"),
 				),
@@ -107,7 +104,7 @@ func CreateMaintenancePolicyDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccMaintenancePolicyDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing maintenance_policy Data Source with required arguments only")
+	fmt.Println("=== STEP  testing maintenance_policy Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_maintenance_policy" "test" {

--- a/testacc/data_source_aci_mcpinstpol_test.go
+++ b/testacc/data_source_aci_mcpinstpol_test.go
@@ -105,7 +105,7 @@ func CreateMCPInstancePolicyDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccMCPInstancePolicyDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing mcp_instance_policy Data Source with required arguments only")
+	fmt.Println("=== STEP  testing mcp_instance_policy Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_mcp_instance_policy" "test" {
@@ -116,7 +116,6 @@ func CreateAccMCPInstancePolicyDSWithInvalidName(rName string) string {
 	data "aci_mcp_instance_policy" "test" {
 	
 		name  = "${aci_mcp_instance_policy.test.name}_invalid"
-		name  = aci_mcp_instance_policy.test.name
 		depends_on = [ aci_mcp_instance_policy.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_mgmtconnectivityprefs_test.go
+++ b/testacc/data_source_aci_mgmtconnectivityprefs_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccAciMgmtPreferenceDataSource_Basic(t *testing.T) {
+func TestAccAciMgmtconnectivitypreferenceDataSource_Basic(t *testing.T) {
 	resourceName := "aci_mgmt_preference.test"
 	dataSourceName := "data.aci_mgmt_preference.test"
 	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
 	randomValue := acctest.RandString(10)
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckAciMgmtconnectivitypreferenceDestroy,
@@ -33,11 +33,6 @@ func TestAccAciMgmtPreferenceDataSource_Basic(t *testing.T) {
 				Config:      CreateAccMgmtPreferenceDataSourceUpdate(randomParameter, randomValue),
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
 			},
-
-			{
-				Config:      CreateAccMgmtPreferenceDSWithInvalidName(),
-				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
-			},
 			{
 				Config: CreateAccMgmtPreferenceDataSourceUpdatedResource("annotation", "orchestrator:terraform-testacc"),
 				Check: resource.ComposeTestCheckFunc(
@@ -49,22 +44,6 @@ func TestAccAciMgmtPreferenceDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccMgmtPreferenceConfigDataSource() string {
-	fmt.Println("=== STEP  testing mgmt_preference Data Source with required arguments only")
-	resource := fmt.Sprintf(`
-	
-	resource "aci_mgmt_preference" "test" {
-	
-	}
-
-	data "aci_mgmt_preference" "test" {
-	
-		depends_on = [ aci_mgmt_preference.test ]
-	}
-	`)
-	return resource
-}
-
-func CreateAccMgmtPreferenceDSWithInvalidName() string {
 	fmt.Println("=== STEP  testing mgmt_preference Data Source with required arguments only")
 	resource := fmt.Sprintf(`
 	

--- a/testacc/data_source_aci_mgmtgrp_test.go
+++ b/testacc/data_source_aci_mgmtgrp_test.go
@@ -96,7 +96,7 @@ func CreateManagedNodeConnectivityGroupDSWithoutRequired(rName, attrName string)
 }
 
 func CreateAccManagedNodeConnectivityGroupDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing managed_node_connectivity_group Data Source with required arguments only")
+	fmt.Println("=== STEP  testing managed_node_connectivity_group Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_managed_node_connectivity_group" "test" {

--- a/testacc/data_source_aci_mgmtinbzone_test.go
+++ b/testacc/data_source_aci_mgmtinbzone_test.go
@@ -41,6 +41,8 @@ func TestAccAciMgmtZoneDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "type", resourceName, "type"),
 				),
 			},
 			{

--- a/testacc/data_source_aci_pkiexportencryptionkey_test.go
+++ b/testacc/data_source_aci_pkiexportencryptionkey_test.go
@@ -37,11 +37,6 @@ func TestAccAciEncryptionKeyDataSource_Basic(t *testing.T) {
 				Config:      CreateAccEncryptionKeyDataSourceUpdate(randomParameter, randomValue),
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
 			},
-
-			{
-				Config:      CreateAccEncryptionKeyDSWithInvalidName(),
-				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
-			},
 			{
 				Config: CreateAccEncryptionKeyDataSourceUpdatedResource("annotation", "orchestrator:terraform-testacc"),
 				Check: resource.ComposeTestCheckFunc(
@@ -53,22 +48,6 @@ func TestAccAciEncryptionKeyDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccEncryptionKeyConfigDataSource() string {
-	fmt.Println("=== STEP  testing encryption_key Data Source with required arguments only")
-	resource := fmt.Sprintf(`
-	
-	resource "aci_encryption_key" "test" {
-	
-	}
-
-	data "aci_encryption_key" "test" {
-	
-		depends_on = [ aci_encryption_key.test ]
-	}
-	`)
-	return resource
-}
-
-func CreateAccEncryptionKeyDSWithInvalidName() string {
 	fmt.Println("=== STEP  testing encryption_key Data Source with required arguments only")
 	resource := fmt.Sprintf(`
 	

--- a/testacc/data_source_aci_qosinstpol_test.go
+++ b/testacc/data_source_aci_qosinstpol_test.go
@@ -106,7 +106,7 @@ func CreateQosInstancePolicyDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccQosInstancePolicyDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing qos_instance_policy Data Source with required arguments only")
+	fmt.Println("=== STEP  testing qos_instance_policy Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_qos_instance_policy" "test" {
@@ -117,7 +117,6 @@ func CreateAccQosInstancePolicyDSWithInvalidName(rName string) string {
 	data "aci_qos_instance_policy" "test" {
 	
 		name  = "${aci_qos_instance_policy.test.name}_invalid"
-		name  = aci_qos_instance_policy.test.name
 		depends_on = [ aci_qos_instance_policy.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_rtctrlctxp_test.go
+++ b/testacc/data_source_aci_rtctrlctxp_test.go
@@ -72,18 +72,18 @@ func CreateAccRouteControlContextConfigDataSource(fvTenantName, rtctrlProfileNam
 	
 	}
 	
-	resource "aci_route_control_profile" "test" {
+	resource "aci_bgp_route_control_profile" "test" {
 		name 		= "%s"
-		tenant_dn = aci_tenant.test.id
+		parent_dn = aci_tenant.test.id
 	}
 	
 	resource "aci_route_control_context" "test" {
-		route_control_profile_dn  = aci_route_control_profile.test.id
+		route_control_profile_dn  = aci_bgp_route_control_profile.test.id
 		name  = "%s"
 	}
 
 	data "aci_route_control_context" "test" {
-		route_control_profile_dn  = aci_route_control_profile.test.id
+		route_control_profile_dn  = aci_bgp_route_control_profile.test.id
 		name  = aci_route_control_context.test.name
 		depends_on = [ aci_route_control_context.test ]
 	}
@@ -100,13 +100,13 @@ func CreateRouteControlContextDSWithoutRequired(fvTenantName, rtctrlProfileName,
 	
 	}
 	
-	resource "aci_route_control_profile" "test" {
+	resource "aci_bgp_route_control_profile" "test" {
 		name 		= "%s"
-		tenant_dn = aci_tenant.test.id
+		parent_dn = aci_tenant.test.id
 	}
 	
 	resource "aci_route_control_context" "test" {
-		route_control_profile_dn  = aci_route_control_profile.test.id
+		route_control_profile_dn  = aci_bgp_route_control_profile.test.id
 		name  = "%s"
 	}
 	`
@@ -114,7 +114,7 @@ func CreateRouteControlContextDSWithoutRequired(fvTenantName, rtctrlProfileName,
 	case "route_control_profile_dn":
 		rBlock += `
 	data "aci_route_control_context" "test" {
-	#	route_control_profile_dn  = aci_route_control_profile.test.id
+	#	route_control_profile_dn  = aci_bgp_route_control_profile.test.id
 		name  = aci_route_control_context.test.name
 		depends_on = [ aci_route_control_context.test ]
 	}
@@ -122,7 +122,7 @@ func CreateRouteControlContextDSWithoutRequired(fvTenantName, rtctrlProfileName,
 	case "name":
 		rBlock += `
 	data "aci_route_control_context" "test" {
-		route_control_profile_dn  = aci_route_control_profile.test.id
+		route_control_profile_dn  = aci_bgp_route_control_profile.test.id
 	#	name  = aci_route_control_context.test.name
 		depends_on = [ aci_route_control_context.test ]
 	}
@@ -140,18 +140,18 @@ func CreateAccRouteControlContextDSWithInvalidParentDn(fvTenantName, rtctrlProfi
 	
 	}
 	
-	resource "aci_route_control_profile" "test" {
+	resource "aci_bgp_route_control_profile" "test" {
 		name 		= "%s"
-		tenant_dn = aci_tenant.test.id
+		parent_dn = aci_tenant.test.id
 	}
 	
 	resource "aci_route_control_context" "test" {
-		route_control_profile_dn  = aci_route_control_profile.test.id
+		route_control_profile_dn  = aci_bgp_route_control_profile.test.id
 		name  = "%s"
 	}
 
 	data "aci_route_control_context" "test" {
-		route_control_profile_dn  = aci_route_control_profile.test.id
+		route_control_profile_dn  = aci_bgp_route_control_profile.test.id
 		name  = "${aci_route_control_context.test.name}_invalid"
 		depends_on = [ aci_route_control_context.test ]
 	}
@@ -168,18 +168,18 @@ func CreateAccRouteControlContextDataSourceUpdate(fvTenantName, rtctrlProfileNam
 	
 	}
 	
-	resource "aci_route_control_profile" "test" {
+	resource "aci_bgp_route_control_profile" "test" {
 		name 		= "%s"
-		tenant_dn = aci_tenant.test.id
+		parent_dn = aci_tenant.test.id
 	}
 	
 	resource "aci_route_control_context" "test" {
-		route_control_profile_dn  = aci_route_control_profile.test.id
+		route_control_profile_dn  = aci_bgp_route_control_profile.test.id
 		name  = "%s"
 	}
 
 	data "aci_route_control_context" "test" {
-		route_control_profile_dn  = aci_route_control_profile.test.id
+		route_control_profile_dn  = aci_bgp_route_control_profile.test.id
 		name  = aci_route_control_context.test.name
 		%s = "%s"
 		depends_on = [ aci_route_control_context.test ]
@@ -197,19 +197,19 @@ func CreateAccRouteControlContextDataSourceUpdatedResource(fvTenantName, rtctrlP
 	
 	}
 	
-	resource "aci_route_control_profile" "test" {
+	resource "aci_bgp_route_control_profile" "test" {
 		name 		= "%s"
-		tenant_dn = aci_tenant.test.id
+		parent_dn = aci_tenant.test.id
 	}
 	
 	resource "aci_route_control_context" "test" {
-		route_control_profile_dn  = aci_route_control_profile.test.id
+		route_control_profile_dn  = aci_bgp_route_control_profile.test.id
 		name  = "%s"
 		%s = "%s"
 	}
 
 	data "aci_route_control_context" "test" {
-		route_control_profile_dn  = aci_route_control_profile.test.id
+		route_control_profile_dn  = aci_bgp_route_control_profile.test.id
 		name  = aci_route_control_context.test.name
 		depends_on = [ aci_route_control_context.test ]
 	}

--- a/testacc/data_source_aci_tacacsgroup_test.go
+++ b/testacc/data_source_aci_tacacsgroup_test.go
@@ -96,7 +96,7 @@ func CreateTACACSAccountingDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccTACACSAccountingDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing tacacs_accounting Data Source with required arguments only")
+	fmt.Println("=== STEP  testing tacacs_accounting Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tacacs_accounting" "test" {
@@ -107,7 +107,6 @@ func CreateAccTACACSAccountingDSWithInvalidName(rName string) string {
 	data "aci_tacacs_accounting" "test" {
 	
 		name  = "${aci_tacacs_accounting.test.name}_invalid"
-		name  = aci_tacacs_accounting.test.name
 		depends_on = [ aci_tacacs_accounting.test ]
 	}
 	`, rName)

--- a/testacc/data_source_aci_tacacssrc_test.go
+++ b/testacc/data_source_aci_tacacssrc_test.go
@@ -100,7 +100,7 @@ func CreateTACACSSourceDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccTACACSSourceDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing tacacs_source Data Source with required arguments only")
+	fmt.Println("=== STEP  testing tacacs_source Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tacacs_source" "test" {

--- a/testacc/data_source_aci_tagannotation_test.go
+++ b/testacc/data_source_aci_tagannotation_test.go
@@ -35,9 +35,6 @@ func TestAccAciAnnotationDataSource_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "parent_dn", resourceName, "parent_dn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "key", resourceName, "key"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "value", resourceName, "value"),
 				),
 			},
@@ -52,9 +49,9 @@ func TestAccAciAnnotationDataSource_Basic(t *testing.T) {
 			},
 
 			{
-				Config: CreateAccAnnotationDataSourceUpdatedResource(fvTenantName, key, "annotation", "orchestrator:terraform-testacc"),
+				Config: CreateAccAnnotationDataSourceUpdatedResource(fvTenantName, key, "test_value"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "value", resourceName, "value"),
 				),
 			},
 		},
@@ -170,7 +167,7 @@ func CreateAccAnnotationDataSourceUpdate(fvTenantName, key, attr, value string) 
 	return resource
 }
 
-func CreateAccAnnotationDataSourceUpdatedResource(fvTenantName, key, attr, value string) string {
+func CreateAccAnnotationDataSourceUpdatedResource(fvTenantName, key, value string) string {
 	fmt.Println("=== STEP  testing annotation Data Source with updated resource")
 	resource := fmt.Sprintf(`
 	
@@ -182,8 +179,7 @@ func CreateAccAnnotationDataSourceUpdatedResource(fvTenantName, key, attr, value
 	resource "aci_annotation" "test" {
 		parent_dn  = aci_tenant.test.id
 		key  = "%s"
-		value = "val"
-		%s = "%s"
+		value = "%s"
 	}
 
 	data "aci_annotation" "test" {
@@ -191,6 +187,6 @@ func CreateAccAnnotationDataSourceUpdatedResource(fvTenantName, key, attr, value
 		key  = aci_annotation.test.key
 		depends_on = [ aci_annotation.test ]
 	}
-	`, fvTenantName, key, attr, value)
+	`, fvTenantName, key, value)
 	return resource
 }

--- a/testacc/data_source_aci_tagtag_test.go
+++ b/testacc/data_source_aci_tagtag_test.go
@@ -35,9 +35,6 @@ func TestAccAciTagDataSource_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "parent_dn", resourceName, "parent_dn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "key", resourceName, "key"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "value", resourceName, "value"),
 				),
 			},
@@ -52,9 +49,9 @@ func TestAccAciTagDataSource_Basic(t *testing.T) {
 			},
 
 			{
-				Config: CreateAccTagDataSourceUpdatedResource(fvTenantName, key, "annotation", "orchestrator:terraform-testacc"),
+				Config: CreateAccTagDataSourceUpdatedResource(fvTenantName, key, "test_value"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "value", resourceName, "value"),
 				),
 			},
 		},
@@ -170,7 +167,7 @@ func CreateAccTagDataSourceUpdate(fvTenantName, key, attr, value string) string 
 	return resource
 }
 
-func CreateAccTagDataSourceUpdatedResource(fvTenantName, key, attr, value string) string {
+func CreateAccTagDataSourceUpdatedResource(fvTenantName, key, value string) string {
 	fmt.Println("=== STEP  testing tag Data Source with updated resource")
 	resource := fmt.Sprintf(`
 	
@@ -182,8 +179,7 @@ func CreateAccTagDataSourceUpdatedResource(fvTenantName, key, attr, value string
 	resource "aci_tag" "test" {
 		parent_dn  = aci_tenant.test.id
 		key  = "%s"
-		value = "val"
-		%s = "%s"
+		value = "%s"
 	}
 
 	data "aci_tag" "test" {
@@ -191,6 +187,6 @@ func CreateAccTagDataSourceUpdatedResource(fvTenantName, key, attr, value string
 		key  = aci_tag.test.key
 		depends_on = [ aci_tag.test ]
 	}
-	`, fvTenantName, key, attr, value)
+	`, fvTenantName, key, value)
 	return resource
 }

--- a/testacc/data_source_aci_vpcinstpol_test.go
+++ b/testacc/data_source_aci_vpcinstpol_test.go
@@ -97,7 +97,7 @@ func CreateVPCDomainPolicyDSWithoutRequired(rName, attrName string) string {
 }
 
 func CreateAccVPCDomainPolicyDSWithInvalidName(rName string) string {
-	fmt.Println("=== STEP  testing vpc_domain_policy Data Source with required arguments only")
+	fmt.Println("=== STEP  testing vpc_domain_policy Data Source with invalid name")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_vpc_domain_policy" "test" {

--- a/testacc/resource_aci_configimportp_test.go
+++ b/testacc/resource_aci_configimportp_test.go
@@ -71,31 +71,6 @@ func TestAccAciConfigurationImportPolicy_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: CreateAccConfigurationImportPolicyConfigSecondWithOptionalValues(rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciConfigurationImportPolicyExists(resourceName, &configuration_import_policy_updated),
-
-					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
-					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
-					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_configuration_import_policy"),
-
-					resource.TestCheckResourceAttr(resourceName, "admin_st", "triggered"),
-
-					resource.TestCheckResourceAttr(resourceName, "fail_on_decrypt_errors", "no"),
-
-					resource.TestCheckResourceAttr(resourceName, "file_name", "file2.tar.gz"),
-
-					resource.TestCheckResourceAttr(resourceName, "import_mode", "atomic"),
-
-					resource.TestCheckResourceAttr(resourceName, "import_type", "replace"),
-
-					resource.TestCheckResourceAttr(resourceName, "snapshot", "yes"),
-
-					testAccCheckAciConfigurationImportPolicyIdEqual(&configuration_import_policy_default, &configuration_import_policy_updated),
-				),
-			},
-			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,

--- a/testacc/resource_aci_epipagingp_test.go
+++ b/testacc/resource_aci_epipagingp_test.go
@@ -42,6 +42,14 @@ func TestAccAciIPAgingPolicy_Basic(t *testing.T) {
 				),
 			},
 			{
+				Config:      CreateAccIPAgingPolicyUpdatedAttr("admin_st", "disabled"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciIPAgingPolicyExists(resourceName, &endpoint_ip_aging_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "admin_st", "disabled"),
+					testAccCheckAciIPAgingPolicyIdEqual(&endpoint_ip_aging_profile_default, &endpoint_ip_aging_profile_updated),
+				),
+			},
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -155,16 +163,6 @@ func testAccCheckAciIPAgingPolicyIdNotEqual(m1, m2 *models.IPAgingPolicy) resour
 	}
 }
 
-func CreateAccIPAgingPolicyConfigWithRequiredParams() string {
-	fmt.Println("=== STEP  testing endpoint_ip_aging_profile creation with updated naming arguments")
-	resource := fmt.Sprintf(`
-	
-	resource "aci_endpoint_ip_aging_profile" "test" {
-	}
-	`)
-	return resource
-}
-
 func CreateAccIPAgingPolicyConfig() string {
 	fmt.Println("=== STEP  testing endpoint_ip_aging_profile creation with required arguments only")
 	resource := fmt.Sprintf(`
@@ -185,21 +183,6 @@ func CreateAccIPAgingPolicyConfigWithOptionalValues() string {
 		annotation = "orchestrator:terraform_testacc"
 		name_alias = "test_endpoint_ip_aging_profile"
 		admin_st = "enabled"
-	}
-	`)
-
-	return resource
-}
-
-func CreateAccIPAgingPolicyRemovingRequiredField() string {
-	fmt.Println("=== STEP  Basic: testing endpoint_ip_aging_profile updation without required parameters")
-	resource := fmt.Sprintf(`
-	resource "aci_endpoint_ip_aging_profile" "test" {
-		description = "created while acceptance testing"
-		annotation = "orchestrator:terraform_testacc"
-		name_alias = "test_endpoint_ip_aging_profile"
-		admin_st = "enabled"
-		
 	}
 	`)
 

--- a/testacc/resource_aci_fabricnodeblk_test.go
+++ b/testacc/resource_aci_fabricnodeblk_test.go
@@ -119,6 +119,14 @@ func TestAccAciNodeBlockFW_Update(t *testing.T) {
 				),
 			},
 			{
+				Config: CreateAccNodeBlockFWUpdatedAttr(firmwareFwGrpName, rName, "to_", "16000"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciNodeBlockFWExists(resourceName, &node_block_firmware_updated),
+					resource.TestCheckResourceAttr(resourceName, "to_", "16000"),
+					testAccCheckAciNodeBlockFWIdEqual(&node_block_firmware_default, &node_block_firmware_updated),
+				),
+			},
+			{
 				Config: CreateAccNodeBlockFWUpdatedAttr(firmwareFwGrpName, rName, "from_", "16000"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciNodeBlockFWExists(resourceName, &node_block_firmware_updated),
@@ -135,14 +143,6 @@ func TestAccAciNodeBlockFW_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: CreateAccNodeBlockFWUpdatedAttr(firmwareFwGrpName, rName, "to_", "16000"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciNodeBlockFWExists(resourceName, &node_block_firmware_updated),
-					resource.TestCheckResourceAttr(resourceName, "to_", "16000"),
-					testAccCheckAciNodeBlockFWIdEqual(&node_block_firmware_default, &node_block_firmware_updated),
-				),
-			},
-			{
 				Config: CreateAccNodeBlockFWUpdatedAttr(firmwareFwGrpName, rName, "to_", "7999"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciNodeBlockFWExists(resourceName, &node_block_firmware_updated),
@@ -150,7 +150,6 @@ func TestAccAciNodeBlockFW_Update(t *testing.T) {
 					testAccCheckAciNodeBlockFWIdEqual(&node_block_firmware_default, &node_block_firmware_updated),
 				),
 			},
-
 			{
 				Config: CreateAccNodeBlockFWConfig(firmwareFwGrpName, rName),
 			},

--- a/testacc/resource_aci_fabricrsoospath_test.go
+++ b/testacc/resource_aci_fabricrsoospath_test.go
@@ -49,7 +49,6 @@ func TestAccAciOutofServiceFabricPath_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "pod_id", podId),
 					resource.TestCheckResourceAttr(resourceName, "node_id", NodeId),
 					resource.TestCheckResourceAttr(resourceName, "interface", Interface),
-					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
 				),
 			},
 			{
@@ -72,12 +71,12 @@ func TestAccAciOutofServiceFabricPath_Basic(t *testing.T) {
 			},
 
 			{
-				Config:      CreateAccOutofServiceFabricPathConfig(randomValue, NodeId, Interface),
-				ExpectError: regexp.MustCompile(`Invalid reference`),
+				Config:      CreateAccOutofServiceFabricPathConfigWithRequiredParams(randomValue, NodeId, Interface),
+				ExpectError: regexp.MustCompile(`Incorrect attribute value type`),
 			},
 			{
-				Config:      CreateAccOutofServiceFabricPathConfig(podId, randomValue, Interface),
-				ExpectError: regexp.MustCompile(`Invalid reference`),
+				Config:      CreateAccOutofServiceFabricPathConfigWithRequiredParams(podId, randomValue, Interface),
+				ExpectError: regexp.MustCompile(`Incorrect attribute value type`),
 			},
 			{
 				Config: CreateAccOutofServiceFabricPathConfigWithRequiredParams(podId, NodeId, InterfaceUpdated),
@@ -242,13 +241,13 @@ func CreateOutofServiceFabricPathWithoutRequired(podId, NodeId, Interface, attrN
 }
 
 func CreateAccOutofServiceFabricPathConfigWithRequiredParams(podId, NodeId, Interface string) string {
-	fmt.Println("=== STEP  testing interface_blacklist creation with updated naming arguments")
+	fmt.Printf("=== STEP  testing interface_blacklist creation with pod_id %s, node_id %s and interface %s\n", podId, NodeId, Interface)
 	resource := fmt.Sprintf(`
 	
 	resource "aci_interface_blacklist" "test" {
 	
-		pod_id  = %s
-  		node_id = %s
+		pod_id  = "%s"
+  		node_id = "%s"
  		interface = "%s"
 	}
 	`, podId, NodeId, Interface)
@@ -296,18 +295,6 @@ func CreateAccOutofServiceFabricPathConfigWithOptionalValues(podId, NodeId, Inte
 		
 	}
 	`, podId, NodeId, Interface)
-
-	return resource
-}
-
-func CreateAccOutofServiceFabricPathRemovingRequiredField() string {
-	fmt.Println("=== STEP  Basic: testing interface_blacklist updation without required parameters")
-	resource := fmt.Sprintf(`
-	resource "aci_interface_blacklist" "test" {
-		annotation = "orchestrator:terraform_testacc"
-		
-	}
-	`)
 
 	return resource
 }

--- a/testacc/resource_aci_firmwareosource_test.go
+++ b/testacc/resource_aci_firmwareosource_test.go
@@ -206,6 +206,11 @@ func TestAccAciFirmwareDownloadTask_Negative(t *testing.T) {
 			},
 
 			{
+				Config:      CreateAccFirmwareDownloadTaskUpdatedAttr(rName, "load_catalog_if_exists_and_newer", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
 				Config:      CreateAccFirmwareDownloadTaskUpdatedAttr(rName, "polling_interval", randomValue),
 				ExpectError: regexp.MustCompile(`unknown property value`),
 			},

--- a/testacc/resource_aci_fvepretpol_test.go
+++ b/testacc/resource_aci_fvepretpol_test.go
@@ -108,59 +108,6 @@ func TestAccAciEndPointRetentionPolicy_Basic(t *testing.T) {
 	})
 }
 
-func TestAccAciEndPointRetentionPolicy_Update(t *testing.T) {
-	var end_point_retention_policy_default models.EndPointRetentionPolicy
-	var end_point_retention_policy_updated models.EndPointRetentionPolicy
-	resourceName := "aci_end_point_retention_policy.test"
-	rName := makeTestVariable(acctest.RandString(5))
-
-	fvTenantName := makeTestVariable(acctest.RandString(5))
-	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviders,
-		CheckDestroy:      testAccCheckAciEndPointRetentionPolicyDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: CreateAccEndPointRetentionPolicyConfig(fvTenantName, rName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciEndPointRetentionPolicyExists(resourceName, &end_point_retention_policy_default),
-				),
-			},
-
-			{
-
-				Config: CreateAccEndPointRetentionPolicyUpdatedAttrList(fvTenantName, rName, "bounce_trig", StringListtoString([]string{"protocol", "rarp-flood"})),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciEndPointRetentionPolicyExists(resourceName, &end_point_retention_policy_updated),
-					resource.TestCheckResourceAttr(resourceName, "bounce_trig.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "bounce_trig.0", "protocol"),
-					resource.TestCheckResourceAttr(resourceName, "bounce_trig.1", "rarp-flood"),
-				),
-			},
-			{
-
-				Config: CreateAccEndPointRetentionPolicyUpdatedAttrList(fvTenantName, rName, "bounce_trig", StringListtoString([]string{"rarp-flood"})),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciEndPointRetentionPolicyExists(resourceName, &end_point_retention_policy_updated),
-					resource.TestCheckResourceAttr(resourceName, "bounce_trig.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "bounce_trig.0", "rarp-flood"),
-				),
-			},
-			{
-				Config: CreateAccEndPointRetentionPolicyUpdatedAttrList(fvTenantName, rName, "bounce_trig", StringListtoString([]string{"rarp-flood", "protocol"})),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciEndPointRetentionPolicyExists(resourceName, &end_point_retention_policy_updated),
-					resource.TestCheckResourceAttr(resourceName, "bounce_trig.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "bounce_trig.0", "rarp-flood"),
-					resource.TestCheckResourceAttr(resourceName, "bounce_trig.1", "protocol"),
-				),
-			},
-			{
-				Config: CreateAccEndPointRetentionPolicyConfig(fvTenantName, rName),
-			},
-		},
-	})
-}
 
 func TestAccAciEndPointRetentionPolicy_Negative(t *testing.T) {
 	rName := makeTestVariable(acctest.RandString(5))
@@ -383,7 +330,7 @@ func CreateEndPointRetentionPolicyWithoutRequired(fvTenantName, rName, attrName 
 }
 
 func CreateAccEndPointRetentionPolicyConfigWithRequiredParams(fvTenantName, rName string) string {
-	fmt.Println("=== STEP  testing end_point_retention_policy creation with required arguments only")
+	fmt.Printf("=== STEP  testing end_point_retention_policy creation with parent resource name %s and resource name %s\n", fvTenantName, rName)
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {
@@ -529,24 +476,6 @@ func CreateAccEndPointRetentionPolicyUpdatedAttr(fvTenantName, rName, attribute,
 		tenant_dn  = aci_tenant.test.id
 		name  = "%s"
 		%s = "%s"
-	}
-	`, fvTenantName, rName, attribute, value)
-	return resource
-}
-
-func CreateAccEndPointRetentionPolicyUpdatedAttrList(fvTenantName, rName, attribute, value string) string {
-	fmt.Printf("=== STEP  testing end_point_retention_policy attribute: %s = %s \n", attribute, value)
-	resource := fmt.Sprintf(`
-	
-	resource "aci_tenant" "test" {
-		name 		= "%s"
-	
-	}
-	
-	resource "aci_end_point_retention_policy" "test" {
-		tenant_dn  = aci_tenant.test.id
-		name  = "%s"
-		%s = %s
 	}
 	`, fvTenantName, rName, attribute, value)
 	return resource

--- a/testacc/resource_aci_infrageneric_test.go
+++ b/testacc/resource_aci_infrageneric_test.go
@@ -226,7 +226,7 @@ func CreateAccessGenericWithoutRequired(infraAttEntityPName, rName, attrName str
 }
 
 func CreateAccAccessGenericConfigWithRequiredParams(infraAttEntityPName, rName string) string {
-	fmt.Println("=== STEP  testing access_generic creation with required arguments only")
+	fmt.Printf("=== STEP  testing access_generic creation with parent resource name %s and resource name %s\n", infraAttEntityPName, rName)
 	resource := fmt.Sprintf(`
 	
 	resource "aci_attachable_access_entity_profile" "test" {

--- a/testacc/resource_aci_iproutep_test.go
+++ b/testacc/resource_aci_iproutep_test.go
@@ -358,7 +358,7 @@ func CreateAccL3outStaticRouteWithInavalidIP(rName, tdn, ip string) string {
 }
 
 func CreateAccL3outStaticRouteWithInValidParentDn(rName, ip string) string {
-	fmt.Println("=== STEP  testing l3out_static_route creation with required arguments only")
+	fmt.Println("=== STEP  testing l3out_static_route creation with invalid parent dn")
 	resource := fmt.Sprintf(`
 	resource "aci_tenant" "test" {
 		name 		= "%s"

--- a/testacc/resource_aci_isisdompol_test.go
+++ b/testacc/resource_aci_isisdompol_test.go
@@ -98,6 +98,14 @@ func TestAccAciISISDomainPolicy_Update(t *testing.T) {
 				),
 			},
 			{
+				Config: CreateAccISISDomainPolicyUpdatedAttr("lsp_fast_flood", "enabled"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciISISDomainPolicyExists(resourceName, &isis_domain_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "lsp_fast_flood", "enabled"),
+					testAccCheckAciISISDomainPolicyIdEqual(&isis_domain_policy_default, &isis_domain_policy_updated),
+				),
+			},
+			{
 				Config: CreateAccISISDomainPolicyUpdatedAttr("mtu", "4352"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciISISDomainPolicyExists(resourceName, &isis_domain_policy_updated),
@@ -507,28 +515,6 @@ func CreateAccISISDomainPolicyConfigWithOptionalValues() string {
 	}
 	`
 
-	return resource
-}
-
-func CreateAccISISDomainPolicyRemovingRequiredField() string {
-	fmt.Println("=== STEP  Basic: testing isis_domain_policy updation without required parameters")
-	resource := `
-	resource "aci_isis_domain_policy" "test" {
-		description = "created while acceptance testing"
-		annotation = "orchestrator:terraform_testacc"
-		name_alias = "test_isis_domain_policy"
-		mtu = "257"
-		redistrib_metric = "2"
-		lsp_fast_flood = "disabled"
-		lsp_gen_init_intvl = "60"
-		lsp_gen_max_intvl = "60"
-		lsp_gen_sec_intvl = "60"
-		spf_comp_init_intvl = "60"
-		spf_comp_max_intvl = "60"
-		spf_comp_sec_intvl = "60"
-		isis_level_type = "l2"
-	}
-	`
 	return resource
 }
 

--- a/testacc/resource_aci_mgmtconnectivityprefs_test.go
+++ b/testacc/resource_aci_mgmtconnectivityprefs_test.go
@@ -17,7 +17,7 @@ func TestAccAciMgmtconnectivitypreference_Basic(t *testing.T) {
 	var mgmt_preference_updated models.Mgmtconnectivitypreference
 	resourceName := "aci_mgmt_preference.test"
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckAciMgmtconnectivitypreferenceDestroy,
@@ -48,6 +48,14 @@ func TestAccAciMgmtconnectivitypreference_Basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: CreateAccMgmtconnectivitypreferenceUpdatedAttr("interface_pref", "inband"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMgmtconnectivitypreferenceExists(resourceName, &mgmt_preference_updated),
+					resource.TestCheckResourceAttr(resourceName, "interface_pref", "inband"),
+					testAccCheckAciMgmtconnectivitypreferenceIdEqual(&mgmt_preference_default, &mgmt_preference_updated),
+				),
+			},
 		},
 	})
 }
@@ -57,7 +65,7 @@ func TestAccAciMgmtconnectivitypreference_Negative(t *testing.T) {
 	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
 	randomValue := acctest.RandString(5)
 
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 		CheckDestroy:      testAccCheckAciMgmtconnectivitypreferenceDestroy,
@@ -158,16 +166,6 @@ func testAccCheckAciMgmtconnectivitypreferenceIdNotEqual(m1, m2 *models.Mgmtconn
 	}
 }
 
-func CreateAccMgmtconnectivitypreferenceConfigWithRequiredParams() string {
-	fmt.Println("=== STEP  testing mgmt_preference creation with updated naming arguments")
-	resource := fmt.Sprintf(`
-	
-	resource "aci_mgmt_preference" "test" {
-	
-	}
-	`)
-	return resource
-}
 func CreateAccMgmtconnectivitypreferenceConfig() string {
 	fmt.Println("=== STEP  testing mgmt_preference creation with required arguments only")
 	resource := fmt.Sprintf(`

--- a/testacc/resource_aci_mgmtinbzone_test.go
+++ b/testacc/resource_aci_mgmtinbzone_test.go
@@ -74,6 +74,14 @@ func TestAccAciMgmtZone_Basic(t *testing.T) {
 				ExpectError: regexp.MustCompile(`Missing required argument`),
 			},
 			{
+				Config:      CreateAccMgmtZoneConfigWithRequiredParams(rNameUpdated, zoneType, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			{
+				Config:      CreateAccMgmtZoneConfigWithRequiredParams(rNameUpdated, acctest.RandString(5), acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`expected(.)*to be one of(.)*, got(.)*`),
+			},
+			{
 				Config: CreateAccMgmtZoneConfigWithRequiredParams(rNameUpdated, zoneType, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciMgmtZoneExists(resourceName, &mgmt_zone_updated),
@@ -296,7 +304,7 @@ func CreateMgmtZoneWithoutRequired(mgmtGrpName, zoneType, rName, attrName string
 }
 
 func CreateAccMgmtZoneConfigWithRequiredParams(mgmtGrpName, zoneType, rName string) string {
-	fmt.Println("=== STEP  testing mgmt_zone creation with updated naming arguments")
+	fmt.Printf("=== STEP  testing mgmt_zone creation with parent resource name %s, zone type %s and resource name %s\n", mgmtGrpName, zoneType, rName)
 	resource := fmt.Sprintf(`
 	
 	resource "aci_managed_node_connectivity_group" "test" {

--- a/testacc/resource_aci_rtctrlsubjp_test.go
+++ b/testacc/resource_aci_rtctrlsubjp_test.go
@@ -40,6 +40,8 @@ func TestAccAciMatchRule_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", fvTenantName)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
 				),
 			},
 			{
@@ -49,7 +51,8 @@ func TestAccAciMatchRule_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", fvTenantName)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
-
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_match_rule"),
 					testAccCheckAciMatchRuleIdEqual(&match_rule_default, &match_rule_updated),
 				),
 			},
@@ -116,7 +119,14 @@ func TestAccAciMatchRule_Negative(t *testing.T) {
 				Config:      CreateAccMatchRuleUpdatedAttr(fvTenantName, rName, "annotation", acctest.RandString(129)),
 				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
 			},
-
+			{
+				Config:      CreateAccMatchRuleUpdatedAttr(fvTenantName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccMatchRuleUpdatedAttr(fvTenantName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
 			{
 				Config:      CreateAccMatchRuleUpdatedAttr(fvTenantName, rName, randomParameter, randomValue),
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
@@ -335,7 +345,8 @@ func CreateAccMatchRuleConfigWithOptionalValues(fvTenantName, rName string) stri
 		tenant_dn  = "${aci_tenant.test.id}"
 		name  = "%s"
 		annotation = "orchestrator:terraform_testacc"
-		
+		description = "created while acceptance testing"
+		name_alias = "test_match_rule"
 	}
 	`, fvTenantName, rName)
 

--- a/testacc/resource_aci_snmpcommunityp_test.go
+++ b/testacc/resource_aci_snmpcommunityp_test.go
@@ -73,10 +73,10 @@ func TestAccAciVRFSnmpContextCommunity_Basic(t *testing.T) {
 				ExpectError: regexp.MustCompile(`Missing required argument`),
 			},
 			{
-				Config: CreateAccVRFSnmpContextCommunityConfigWithRequiredParams(rName, rNameUpdated, rName),
+				Config: CreateAccVRFSnmpContextCommunityConfigWithRequiredParams(rNameUpdated, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciVRFSnmpContextCommunityExists(resourceName, &vrf_snmp_context_community_updated),
-					resource.TestCheckResourceAttr(resourceName, "vrf_snmp_context_dn", fmt.Sprintf("uni/tn-%s/ctx-%s/snmpctx", rName, rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "vrf_snmp_context_dn", fmt.Sprintf("uni/tn-%s/ctx-%s/snmpctx", rNameUpdated, rNameUpdated)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					testAccCheckAciVRFSnmpContextCommunityIdNotEqual(&vrf_snmp_context_community_default, &vrf_snmp_context_community_updated),
 				),
@@ -85,7 +85,7 @@ func TestAccAciVRFSnmpContextCommunity_Basic(t *testing.T) {
 				Config: CreateAccVRFSnmpContextCommunityConfig(fvTenantName, fvCtxName, rName),
 			},
 			{
-				Config: CreateAccVRFSnmpContextCommunityConfigWithRequiredParams(rName, rName, rNameUpdated),
+				Config: CreateAccVRFSnmpContextCommunityConfigWithRequiredParams(rName, rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciVRFSnmpContextCommunityExists(resourceName, &vrf_snmp_context_community_updated),
 					resource.TestCheckResourceAttr(resourceName, "vrf_snmp_context_dn", fmt.Sprintf("uni/tn-%s/ctx-%s/snmpctx", rName, rName)),
@@ -260,8 +260,8 @@ func CreateVRFSnmpContextCommunityWithoutRequired(fvTenantName, fvCtxName, rName
 	return fmt.Sprintf(rBlock, fvTenantName, fvCtxName, rName)
 }
 
-func CreateAccVRFSnmpContextCommunityConfigWithRequiredParams(fvTenantName, fvCtxName, rName string) string {
-	fmt.Println("=== STEP  testing vrf_snmp_context_community creation with updated naming arguments")
+func CreateAccVRFSnmpContextCommunityConfigWithRequiredParams(prName, rName string) string {
+	fmt.Printf("=== STEP  testing vrf_snmp_context_community creation with parent resource name %s and resource name %s\n", prName, rName)
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tenant" "test" {
@@ -276,14 +276,14 @@ func CreateAccVRFSnmpContextCommunityConfigWithRequiredParams(fvTenantName, fvCt
 
 	resource "aci_vrf_snmp_context" "test" {
 		vrf_dn = aci_vrf.test.id
-		name = "example"
+		name = "%s"
 	}
 	
 	resource "aci_vrf_snmp_context_community" "test" {
 		vrf_snmp_context_dn  = aci_vrf_snmp_context.test.id
 		name  = "%s"
 	}
-	`, fvTenantName, fvCtxName, rName)
+	`, prName, prName, prName, rName)
 	return resource
 }
 func CreateAccVRFSnmpContextCommunityConfigUpdatedName(fvTenantName, fvCtxName, rName string) string {

--- a/testacc/resource_aci_tagannotation_test.go
+++ b/testacc/resource_aci_tagannotation_test.go
@@ -287,29 +287,6 @@ func CreateAccAnnotationWithInValidParentDn(rName, key, value string) string {
 	return resource
 }
 
-func CreateAccAnnotationConfigWithOptionalValues(fvTenantName, key, value string) string {
-	fmt.Println("=== STEP  Basic: testing annotation creation with optional parameters")
-	resource := fmt.Sprintf(`
-	
-	resource "aci_tenant" "test" {
-		name 		= "%s"
-	
-	}
-	
-	resource "aci_annotation" "test" {
-		parent_dn  = "${aci_tenant.test.id}"
-		key  = "%s"
-		value = "%s"
-		description = "created while acceptance testing"
-		annotation = "orchestrator:terraform_testacc"
-		name_alias = "test_annotation"
-		
-	}
-	`, fvTenantName, key, value)
-
-	return resource
-}
-
 func CreateAccAnnotationRemovingRequiredField() string {
 	fmt.Println("=== STEP  Basic: testing annotation updation without required parameters")
 	resource := fmt.Sprintf(`
@@ -321,25 +298,6 @@ func CreateAccAnnotationRemovingRequiredField() string {
 	}
 	`)
 
-	return resource
-}
-
-func CreateAccAnnotationUpdatedAttr(fvTenantName, key, value, attribute, val string) string {
-	fmt.Printf("=== STEP  testing annotation attribute: %s = %s \n", attribute, value)
-	resource := fmt.Sprintf(`
-	
-	resource "aci_tenant" "test" {
-		name 		= "%s"
-	
-	}
-	
-	resource "aci_annotation" "test" {
-		parent_dn  = aci_tenant.test.id
-		key  = "%s"
-		value = "%s"
-		%s = "%s"
-	}
-	`, fvTenantName, key, value, attribute, val)
 	return resource
 }
 

--- a/testacc/resource_aci_tagtag_test.go
+++ b/testacc/resource_aci_tagtag_test.go
@@ -287,29 +287,6 @@ func CreateAccTagWithInValidParentDn(rName, key, value string) string {
 	return resource
 }
 
-func CreateAccTagConfigWithOptionalValues(fvTenantName, key, value string) string {
-	fmt.Println("=== STEP  Basic: testing tag creation with optional parameters")
-	resource := fmt.Sprintf(`
-	
-	resource "aci_tenant" "test" {
-		name 		= "%s"
-	
-	}
-	
-	resource "aci_tag" "test" {
-		parent_dn  = "${aci_tenant.test.id}"
-		key  = "%s"
-		value = "%s"
-		description = "created while acceptance testing"
-		annotation = "orchestrator:terraform_testacc"
-		name_alias = "test_tag"
-		
-	}
-	`, fvTenantName, key, value)
-
-	return resource
-}
-
 func CreateAccTagRemovingRequiredField() string {
 	fmt.Println("=== STEP  Basic: testing tag updation without required parameters")
 	resource := fmt.Sprintf(`
@@ -323,23 +300,3 @@ func CreateAccTagRemovingRequiredField() string {
 
 	return resource
 }
-
-func CreateAccTagUpdatedAttr(fvTenantName, key, value, attribute, val string) string {
-	fmt.Printf("=== STEP  testing tag attribute: %s = %s \n", attribute, value)
-	resource := fmt.Sprintf(`
-	
-	resource "aci_tenant" "test" {
-		name 		= "%s"
-	
-	}
-	
-	resource "aci_tag" "test" {
-		parent_dn  = aci_tenant.test.id
-		key  = "%s"
-		value = "%s"
-		%s = "%s"
-	}
-	`, fvTenantName, key, value, attribute, val)
-	return resource
-}
-

--- a/testacc/resource_aci_trigrecurrwindowp_test.go
+++ b/testacc/resource_aci_trigrecurrwindowp_test.go
@@ -392,6 +392,11 @@ func TestAccAciRecurringWindow_Negative(t *testing.T) {
 			},
 
 			{
+				Config:      CreateAccRecurringWindowUpdatedAttr(trigSchedPName, rName, "time_cap", "01:23:59:59.000"),
+				ExpectError: regexp.MustCompile(`Max Duration cannot exceed 24 hours`),
+			},
+
+			{
 				Config:      CreateAccRecurringWindowUpdatedAttr(trigSchedPName, rName, randomParameter, randomValue),
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
 			},

--- a/website/docs/d/match_rule.html.markdown
+++ b/website/docs/d/match_rule.html.markdown
@@ -41,3 +41,4 @@ data "aci_match_rule" "example" {
 * `id` - Attribute id set to the Dn of the Match Rule.
 * `annotation` - (Optional) Annotation of object Match Rule.
 * `name_alias` - (Optional) Name Alias of object Match Rule.
+* `description` - (Optional) Description of object Match Rule.

--- a/website/docs/d/route_control_context.html.markdown
+++ b/website/docs/d/route_control_context.html.markdown
@@ -40,6 +40,7 @@ data "aci_route_control_context" "control" {
 ## Attribute Reference ##
 * `id` - Attribute id set to the Dn of the Route Control Context.
 * `annotation` - (Optional) Annotation of object Route Control Context.
+* `description` - (Optional) Description of object Route Control Context.
 * `name_alias` - (Optional) Name Alias of object Route Control Context.
 * `action` - (Optional) Action. The action required when the condition is met.
 * `order` - (Optional) Local Order. The order of the policy context.

--- a/website/docs/r/match_rule.html.markdown
+++ b/website/docs/r/match_rule.html.markdown
@@ -36,6 +36,8 @@ resource "aci_match_rule" "rule" {
 * `tenant_dn` - (Required) Distinguished name of parent Tenant object.
 * `name` - (Required) Name of object Match Rule.
 * `annotation` - (Optional) Annotation of object Match Rule.
+* `name_alias` - (Optional) Name Alias of object Match Rule.
+* `description` - (Optional) Description of object Match Rule.
 
 
 

--- a/website/docs/r/recurring_window.html.markdown
+++ b/website/docs/r/recurring_window.html.markdown
@@ -44,6 +44,7 @@ resource "aci_recurring_window" "example" {
 * `scheduler_dn` - (Required) Distinguished name of parent Scheduler object.
 * `name` - (Required) Name of object Recurring Window.
 * `annotation` - (Optional) Annotation of object Recurring Window.
+* `name_alias` - (Optional) Name Alias of object Recurring Window.
 * `concur_cap` - (Optional) Maximum Concurrent Tasks. The concurrency capacity limit. This is the maximum number of tasks that can be processed concurrently. Range: "1" - "65535". Default value is "unlimited"(If user sets "0" as a value, provider will accept it but it'll set it as "unlimited"). Type: String.
 * `day` - (Optional) Recurring Window Schedule Day. The day of the week that the recurring window begins. Allowed values are "Friday", "Monday", "Saturday", "Sunday", "Thursday", "Tuesday", "Wednesday", "even-day", "every-day", "odd-day", and default value is "every-day". Type: String.
 * `hour` - (Optional) Schedule Hour. The hour that the recurring window begins. Range: "0" - "23". Default value is "0". 

--- a/website/docs/r/route_control_context.html.markdown
+++ b/website/docs/r/route_control_context.html.markdown
@@ -39,6 +39,8 @@ resource "aci_route_control_context" "control" {
 * `route_control_profile_dn` - (Required) Distinguished name of parent Route Control Profile object.
 * `name` - (Required) Name of object Route Control Context.
 * `annotation` - (Optional) Annotation of object Route Control Context.
+* `description` - (Optional) Description of object Route Control Context.
+* `name_alias` - (Optional) Name Alias of object Route Control Context.
 * `action` - (Optional) Action. The action required when the condition is met. Allowed values are "deny", "permit", and default value is "permit". Type: String.
 * `order` - (Optional) Local Order.The order of the policy context. Allowed range is 0-9 and default value is "0".
 * `set_rule` - (Optional) Represents the relation to an Attribute Profile (class rtctrlAttrP). Type: String.


### PR DESCRIPTION
$ go test -v -run TestAccAciRecurringWindow -timeout=60m
=== RUN   TestAccAciRecurringWindowDataSource_Basic
=== STEP  Basic: testing recurring_window Data Source without  scheduler_dn
=== STEP  Basic: testing recurring_window Data Source without  name
=== STEP  testing recurring_window Data Source with required arguments only
=== STEP  testing recurring_window Data Source with random attribute
=== STEP  testing recurring_window Data Source with Invalid Parent Dn
=== STEP  testing recurring_window Data Source with updated resource
=== PAUSE TestAccAciRecurringWindowDataSource_Basic
=== RUN   TestAccAciRecurringWindow_Basic
=== STEP  Basic: testing recurring_window creation without  scheduler_dn
=== STEP  Basic: testing recurring_window creation without  name
=== STEP  testing recurring_window creation with required arguments only
=== STEP  Basic: testing recurring_window creation with optional parameters
=== STEP  testing recurring_window creation with invalid name =  pjn27ed8g92aogo72g9dvm761732qd7zg7icxqntzqxod4uz3h4r04fte9719zg39
=== STEP  Basic: testing recurring_window updation without required parameters
=== STEP  testing recurring_window creation with parent resource name acctest_egjqg and resource name acctest_rrpg3
=== STEP  testing recurring_window creation with required arguments only
=== STEP  testing recurring_window creation with parent resource name acctest_rrpg3 and resource name acctest_egjqg
=== PAUSE TestAccAciRecurringWindow_Basic
=== RUN   TestAccAciRecurringWindow_Update
=== STEP  testing recurring_window creation with required arguments only
=== STEP  testing recurring_window attribute: concur_cap = 65535
=== STEP  testing recurring_window attribute: concur_cap = 32767
=== STEP  testing recurring_window attribute: day = Monday
=== STEP  testing recurring_window attribute: day = Saturday
=== STEP  testing recurring_window attribute: day = Sunday
=== STEP  testing recurring_window attribute: day = Thursday
=== STEP  testing recurring_window attribute: day = Tuesday
=== STEP  testing recurring_window attribute: day = Wednesday
=== STEP  testing recurring_window attribute: day = even-day
=== STEP  testing recurring_window attribute: day = odd-day
=== STEP  testing recurring_window attribute: hour = 23
=== STEP  testing recurring_window attribute: hour = 11
=== STEP  testing recurring_window attribute: minute = 59
=== STEP  testing recurring_window attribute: minute = 29
=== STEP  testing recurring_window attribute: node_upg_interval = 18000
=== STEP  testing recurring_window attribute: node_upg_interval = 9000
=== STEP  testing recurring_window attribute: proc_cap = 65535
=== STEP  testing recurring_window attribute: proc_cap = 32767
=== STEP  testing recurring_window creation with required arguments only
=== PAUSE TestAccAciRecurringWindow_Update
=== RUN   TestAccAciRecurringWindow_Negative
=== STEP  testing recurring_window creation with required arguments only
=== STEP  Negative Case: testing recurring_window creation with invalid parent Dn
=== STEP  testing recurring_window attribute: annotation = ijd6ow8jltgcx1zwy1qvcr2rv4virwm0ya13ahi8do9kkmov83wi1u1djsgeg4zmpglsu7ords9eexp17wln11mfxlapphshyr00gjpwys711x36x3m0qfkov4u0wvawm
=== STEP  testing recurring_window attribute: name_alias = thyes74bi6qqh6v2rwmi7eiyfi1pff7ocy86juruvi8wnvkvoe0bnaw7ucg7jvz3
=== STEP  testing recurring_window attribute: concur_cap = 1avzf
=== STEP  testing recurring_window attribute: concur_cap = -1
=== STEP  testing recurring_window attribute: concur_cap = 65536
=== STEP  testing recurring_window attribute: day = 1avzf
=== STEP  testing recurring_window attribute: hour = 1avzf
=== STEP  testing recurring_window attribute: hour = -1
=== STEP  testing recurring_window attribute: hour = 24
=== STEP  testing recurring_window attribute: minute = 1avzf
=== STEP  testing recurring_window attribute: minute = -1
=== STEP  testing recurring_window attribute: minute = 60
=== STEP  testing recurring_window attribute: node_upg_interval = 1avzf
=== STEP  testing recurring_window attribute: node_upg_interval = -1
=== STEP  testing recurring_window attribute: node_upg_interval = 18001
=== STEP  testing recurring_window attribute: proc_break = 1avzf
=== STEP  testing recurring_window attribute: proc_cap = 1avzf
=== STEP  testing recurring_window attribute: proc_cap = -1
=== STEP  testing recurring_window attribute: proc_cap = 65536
=== STEP  testing recurring_window attribute: time_cap = 1avzf
=== STEP  testing recurring_window attribute: time_cap = 01:23:59:59.000
=== STEP  testing recurring_window attribute: clwgi = 1avzf
=== STEP  testing recurring_window creation with required arguments only
=== PAUSE TestAccAciRecurringWindow_Negative
=== RUN   TestAccAciRecurringWindow_MultipleCreateDelete
=== STEP  testing multiple recurring_window creation with required arguments only
=== PAUSE TestAccAciRecurringWindow_MultipleCreateDelete
=== CONT  TestAccAciRecurringWindowDataSource_Basic
=== CONT  TestAccAciRecurringWindow_Negative
=== CONT  TestAccAciRecurringWindow_Update
=== CONT  TestAccAciRecurringWindow_Basic
=== CONT  TestAccAciRecurringWindow_MultipleCreateDelete
=== STEP  testing recurring_window destroy
--- PASS: TestAccAciRecurringWindow_MultipleCreateDelete (21.15s)
=== STEP  testing recurring_window destroy
--- PASS: TestAccAciRecurringWindowDataSource_Basic (37.70s)
=== STEP  testing recurring_window destroy
--- PASS: TestAccAciRecurringWindow_Basic (73.40s)
=== STEP  testing recurring_window destroy
--- PASS: TestAccAciRecurringWindow_Negative (126.89s)
=== STEP  testing recurring_window destroy
--- PASS: TestAccAciRecurringWindow_Update (219.34s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   220.728s
