### PR TITLE
Updated EPGs using Function

### DIFF
--- a/testacc/resource_aci_infrarsfunctoepg_test.go
+++ b/testacc/resource_aci_infrarsfunctoepg_test.go
@@ -658,10 +658,9 @@ func CreateAccEPGsUsingFunctionRemovingRequiredField() string {
 		description = "created while acceptance testing"
 		annotation = "orchestrator:terraform_testacc"
 		name_alias = "test_epgs_using_function"
-		encap = ""
 		instr_imedcy = "immediate"
 		mode = "native"
-		primary_encap = ""
+		primary_encap = "unknown"
 	}
 	`)
 	return resource


### PR DESCRIPTION
$ go test -v -run TestAccAciEPGsUsingFunction_Basic -timeout=60m
=== RUN   TestAccAciEPGsUsingFunction_Basic
=== STEP  Basic: testing epgs_using_function creation without  access_generic_dn
=== STEP  Basic: testing epgs_using_function creation without  tdn
=== STEP  Basic: testing epgs_using_function creation without  encap
=== STEP  testing epgs_using_function creation with required arguments only
=== STEP  Basic: testing epgs_using_function creation with optional parameters
=== STEP  Basic: testing epgs_using_function updation without required parameters
=== STEP  testing epgs_using_function creation with Updation required arguments only
=== STEP  testing epgs_using_function creation with required arguments only
=== STEP  testing epgs_using_function creation with Updation required arguments only
=== STEP  testing epgs_using_function creation with required arguments only
=== STEP  testing epgs_using_function creation with Updation of Encap
=== PAUSE TestAccAciEPGsUsingFunction_Basic
=== CONT  TestAccAciEPGsUsingFunction_Basic
=== STEP  testing epgs_using_function destroy
--- PASS: TestAccAciEPGsUsingFunction_Basic (335.69s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   337.358s
