### PR TITLE
updated test files

### DIFF
--- a/testacc/data_source_aci_fvepretpol_test.go
+++ b/testacc/data_source_aci_fvepretpol_test.go
@@ -90,7 +90,7 @@ func CreateAccEndPointRetentionPolicyConfigDataSource(fvTenantName, rName string
 }
 
 func CreateEndPointRetentionPolicyDSWithoutRequired(fvTenantName, rName, attrName string) string {
-	fmt.Println("=== STEP  Basic: testing end_point_retention_policy creation without ", attrName)
+	fmt.Println("=== STEP  Basic: testing end_point_retention_policy Data Source without ", attrName)
 	rBlock := `
 	
 	resource "aci_tenant" "test" {

--- a/testacc/resource_aci_fileremotepath_test.go
+++ b/testacc/resource_aci_fileremotepath_test.go
@@ -118,9 +118,12 @@ func TestAccAciRemotePathofaFile_Negative(t *testing.T) {
 		CheckDestroy:      testAccCheckAciRemotePathofaFileDestroy,
 		Steps: []resource.TestStep{
 			{
+				Config:      CreateAccRemotePathofaFileWhenUserPasswordIsnotGiven(rName, host),
+				ExpectError: regexp.MustCompile(`user_passwd must be set when auth_type is usePassword`),
+			},
+			{
 				Config: CreateAccRemotePathofaFileConfig(rName, host),
 			},
-
 			{
 				Config:      CreateAccRemotePathofaFileUpdatedAttr(rName, host, "description", acctest.RandString(129)),
 				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
@@ -373,6 +376,18 @@ func CreateAccRemotePathofaFileRemovingRequiredField() string {
 	return resource
 }
 
+func CreateAccRemotePathofaFileWhenUserPasswordIsnotGiven(rName, host string) string {
+	fmt.Println("=== STEP  testing file_remote_path when auth_type is usePassword and user_passwd is not given")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_file_remote_path" "test" {
+		name  = "%s"
+		host = "%s"
+	}
+	`, rName, host)
+	return resource
+}
+
 func CreateAccRemotePathofaFileUpdatedAttr(rName, host, attribute, value string) string {
 	fmt.Printf("=== STEP  testing file_remote_path attribute: %s = %s \n", attribute, value)
 	resource := fmt.Sprintf(`
@@ -401,4 +416,3 @@ func CreateAccRemotePathofaFileUpdatedPasswd(rName, host, attribute, value strin
 	`, rName, host, attribute, value)
 	return resource
 }
-

