### PR TITLE
Updated Files for vswitch_policy, tacacs_source and epgs_using_function

### DIFF
--- a/testacc/data_source_aci_tacacssrc_test.go
+++ b/testacc/data_source_aci_tacacssrc_test.go
@@ -29,7 +29,7 @@ func TestAccAciTACACSSourceDataSource_Basic(t *testing.T) {
 			{
 				Config: CreateAccTACACSSourceConfigDataSource(rName),
 				Check: resource.ComposeTestCheckFunc(
-
+					resource.TestCheckResourceAttrPair(dataSourceName, "parent_dn", resourceName, "parent_dn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),

--- a/testacc/data_source_aci_vmmvswitchpolicycont_test.go
+++ b/testacc/data_source_aci_vmmvswitchpolicycont_test.go
@@ -57,7 +57,7 @@ func CreateAccVSwitchPolicyConfigDataSource(vmmProvPName, vmmDomPName string) st
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 	
 	resource "aci_vswitch_policy" "test" {
@@ -68,7 +68,7 @@ func CreateAccVSwitchPolicyConfigDataSource(vmmProvPName, vmmDomPName string) st
 		vmm_domain_dn  = aci_vmm_domain.test.id
 		depends_on = [ aci_vswitch_policy.test ]
 	}
-	`, vmmDomPName)
+	`, vmmDomPName, providerProfileDn)
 	return resource
 }
 
@@ -77,7 +77,7 @@ func CreateVSwitchPolicyDSWithoutRequired(vmmProvPName, vmmDomPName, attrName st
 	rBlock := `
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%s"
 	}
 	
 	resource "aci_vswitch_policy" "test" {
@@ -93,7 +93,7 @@ func CreateVSwitchPolicyDSWithoutRequired(vmmProvPName, vmmDomPName, attrName st
 	}
 		`
 	}
-	return fmt.Sprintf(rBlock, vmmDomPName)
+	return fmt.Sprintf(rBlock, vmmDomPName, providerProfileDn)
 }
 
 func CreateAccVSwitchPolicyDSWithInvalidParentDn(vmmProvPName, vmmDomPName string) string {
@@ -102,7 +102,7 @@ func CreateAccVSwitchPolicyDSWithInvalidParentDn(vmmProvPName, vmmDomPName strin
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 	resource "aci_vswitch_policy" "test" {
 		vmm_domain_dn  = aci_vmm_domain.test.id
@@ -112,7 +112,7 @@ func CreateAccVSwitchPolicyDSWithInvalidParentDn(vmmProvPName, vmmDomPName strin
 		vmm_domain_dn  = "${aci_vmm_domain.test.id}_invalid"
 		depends_on = [ aci_vswitch_policy.test ]
 	}
-	`, vmmDomPName)
+	`, vmmDomPName, providerProfileDn)
 	return resource
 }
 
@@ -122,7 +122,7 @@ func CreateAccVSwitchPolicyDataSourceUpdate(vmmProvPName, vmmDomPName, key, valu
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 	resource "aci_vswitch_policy" "test" {
 		vmm_domain_dn  = aci_vmm_domain.test.id
@@ -133,7 +133,7 @@ func CreateAccVSwitchPolicyDataSourceUpdate(vmmProvPName, vmmDomPName, key, valu
 		%s = "%s"
 		depends_on = [ aci_vswitch_policy.test ]
 	}
-	`, vmmDomPName, key, value)
+	`, vmmDomPName, providerProfileDn, key, value)
 	return resource
 }
 
@@ -143,7 +143,7 @@ func CreateAccVSwitchPolicyDataSourceUpdatedResource(vmmProvPName, vmmDomPName, 
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 
 	resource "aci_vswitch_policy" "test" {
@@ -155,6 +155,6 @@ func CreateAccVSwitchPolicyDataSourceUpdatedResource(vmmProvPName, vmmDomPName, 
 		vmm_domain_dn  = aci_vmm_domain.test.id
 		depends_on = [ aci_vswitch_policy.test ]
 	}
-	`, vmmDomPName, key, value)
+	`, vmmDomPName, providerProfileDn, key, value)
 	return resource
 }

--- a/testacc/resource_aci_infrarsfunctoepg_test.go
+++ b/testacc/resource_aci_infrarsfunctoepg_test.go
@@ -171,7 +171,7 @@ func TestAccAciEPGsUsingFunction_Negative(t *testing.T) {
 				ExpectError: regexp.MustCompile(`unknown property value`),
 			},
 			{
-				Config:      CreateAccEPGsUsingFunctionUpdatedAttr(infraAttEntityPName, tDn, "name_alias", acctest.RandString(64)),
+				Config:      CreateAccEPGsUsingFunctionUpdatedAttr(infraAttEntityPName, tDn, "annotation", acctest.RandString(129)),
 				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
 			},
 			{

--- a/testacc/resource_aci_tacacssrc_test.go
+++ b/testacc/resource_aci_tacacssrc_test.go
@@ -33,7 +33,6 @@ func TestAccAciTACACSSource_Basic(t *testing.T) {
 				Config: CreateAccTACACSSourceConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciTACACSSourceExists(resourceName, &tacacs_source_default),
-
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "parent_dn", "uni/fabric/moncommon"),
 					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
@@ -49,16 +48,14 @@ func TestAccAciTACACSSource_Basic(t *testing.T) {
 				Config: CreateAccTACACSSourceConfigWithOptionalValues(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciTACACSSourceExists(resourceName, &tacacs_source_updated),
-
+					resource.TestCheckResourceAttr(resourceName, "parent_dn", "uni/fabric/moncommon"),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
 					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
 					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_tacacs_source"),
 					resource.TestCheckResourceAttr(resourceName, "incl.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "incl.0", "audit"),
-
 					resource.TestCheckResourceAttr(resourceName, "min_sev", "cleared"),
-
 					testAccCheckAciTACACSSourceIdEqual(&tacacs_source_default, &tacacs_source_updated),
 				),
 			},

--- a/testacc/resource_aci_vmmvswitchpolicycont_test.go
+++ b/testacc/resource_aci_vmmvswitchpolicycont_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+var providerProfileDn string = "uni/vmmp-VMware"
+
 func TestAccAciVSwitchPolicy_Basic(t *testing.T) {
 	var vswitch_policy_default models.VSwitchPolicyGroup
 	var vswitch_policy_updated models.VSwitchPolicyGroup
@@ -31,7 +33,7 @@ func TestAccAciVSwitchPolicy_Basic(t *testing.T) {
 				Config: CreateAccVSwitchPolicyConfig(vmmDomPName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciVSwitchPolicyExists(resourceName, &vswitch_policy_default),
-					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("uni/vmmp-VMware/dom-%s", vmmDomPName)),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("%v/dom-%s", providerProfileDn, vmmDomPName)),
 					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
@@ -41,7 +43,7 @@ func TestAccAciVSwitchPolicy_Basic(t *testing.T) {
 				Config: CreateAccVSwitchPolicyConfigWithOptionalValues(vmmDomPName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciVSwitchPolicyExists(resourceName, &vswitch_policy_updated),
-					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("uni/vmmp-VMware/dom-%s", vmmDomPName)), resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("%v/dom-%s", providerProfileDn, vmmDomPName)), resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
 					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
 					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
 					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_vswitch_policy"),
@@ -61,7 +63,7 @@ func TestAccAciVSwitchPolicy_Basic(t *testing.T) {
 				Config: CreateAccVSwitchPolicyConfigWithRequiredParams(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciVSwitchPolicyExists(resourceName, &vswitch_policy_updated),
-					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("uni/vmmp-VMware/dom-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("%v/dom-%s", providerProfileDn, rNameUpdated)),
 					testAccCheckAciVSwitchPolicyIdNotEqual(&vswitch_policy_default, &vswitch_policy_updated),
 				),
 			},
@@ -182,7 +184,7 @@ func CreateVSwitchPolicyWithoutRequired(vmmDomPName, attrName string) string {
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 	
 	`
@@ -195,7 +197,7 @@ func CreateVSwitchPolicyWithoutRequired(vmmDomPName, attrName string) string {
 		`
 
 	}
-	return fmt.Sprintf(rBlock, vmmDomPName)
+	return fmt.Sprintf(rBlock, vmmDomPName, providerProfileDn)
 }
 
 func CreateAccVSwitchPolicyConfigWithRequiredParams(vmmDomPName string) string {
@@ -204,13 +206,13 @@ func CreateAccVSwitchPolicyConfigWithRequiredParams(vmmDomPName string) string {
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 	
 	resource "aci_vswitch_policy" "test" {
 		vmm_domain_dn  = aci_vmm_domain.test.id
 	}
-	`, vmmDomPName)
+	`, vmmDomPName, providerProfileDn)
 	return resource
 }
 
@@ -220,12 +222,12 @@ func CreateAccVSwitchPolicyConfig(vmmDomPName string) string {
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 	resource "aci_vswitch_policy" "test" {
 		vmm_domain_dn  = aci_vmm_domain.test.id
 	}
-	`, vmmDomPName)
+	`, vmmDomPName, providerProfileDn)
 	return resource
 }
 
@@ -247,7 +249,7 @@ func CreateAccVSwitchPolicyConfigWithOptionalValues(vmmDomPName string) string {
 	resource := fmt.Sprintf(`
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 	
 	resource "aci_vswitch_policy" "test" {
@@ -257,7 +259,7 @@ func CreateAccVSwitchPolicyConfigWithOptionalValues(vmmDomPName string) string {
 		name_alias = "test_vswitch_policy"
 		
 	}
-	`, vmmDomPName)
+	`, vmmDomPName, providerProfileDn)
 
 	return resource
 }
@@ -281,13 +283,13 @@ func CreateAccVSwitchPolicyUpdatedAttr(vmmDomPName, attribute, value string) str
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 	
 	resource "aci_vswitch_policy" "test" {
 		vmm_domain_dn  = aci_vmm_domain.test.id
 		%s = "%s"
 	}
-	`, vmmDomPName, attribute, value)
+	`, vmmDomPName, providerProfileDn, attribute, value)
 	return resource
 }

--- a/website/docs/r/epgs_using_function.html.markdown
+++ b/website/docs/r/epgs_using_function.html.markdown
@@ -35,7 +35,7 @@ resource "aci_epgs_using_function" "example" {
 Allowed values: "immediate", "lazy". Default value: "lazy".
 * `mode` - (Optional) Bgp domain mode.
 Allowed values: "regular", "native", "untagged". Default value: "regular"
-* `primary_encap` - (Optional) Primary encap for object EPGs Using Function.
+* `primary_encap` - (Optional) Primary encap for object EPGs Using Function. Default value is "unknown".
 
 ## Attribute Reference
 


### PR DESCRIPTION
$ go test -v -run TestAccAciTACACSSource_Basic -timeout=60m
=== RUN   TestAccAciTACACSSource_Basic
=== STEP  Basic: testing tacacs_source creation without  name
=== STEP  testing tacacs_source creation with required arguments only
=== STEP  Basic: testing tacacs_source creation with optional parameters
=== STEP  testing tacacs_source creation with invalid name =  govm7310r1n7manrbmkikwhxjad66wkjof8wk4jla3we3fekpxvt06wjtcmf2ykvw
=== STEP  Basic: testing tacacs_source updation without required parameters
=== STEP  testing tacacs_source creation with updated naming arguments
=== PAUSE TestAccAciTACACSSource_Basic
=== CONT  TestAccAciTACACSSource_Basic
=== STEP  testing tacacs_source destroy
--- PASS: TestAccAciTACACSSource_Basic (139.33s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   142.101s

$ go test -v -run TestAccAciTACACSSourceDataSource_Basic -timeout=60m
=== RUN   TestAccAciTACACSSourceDataSource_Basic
=== STEP  Basic: testing tacacs_source Data Source without  name
=== STEP  testing tacacs_source Data Source with required arguments only
=== STEP  testing tacacs_source Data Source with random attribute
=== STEP  testing tacacs_source Data Source with required arguments only
=== STEP  testing tacacs_source Data Source with updated resource
=== PAUSE TestAccAciTACACSSourceDataSource_Basic
=== CONT  TestAccAciTACACSSourceDataSource_Basic
=== STEP  testing tacacs_source destroy
--- PASS: TestAccAciTACACSSourceDataSource_Basic (121.07s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   123.082s

$ go test -v -run TestAccAciVSwitchPolicy_Basic -timeout=60m
=== RUN   TestAccAciVSwitchPolicy_Basic
=== STEP  Basic: testing vswitch_policy creation without  vmm_domain_dn
=== STEP  testing vswitch_policy creation with required arguments only
=== STEP  Basic: testing vswitch_policy creation with optional parameters
=== STEP  Basic: testing vswitch_policy updation without required parameters
=== STEP  testing vswitch_policy creation with Updated required arguments only
=== STEP  testing vswitch_policy creation with required arguments only
=== PAUSE TestAccAciVSwitchPolicy_Basic
=== CONT  TestAccAciVSwitchPolicy_Basic
=== STEP  testing vswitch_policy destroy
--- PASS: TestAccAciVSwitchPolicy_Basic (181.02s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   182.449s

$ go test -v -run TestAccAciVSwitchPolicy_Negative -timeout=60m
=== RUN   TestAccAciVSwitchPolicy_Negative
=== STEP  testing vswitch_policy creation with required arguments only
=== STEP  Negative Case: testing vswitch_policy creation with invalid parent Dn
=== STEP  testing vswitch_policy attribute: description = 1kruhjq6ivmvybq0mlpj8wmg8tegozqmbpigvlxmclvnnd2xhkiu2ft0qhi2oszz0jy96cxp612po19k9zly2zld00nwnsplf8kb7uh4dvimgxax2egwb3cr2wc3d19gt
=== STEP  testing vswitch_policy attribute: annotation = 2tjm9s3x2zib880lthe069bofj1to8lxztvlo1839h08a204b4a9ks1jw3xqmt60tgn9jyjjiwybutve3q3laxurwt348qt3sqxd3digl2aswsi3q74lgx64vzqprnjgl
=== STEP  testing vswitch_policy attribute: name_alias = plxd1by99jpfweugo2iuklb2lapbd3u4rg06slcuy2q33dnmsee4a63odwgvxw8f
=== STEP  testing vswitch_policy attribute: mzyri = ik2eu
=== STEP  testing vswitch_policy creation with required arguments only
=== PAUSE TestAccAciVSwitchPolicy_Negative
=== CONT  TestAccAciVSwitchPolicy_Negative
=== STEP  testing vswitch_policy destroy
--- PASS: TestAccAciVSwitchPolicy_Negative (227.58s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   229.599s

$ go test -v -run TestAccAciVSwitchPolicyDataSource_Basic -timeout=60m
=== RUN   TestAccAciVSwitchPolicyDataSource_Basic
=== STEP  Basic: testing vswitch_policy Data Source without  vmm_domain_dn
=== STEP  testing vswitch_policy Data Source with required arguments only
=== STEP  testing vswitch_policy Data Source with random attribute
=== STEP  testing vswitch_policy Data Source with Invalid Parent Dn
=== STEP  testing vswitch_policy Data Source with updated resource
=== PAUSE TestAccAciVSwitchPolicyDataSource_Basic
=== CONT  TestAccAciVSwitchPolicyDataSource_Basic
=== STEP  testing vswitch_policy destroy
--- PASS: TestAccAciVSwitchPolicyDataSource_Basic (114.99s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   118.387s

$ go test -v -run TestAccAciEPGsUsingFunction_Negative -timeout=60m
=== RUN   TestAccAciEPGsUsingFunction_Negative
=== STEP  testing epgs_using_function creation with required arguments only
=== STEP  Negative Case: testing epgs_using_function creation with invalid parent Dn
=== STEP  Negative Case: testing epgs_using_function creation with invalid TDn
=== STEP  Negative Case: testing epgs_using_function creation with invalid encap
=== STEP  testing epgs_using_function attribute: annotation = k309odsjuitc3mwyt6mgtir8rcttdabg6dzkj1cxby7ifuofog0z6mosc9g7luj8nklfdxfz2vd8qcd6tb3wiqmt0kfd92k1gvktvrdo31sm2lbuiudqmdruw2ya2zsk4
=== STEP  testing epgs_using_function attribute: instr_imedcy = 1bazx
=== STEP  testing epgs_using_function attribute: mode = 1bazx
=== STEP  testing epgs_using_function attribute: primary_encap = 1bazx
=== STEP  testing epgs_using_function attribute: mslyg = 1bazx
=== STEP  testing epgs_using_function creation with required arguments only
=== PAUSE TestAccAciEPGsUsingFunction_Negative
=== CONT  TestAccAciEPGsUsingFunction_Negative
=== STEP  testing epgs_using_function destroy
--- PASS: TestAccAciEPGsUsingFunction_Negative (218.50s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   220.088s
