### PR TITLE
updated test file for fileremote path

### DIFF
--- a/testacc/resource_aci_fileremotepath_test.go
+++ b/testacc/resource_aci_fileremotepath_test.go
@@ -158,6 +158,16 @@ func TestAccAciRemotePathofaFile_Negative(t *testing.T) {
 			},
 
 			{
+				Config:      CreateAccRemotePathofaFileUpdatedAttr(rName, host, "remote_port", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccRemotePathofaFileUpdatedAttr(rName, host, "remote_port", "65536"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
 				Config:      CreateAccRemotePathofaFileUpdatedAttr(rName, host, randomParameter, randomValue),
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
 			},


### PR DESCRIPTION
$ go test -v -run TestAccAciRemotePathofaFile_Negative -timeout=60m
=== RUN   TestAccAciRemotePathofaFile_Negative
=== STEP  testing file_remote_path when auth_type is usePassword and user_passwd is not given
=== STEP  testing file_remote_path creation with required arguments only
=== STEP  testing file_remote_path attribute: description = tgii9ptachpxlu3atgvb3o1ivigtung2ldxw421zdw3t9gn4zjhjvgxzuwyhe62aun2f3n7ipwme2ppi7bllv37fppst910i9kz2y2oac07tmpcmtf1sjlkcoy2xa6npu
=== STEP  testing file_remote_path attribute: annotation = zj8tmo9br7idvgi9crswpp1xwv33g03gwxf33y4qzyjwhja6qtj0ntuaexr2idncatqeo9rz4p7bv7wrgt0t2sghbmiemnmp6csjmhdvdr1zkrm8uy2qu1lnybz7708wy
=== STEP  testing file_remote_path attribute: name_alias = xqocqaxx2yjkbw0b2t3s8oek76i34yeczfz6d7gadz3hotplu9q4qc8x0c8ayfps
=== STEP  testing file_remote_path attribute: auth_type = pobh2
=== STEP  testing file_remote_path attribute: protocol = pobh2
=== STEP  testing file_remote_path attribute: remote_path = pobh2
=== STEP  testing file_remote_path attribute: remote_port = pobh2
=== STEP  testing file_remote_path attribute: remote_port = -1
=== STEP  testing file_remote_path attribute: remote_port = 65536
=== STEP  testing file_remote_path attribute: pbpaq = pobh2
=== STEP  testing file_remote_path creation with required arguments only
=== PAUSE TestAccAciRemotePathofaFile_Negative
=== CONT  TestAccAciRemotePathofaFile_Negative
=== STEP  testing file_remote_path destroy
--- PASS: TestAccAciRemotePathofaFile_Negative (57.49s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   58.831s