--- a/testacc/resource_aci_mgmtinbzone_test.go
+++ b/testacc/resource_aci_mgmtinbzone_test.go
@@ -78,7 +78,7 @@ func TestAccAciMgmtZone_Basic(t *testing.T) {
 				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
 			},
 			{
-				Config:      CreateAccMgmtZoneConfigWithRequiredParams(rNameUpdated, acctest.RandString(5), acctest.RandString(65)),
+				Config:      CreateAccMgmtZoneConfigWithRequiredParams(rNameUpdated, acctest.RandString(5), rName),
 				ExpectError: regexp.MustCompile(`expected(.)*to be one of(.)*, got(.)*`),
 			},
 			{

--- a/website/docs/d/fex_profile.html.markdown
+++ b/website/docs/d/fex_profile.html.markdown
@@ -29,5 +29,5 @@ data "aci_fex_profile" "example" {
 
 - `id` - Attribute id set to the Dn of the FEX Profile.
 - `annotation` - (Optional) Specifies the annotation of the policy definition.
-- `name_alias` - (Optional) Specifies the description of the policy definition.
+- `description` - (Optional) Specifies the description of the policy definition.
 - `name_alias` - (Optional) Specifies the alias name of the policy definition.

--- a/website/docs/r/file_remote_path.html.markdown
+++ b/website/docs/r/file_remote_path.html.markdown
@@ -39,6 +39,7 @@ resource "aci_file_remote_path" "example" {
 * `host` - (Required) Hostname or IP for export destination of object File Remote Path.
 * `annotation` - (Optional) Annotation of object File Remote Path.
 * `auth_type` - (Optional) Authentication Type Choice. Allowed values are "usePassword" and "useSshKeyContents". Default value is "usePassword". Type: String.
+* `name_alias` - (Optional) Name Alias of object File Remote Path.
 * `identity_private_key_contents` - (Optional) SSH Private Key File contents for datatransfer. Must be set if `auth_type` is equal to "useSshKeyContents".
 * `identity_private_key_passphrase` - (Optional)  Passphrase given at the identity key creation. Should be set if and only if `identity_private_key_contents` is set.
 * `protocol` - (Optional) Transfer protocol to be used for data export of object File Remote Path .Allowed values are "ftp", "scp" and "sftp". Default value is "sftp". Type: String. Value "ftp" cannot be set if `auth_type` is equal to "useSshKeyContents".


### PR DESCRIPTION
$ go test -v -run TestAccAciRemotePathofaFile_Negative -timeout=60m
=== RUN   TestAccAciRemotePathofaFile_Negative
=== STEP  testing file_remote_path when auth_type is usePassword and user_passwd is not given
=== STEP  testing file_remote_path creation with required arguments only
=== STEP  testing file_remote_path attribute: description = mlqbm4y2gmy2ba2ovv1vku0sx4jqbg8djngsvk9m20n67qlzc4hc9ud4cl94gjrtbgw74q4l0peitrhyzzumobozdoxsx3ydx8bqcyb12yrnl4y1gn0pc2ez2lgzrony0
=== STEP  testing file_remote_path attribute: annotation = jmsmfzfhbxpczqqhfsqzg7b3l1mg4gv2qug94y792h0nmb8ek714w0op8y073iu1lukqooy7dfx48em8wt9vteuqmtfzrag1iqykvcfv69cp7zurjoywzjzpevyask70l
=== STEP  testing file_remote_path attribute: name_alias = xs4q7k0xhbu1jmz6q68c7zbnqu431bdxi681x7eauhxm1iq09x6znbcm0urtctzz
=== STEP  testing file_remote_path attribute: auth_type = 0bx8i
=== STEP  testing file_remote_path attribute: protocol = 0bx8i
=== STEP  testing file_remote_path attribute: remote_path = 0bx8i
=== STEP  testing file_remote_path attribute: remote_port = 0bx8i
=== STEP  testing file_remote_path attribute: pmzsn = 0bx8i
=== STEP  testing file_remote_path creation with required arguments only
=== PAUSE TestAccAciRemotePathofaFile_Negative
=== CONT  TestAccAciRemotePathofaFile_Negative
=== STEP  testing file_remote_path destroy
--- PASS: TestAccAciRemotePathofaFile_Negative (49.38s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   51.196s
$ go test -v -run TestAccAciMgmtZone_Basic -timeout=60m
=== RUN   TestAccAciMgmtZone_Basic
=== STEP  Basic: testing mgmt_zone creation without  managed_node_connectivity_group_dn
=== STEP  Basic: testing mgmt_zone creation without  type
=== STEP  Basic: testing mgmt_zone creation without  name
=== STEP  testing mgmt_zone creation with required arguments only
=== STEP  Basic: testing mgmt_zone creation with optional parameters
=== STEP  Basic: testing mgmt_zone updation without required parameters
=== STEP  testing mgmt_zone creation with parent resource name acctest_dzjdf, zone type in_band and resource name ynubsh74umedsd44or7yp4uwc6lmd3fw70rdgbrjq3v0ns02gt79slkyn70ggpm7d
=== STEP  testing mgmt_zone creation with parent resource name acctest_dzjdf, zone type v2qke and resource name acctest_gicf1
=== STEP  testing mgmt_zone creation with parent resource name acctest_dzjdf, zone type in_band and resource name acctest_gicf1
=== STEP  testing mgmt_zone creation with parent resource name acctest_gicf1, zone type out_of_band and resource name acctest_gicf1
=== STEP  testing mgmt_zone creation with parent resource name acctest_gicf1, zone type in_band and resource name acctest_dzjdf
=== STEP  testing mgmt_zone creation with required arguments only
=== PAUSE TestAccAciMgmtZone_Basic
=== CONT  TestAccAciMgmtZone_Basic
=== STEP  testing mgmt_zone destroy
--- PASS: TestAccAciMgmtZone_Basic (75.10s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   76.631s
