### PR TITLE
updated file remote path

### DIFF
--- a/testacc/resource_aci_fileremotepath_test.go
+++ b/testacc/resource_aci_fileremotepath_test.go
@@ -64,6 +64,7 @@ func TestAccAciRemotePathofaFile_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_file_remote_path"),
 					resource.TestCheckResourceAttr(resourceName, "auth_type", "usePassword"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "scp"),
+					resource.TestCheckResourceAttr(resourceName, "remote_port", "18"),
 
 					resource.TestCheckResourceAttr(resourceName, "remote_path", "/example"),
 
@@ -357,7 +358,7 @@ func CreateAccRemotePathofaFileConfigWithOptionalValues(rName, host string) stri
 		remote_path = "/example"
 		user_name = "example"
 		user_passwd = "example"
-		
+		remote_port = "18"
 	}
 	`, rName, host)
 


### PR DESCRIPTION
$ go test -v -run TestAccAciRemotePathofaFile -timeout=60m
=== RUN   TestAccAciRemotePathofaFileDataSource_Basic
=== STEP  Basic: testing file_remote_path Data Source without  name
=== STEP  testing file_remote_path Data Source with required arguments only
=== STEP  testing file_remote_path Data Source with random attribute
=== STEP  testing file_remote_path Data Source with invalid name
=== STEP  testing file_remote_path Data Source with updated resource
=== PAUSE TestAccAciRemotePathofaFileDataSource_Basic
=== RUN   TestAccAciRemotePathofaFile_Basic
=== STEP  Basic: testing file_remote_path creation without  name
=== STEP  Basic: testing file_remote_path creation without  host
=== STEP  testing file_remote_path creation with required arguments only
=== STEP  Basic: testing file_remote_path creation with optional parameters
=== STEP  testing file_remote_path creation with invalid name =  kp4fu0cfz29r870ifcahoyiqzzbllrhpkzt0d9yyyyc8erzgfsw0gp3xm40tnut2v cisco.com
=== STEP  Basic: testing file_remote_path updation without required parameters
=== STEP  testing file_remote_path creation with updated naming arguments
=== PAUSE TestAccAciRemotePathofaFile_Basic
=== RUN   TestAccAciRemotePathofaFile_Negative
=== STEP  testing file_remote_path when auth_type is usePassword and user_passwd is not given
=== STEP  testing file_remote_path creation with required arguments only
=== STEP  testing file_remote_path attribute: description = g8cxeno0qmw3zddo690i2uko81848wz1tthxmqkkwclsb37ag9jrk2uce3s0193copqe6bis7h9oz7kmqojmfn73pizew0vazlgrnlhenx4gadnyjfkmlc1j0o77sppy3
=== STEP  testing file_remote_path attribute: annotation = fp96owswcwppii8sg9vmeerw93ylw2wzdwezgmmx8fgxopizf8datd0ntbhhxvkobd6r7s87d9dfosst38io7ahyun7msqz01ccykofi69djc7zrkhtcp0d8pjwqzhfg0
=== STEP  testing file_remote_path attribute: name_alias = ra8axsfas99crz4r63k8816vbzi6inilfoolzl7j98sc7v77bpybsfnoojckazpx
=== STEP  testing file_remote_path attribute: auth_type = 1epv6
=== STEP  testing file_remote_path attribute: protocol = 1epv6
=== STEP  testing file_remote_path attribute: remote_path = 1epv6
=== STEP  testing file_remote_path attribute: remote_port = 1epv6
=== STEP  testing file_remote_path attribute: remote_port = -1
=== STEP  testing file_remote_path attribute: remote_port = 65536
=== STEP  testing file_remote_path attribute: ttqhc = 1epv6
=== STEP  testing file_remote_path creation with required arguments only
=== PAUSE TestAccAciRemotePathofaFile_Negative
=== RUN   TestAccAciRemotePathofaFile_MultipleCreateDelete
=== STEP  testing multiple file_remote_path creation with required arguments only
=== PAUSE TestAccAciRemotePathofaFile_MultipleCreateDelete
=== CONT  TestAccAciRemotePathofaFileDataSource_Basic
=== CONT  TestAccAciRemotePathofaFile_MultipleCreateDelete
=== CONT  TestAccAciRemotePathofaFile_Negative
=== CONT  TestAccAciRemotePathofaFile_Basic
=== STEP  testing file_remote_path destroy
--- PASS: TestAccAciRemotePathofaFile_MultipleCreateDelete (16.15s)
=== STEP  testing file_remote_path destroy
--- PASS: TestAccAciRemotePathofaFileDataSource_Basic (32.24s)
=== STEP  testing file_remote_path destroy
--- PASS: TestAccAciRemotePathofaFile_Basic (48.40s)
=== STEP  testing file_remote_path destroy
--- PASS: TestAccAciRemotePathofaFile_Negative (60.39s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   62.521s
