### PR TITLE
added some test files

### DIFF
--- a/aci/data_source_aci_topsystem.go
+++ b/aci/data_source_aci_topsystem.go
@@ -83,7 +83,7 @@ func dataSourceAciSystem() *schema.Resource {
 				Computed: true,
 			},
 
-			"boot_strap_tate": &schema.Schema{
+			"boot_strap_state": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -350,7 +350,6 @@ func getRemoteSystem(client *client.Client, dn string) (*models.System, error) {
 
 func setSystemAttributes(topSystem *models.System, d *schema.ResourceData) (*schema.ResourceData, error) {
 	d.SetId(topSystem.DistinguishedName)
-	d.Set("description", topSystem.Description)
 
 	topSystemMap, err := topSystem.ToMap()
 
@@ -367,7 +366,7 @@ func setSystemAttributes(topSystem *models.System, d *schema.ResourceData) (*sch
 	d.Set("rldirect_mode", topSystemMap["rldirectMode"])
 	d.Set("role", topSystemMap["role"])
 	d.Set("server_type", topSystemMap["serverType"])
-	d.Set("bootstrap_state", topSystemMap["bootstrapState"])
+	d.Set("boot_strap_state", topSystemMap["bootstrapState"])
 	d.Set("child_action", topSystemMap["childAction"])
 	d.Set("config_issues", topSystemMap["configIssues"])
 	d.Set("control_plane_mtu", topSystemMap["controlPlaneMTU"])

--- a/aci/resource_aci_dhcpoptionpol.go
+++ b/aci/resource_aci_dhcpoptionpol.go
@@ -89,6 +89,7 @@ func resourceAciDHCPOptionPolicy() *schema.Resource {
 			"dhcp_option_ids": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		}),

--- a/testacc/data_source_aci_aaasamlenccert_test.go
+++ b/testacc/data_source_aci_aaasamlenccert_test.go
@@ -1,0 +1,57 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciKeypairforSAMLEncryptionDataSource_Basic(t *testing.T) {
+	dataSourceName := "data.aci_saml_certificate.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccKeypairforSAMLEncryptionConfigDataSource(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "regenerate"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "expiry_status"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "certificate_validty"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "certificate"),
+				),
+			},
+			{
+				Config:      CreateAccKeypairforSAMLEncryptionDataSourceUpdate(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccKeypairforSAMLEncryptionConfigDataSource(),
+			},
+		},
+	})
+}
+
+
+func CreateAccKeypairforSAMLEncryptionConfigDataSource() string {
+	fmt.Println("=== STEP  testing saml_certificate Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	data "aci_saml_certificate" "test" {}
+	`)
+	return resource
+}
+
+func CreateAccKeypairforSAMLEncryptionDataSourceUpdate(key, value string) string {
+	fmt.Println("=== STEP  testing saml_certificate Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	data "aci_saml_certificate" "test" {
+		%s = "%s"
+	}
+	`, key,value)
+	return resource
+}

--- a/testacc/data_source_aci_dhcpoption_test.go
+++ b/testacc/data_source_aci_dhcpoption_test.go
@@ -1,0 +1,200 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciDHCPOptionDataSource_Basic(t *testing.T) {
+	dataSourceName := "data.aci_dhcp_option.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateDHCPOptionDSWithoutRequired(rName, rName, rName, "dhcp_option_policy_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateDHCPOptionDSWithoutRequired(rName, rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccDHCPOptionConfigDataSource(rName, rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "dhcp_option_policy_dn", fmt.Sprintf("uni/tn-%s/dhcpoptpol-%s", rName, rName)),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "annotation", "test_annotation"),
+					resource.TestCheckResourceAttr(dataSourceName, "data", "test_data"),
+					resource.TestCheckResourceAttr(dataSourceName, "name_alias", "test_name_alias"),
+					resource.TestCheckResourceAttr(dataSourceName, "dhcp_option_id", "1"),
+				),
+			},
+			{
+				Config:      CreateAccDHCPOptionDataSourceUpdate(rName, rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccDHCPOptionDSWithInvalidName(rName, rName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+
+			{
+				Config: CreateAccDHCPOptionDataSourceUpdatedResource(rName, rName, rName, "name_alias", "updated_name_alias"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "name_alias", "updated_name_alias"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccDHCPOptionConfigDataSource(fvTenantName, dhcpOptionPolName, rName string) string {
+	fmt.Println("=== STEP  testing dhcp_option Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "name" {
+		name = "%s"
+	  }
+	  
+	  resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.name.id
+		name  = "%s"
+	  
+		dhcp_option {
+		  name  = "%s"
+		  annotation  = "test_annotation"
+		  data  = "test_data"
+		  dhcp_option_id  = "1"
+		  name_alias  = "test_name_alias"
+		}
+	  }
+	  
+	  data "aci_dhcp_option" "test" {
+		dhcp_option_policy_dn  = aci_dhcp_option_policy.test.id
+		name  = aci_dhcp_option_policy.test.dhcp_option.0.name
+	  }
+	`, fvTenantName, dhcpOptionPolName, rName)
+	return resource
+}
+
+func CreateDHCPOptionDSWithoutRequired(fvTenantName, dhcpOptionPolName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing dhcp_option Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+		dhcp_option {
+			name  = "%s"
+		}
+	}
+	
+	`
+	switch attrName {
+	case "dhcp_option_policy_dn":
+		rBlock += `
+	data "aci_dhcp_option" "test" {
+	#	dhcp_option_policy_dn  = aci_dhcp_option_policy.test.id
+		name  = aci_dhcp_option_policy.test.dhcp_option.0.name
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_dhcp_option" "test" {
+		dhcp_option_policy_dn  = aci_dhcp_option_policy.test.id
+	#	name  = aci_dhcp_option_policy.test.dhcp_option.0.name
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, dhcpOptionPolName, rName)
+}
+
+func CreateAccDHCPOptionDSWithInvalidName(fvTenantName, dhcpOptionPolName, rName string) string {
+	fmt.Println("=== STEP  testing dhcp_option Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "name" {
+		name = "%s"
+	  }
+	  
+	  resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.name.id
+		name  = "%s"
+	  
+		dhcp_option {
+		  name  = "%s"
+		}
+	  }
+
+	data "aci_dhcp_option" "test" {
+		dhcp_option_policy_dn  = aci_dhcp_option_policy.test.id
+		name  = "${aci_dhcp_option_policy.test.dhcp_option.0.name}_invalid"
+	}
+	`, fvTenantName, dhcpOptionPolName, rName)
+	return resource
+}
+
+func CreateAccDHCPOptionDataSourceUpdate(fvTenantName, dhcpOptionPolName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing dhcp_option Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "name" {
+		name = "%s"
+	  }
+	  
+	  resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.name.id
+		name  = "%s"
+	  
+		dhcp_option {
+		  name  = "%s"
+		}
+	  }
+	  
+	  data "aci_dhcp_option" "test" {
+		dhcp_option_policy_dn  = aci_dhcp_option_policy.test.id
+		name  = aci_dhcp_option_policy.test.dhcp_option.0.name
+		%s = "%s"
+	  }
+	`, fvTenantName, dhcpOptionPolName, rName, key, value)
+	return resource
+}
+
+func CreateAccDHCPOptionDataSourceUpdatedResource(fvTenantName, dhcpOptionPolName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing dhcp_option Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "name" {
+		name = "%s"
+	  }
+	  
+	  resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.name.id
+		name  = "%s"
+	  
+		dhcp_option {
+		  name  = "%s"
+		  %s = "%s"
+		}
+	  }
+	  
+	  data "aci_dhcp_option" "test" {
+		dhcp_option_policy_dn  = aci_dhcp_option_policy.test.id
+		name  = aci_dhcp_option_policy.test.dhcp_option.0.name
+	  }
+	`, fvTenantName, dhcpOptionPolName, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_fabricnode_test.go
+++ b/testacc/data_source_aci_fabricnode_test.go
@@ -1,0 +1,143 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const fabricNodeId = "101"
+const fabricPodDn = "topology/pod-1"
+
+func TestAccAciTopologyFabricNodeDataSource_Basic(t *testing.T) {
+	dataSourceName := "data.aci_fabric_node.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateTopologyFabricNodeDSWithoutRequired(fabricPodDn, fabricNodeId, "fabric_pod_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateTopologyFabricNodeDSWithoutRequired(fabricPodDn, fabricNodeId, "fabric_node_id"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccTopologyFabricNodeConfigDataSource(fabricPodDn, fabricNodeId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "fabric_pod_dn", fabricPodDn),
+					resource.TestCheckResourceAttr(dataSourceName, "fabric_node_id", fabricNodeId),
+					resource.TestCheckResourceAttrSet(dataSourceName, "ad_st"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "address"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "apic_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "fabric_st"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "node_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "role"),
+				),
+			},
+			{
+				Config:      CreateAccTopologyFabricNodeDataSourceUpdate(fabricPodDn, fabricNodeId, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccTopologyFabricNodeDSWithInvalidNodeId(fabricPodDn, randomValue),
+				ExpectError: regexp.MustCompile(`Invalid RN`),
+			},
+			{
+				Config: CreateAccTopologyFabricNodeConfigDataSource(fabricPodDn, fabricNodeId),
+			},
+		},
+	})
+}
+
+func CreateAccTopologyFabricNodeConfigDataSource(podId, nodeId string) string {
+	fmt.Println("=== STEP  testing fabric_node Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+
+	data "aci_fabric_node" "test" {
+		fabric_pod_dn  = "%s"
+		fabric_node_id  = "%s"
+	}
+	`, podId, nodeId)
+	return resource
+}
+
+func CreateTopologyFabricNodeDSWithoutRequired(podDn, nodeId, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing fabric_node Data Source without ", attrName)
+	rBlock := `
+	`
+	switch attrName {
+	case "fabric_pod_dn":
+		rBlock += `
+	data "aci_fabric_node" "test" {
+	#	fabric_pod_dn  = "%s"
+		fabric_node_id  = "%s"
+	}
+		`
+	case "fabric_node_id":
+		rBlock += `
+	data "aci_fabric_node" "test" {
+		fabric_pod_dn  = "%s"
+	#	fabric_node_id  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, podDn, nodeId)
+}
+
+func CreateAccTopologyFabricNodeDSWithInvalidNodeId(podId, nodeId string) string {
+	fmt.Println("=== STEP  testing fabric_node Data Source with invalid fabric_node_id")
+	resource := fmt.Sprintf(`
+
+	data "aci_fabric_node" "test" {
+		fabric_pod_dn  = "%s"
+		fabric_node_id  = "%s"
+	}
+	`, podId, nodeId)
+	return resource
+}
+
+func CreateAccTopologyFabricNodeDataSourceUpdate(podId, nodeId, key, value string) string {
+	fmt.Println("=== STEP  testing fabric_node Data Source with random attribute")
+	resource := fmt.Sprintf(`
+
+	data "aci_fabric_node" "test" {
+		fabric_pod_dn  = "%s"
+		fabric_node_id  = "%s"
+		%s = "%s"
+	}
+	`, podId, nodeId, key, value)
+	return resource
+}
+
+func CreateAccTopologyFabricNodeDataSourceUpdatedResource(fabricPodName, fabric_node_id, key, value string) string {
+	fmt.Println("=== STEP  testing fabric_node Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_fabric_pod" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_fabric_node" "test" {
+		fabric_pod_dn  = aci_fabric_pod.test.id
+		fabric_node_id  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_fabric_node" "test" {
+		fabric_pod_dn  = aci_fabric_pod.test.id
+		fabric_node_id  = aci_fabric_node.test.fabric_node_id
+		depends_on = [ aci_fabric_node.test ]
+	}
+	`, fabricPodName, fabric_node_id, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_fabricpathep_test.go
+++ b/testacc/data_source_aci_fabricpathep_test.go
@@ -1,0 +1,130 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const podId = "1"
+const nodeId = "101"
+const pathEpName = "eth1/12"
+
+func TestAccAciFabricPathEpDataSource_Basic(t *testing.T) {
+	dataSourceName := "data.aci_fabric_path_ep.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateFabricPathEpDSWithoutRequired("pod_id"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateFabricPathEpDSWithoutRequired("name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateFabricPathEpDSWithoutRequired("node_id"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccFabricPathEpConfigDataSource(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "pod_id", podId),
+					resource.TestCheckResourceAttr(dataSourceName, "name", pathEpName),
+					resource.TestCheckResourceAttr(dataSourceName, "node_id", nodeId),
+				),
+			},
+			{
+				Config:      CreateAccFabricPathEpDataSourceUpdate(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccFabricPathEpDSWithInvalidParentDn(randomValue),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccFabricPathEpConfigDataSource(),
+			},
+		},
+	})
+}
+
+func CreateAccFabricPathEpConfigDataSource() string {
+	fmt.Println("=== STEP  testing fabric_path_ep Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	data "aci_fabric_path_ep" "test" {
+		pod_id  = "%s"
+		name  = "%s"
+		node_id = "%s"
+	}
+	`, podId, pathEpName, nodeId)
+	return resource
+}
+
+func CreateFabricPathEpDSWithoutRequired(attrName string) string {
+	fmt.Println("=== STEP  Basic: testing fabric_path_ep Data Source without ", attrName)
+	rBlock := `
+	`
+	switch attrName {
+	case "pod_id":
+		rBlock += `
+	data "aci_fabric_path_ep" "test" {
+	#	pod_id  = "%s"
+		name  = "%s"
+		node_id = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_fabric_path_ep" "test" {
+		pod_id  = "%s"
+	#	name  = "%s"
+		node_id = "%s"
+	}
+		`
+	case "node_id":
+		rBlock += `
+	data "aci_fabric_path_ep" "test" {
+		pod_id  = "%s"
+		name  = "%s"
+	#	node_id = "%s"
+	}
+	`
+	}
+	return fmt.Sprintf(rBlock, podId, pathEpName, nodeId)
+}
+
+func CreateAccFabricPathEpDSWithInvalidParentDn(value string) string {
+	fmt.Println("=== STEP  testing fabric_path_ep Data Source with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+
+	data "aci_fabric_path_ep" "test" {
+		pod_id  = "%s"
+		name  = "%s"
+		node_id = "%s"
+	}
+	`, podId, value, nodeId)
+	return resource
+}
+
+func CreateAccFabricPathEpDataSourceUpdate(key, value string) string {
+	fmt.Println("=== STEP  testing fabric_path_ep Data Source with random attribute")
+	resource := fmt.Sprintf(`
+
+	data "aci_fabric_path_ep" "test" {
+		pod_id  = "%s"
+		name  = "%s"
+		node_id = "%s"
+		%s = "%s"
+	}
+	`, podId, pathEpName, nodeId, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_fvcep_test.go
+++ b/testacc/data_source_aci_fvcep_test.go
@@ -1,0 +1,56 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciFvCEpDataSource_Basic(t *testing.T) {
+	dataSourceName := "data.aci_client_end_point.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccFvCEpConfigDataSource(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "fvcep_objects.0.application_profile_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "fvcep_objects.0.epg_name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "fvcep_objects.0.mac"),
+					resource.TestCheckResourceAttr(dataSourceName, "fvcep_objects.0.tenant_name", "infra"),
+				),
+			},
+			{
+				Config:      CreateAccFvCEpDataSourceUpdate(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccFvCEpConfigDataSource(),
+			},
+		},
+	})
+}
+
+func CreateAccFvCEpDataSourceUpdate(key, value string) string {
+	fmt.Println("=== STEP  testing client_end_point Data Source with random parameters")
+	resource := fmt.Sprintf(`
+	data "aci_client_end_point" "test" {
+		%s = "%s"
+	}
+	`, key, value)
+	return resource
+}
+
+func CreateAccFvCEpConfigDataSource() string {
+	fmt.Println("=== STEP  testing client_end_point Data Source with required arguments only")
+	resource := fmt.Sprintln(`
+	data "aci_client_end_point" "test" {}
+	`)
+	return resource
+}

--- a/testacc/data_source_aci_ipnexthopp_test.go
+++ b/testacc/data_source_aci_ipnexthopp_test.go
@@ -1,0 +1,291 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciL3outStaticRouteNextHopDataSource_Basic(t *testing.T) {
+	resourceName := "aci_l3out_static_route_next_hop.test"
+	dataSourceName := "data.aci_l3out_static_route_next_hop.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	rtrId, _ := acctest.RandIpAddress("20.0.0.0/16")
+	nhAddr, _ := acctest.RandIpAddress("20.1.0.0/16")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3outStaticRouteNextHopDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateL3outStaticRouteNextHopDSWithoutRequired(rName, fabDn1, rtrId, nhAddr, "nh_addr"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateL3outStaticRouteNextHopDSWithoutRequired(rName, fabDn1, rtrId, nhAddr, "static_route_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccL3outStaticRouteNextHopConfigDataSource(rName, fabDn1, rtrId, nhAddr),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "static_route_dn", resourceName, "static_route_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "nh_addr", resourceName, "nh_addr"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "pref", resourceName, "pref"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "nexthop_profile_type", resourceName, "nexthop_profile_type"),
+				),
+			},
+			{
+				Config:      CreateAccL3outStaticRouteNextHopDataSourceUpdate(rName, fabDn1, rtrId, nhAddr, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccL3outStaticRouteNextHopDSWithInvalidIP(rName, fabDn1, rtrId, nhAddr),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccL3outStaticRouteNextHopDataSourceUpdatedResource(rName, fabDn1, rtrId, nhAddr, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccL3outStaticRouteNextHopConfigDataSource(rName, tdn, rtrId, nhAddr string) string {
+	fmt.Println("=== STEP  testing l3out_static_route_next_hop Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+	}
+
+	resource "aci_l3out_static_route" "test" {
+		fabric_node_dn = aci_logical_node_to_fabric_node.test.id
+		ip  = "%s"
+	}
+
+	resource "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn  = aci_l3out_static_route.test.id
+		nh_addr  = "%s"
+	}
+
+	data "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn = aci_l3out_static_route_next_hop.test.static_route_dn
+		nh_addr  = aci_l3out_static_route_next_hop.test.nh_addr
+		depends_on = [ aci_l3out_static_route_next_hop.test ]
+	}
+	`, rName, rName, rName, tdn, rtrId, rtrId, nhAddr)
+	return resource
+}
+
+func CreateL3outStaticRouteNextHopDSWithoutRequired(rName, tdn, rtrId, nhAddr, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing l3out_static_route_next_hop Data Source without ", attrName)
+	rBlock := `
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+	}
+
+	resource "aci_l3out_static_route" "test" {
+		fabric_node_dn = aci_logical_node_to_fabric_node.test.id
+		ip  = "%s"
+	}
+
+	resource "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn  = aci_l3out_static_route.test.id
+		nh_addr  = "%s"
+	}
+	`
+	switch attrName {
+	case "nh_addr":
+		rBlock += `
+	data "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn = aci_l3out_static_route_next_hop.test.static_route_dn
+	#	nh_addr  = aci_l3out_static_route_next_hop.test.nh_addr
+		depends_on = [ aci_l3out_static_route_next_hop.test ]
+	}
+		`
+	case "static_route_dn":
+		rBlock += `
+	data "aci_l3out_static_route_next_hop" "test" {
+	#	static_route_dn = aci_l3out_static_route_next_hop.test.static_route_dn
+		nh_addr  = aci_l3out_static_route_next_hop.test.nh_addr
+		depends_on = [ aci_l3out_static_route_next_hop.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName, rName, rName, tdn, rtrId, rtrId, nhAddr)
+}
+
+func CreateAccL3outStaticRouteNextHopDSWithInvalidIP(rName, tdn, rtrId, nhAddr string) string {
+	fmt.Println("=== STEP  testing l3out_static_route_next_hop Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+	}
+
+	resource "aci_l3out_static_route" "test" {
+		fabric_node_dn = aci_logical_node_to_fabric_node.test.id
+		ip  = "%s"
+	}
+
+	resource "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn  = aci_l3out_static_route.test.id
+		nh_addr  = "%s"
+	}
+
+	data "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn = aci_l3out_static_route_next_hop.test.static_route_dn
+		nh_addr  = "%s"
+		depends_on = [ aci_l3out_static_route_next_hop.test ]
+	}
+	`, rName, rName, rName, tdn, rtrId, rtrId, nhAddr, rtrId)
+	return resource
+}
+
+func CreateAccL3outStaticRouteNextHopDataSourceUpdate(rName, tdn, rtrId, nhAddr, key, value string) string {
+	fmt.Println("=== STEP  testing l3out_static_route_next_hop Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+	}
+
+	resource "aci_l3out_static_route" "test" {
+		fabric_node_dn = aci_logical_node_to_fabric_node.test.id
+		ip  = "%s"
+	}
+
+	resource "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn  = aci_l3out_static_route.test.id
+		nh_addr  = "%s"
+	}
+
+	data "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn = aci_l3out_static_route_next_hop.test.static_route_dn
+		nh_addr  = aci_l3out_static_route_next_hop.test.nh_addr
+		%s = "%s"
+		depends_on = [ aci_l3out_static_route_next_hop.test ]
+	}
+	`, rName, rName, rName, tdn, rtrId, rtrId, nhAddr, key, value)
+	return resource
+}
+
+func CreateAccL3outStaticRouteNextHopDataSourceUpdatedResource(rName, tdn, rtrId, nhAddr, key, value string) string {
+	fmt.Println("=== STEP  testing l3out_static_route_next_hop Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+
+	}
+
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+	}
+
+	resource "aci_l3out_static_route" "test" {
+		fabric_node_dn = aci_logical_node_to_fabric_node.test.id
+		ip  = "%s"
+	}
+
+	resource "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn  = aci_l3out_static_route.test.id
+		nh_addr  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn = aci_l3out_static_route_next_hop.test.static_route_dn
+		nh_addr  = aci_l3out_static_route_next_hop.test.nh_addr
+		depends_on = [ aci_l3out_static_route_next_hop.test ]
+	}
+	`, rName, rName, rName, tdn, rtrId, rtrId, nhAddr, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_topsystem_test.go
+++ b/testacc/data_source_aci_topsystem_test.go
@@ -1,0 +1,153 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const systemPodId = "1"
+const systemNodeId = "1"
+
+func TestAccAciSystemDataSource_Basic(t *testing.T) {
+	dataSourceName := "data.aci_system.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateSystemDSWithoutRequired(systemPodId, systemNodeId, "pod_id"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateSystemDSWithoutRequired(systemPodId, systemNodeId, "system_id"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccSystemConfigDataSource(systemPodId, systemNodeId),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "address"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "boot_strap_state"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "control_plane_mtu"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "current_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "enforce_subnet_check"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "etep_addr"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "fabric_domain"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "fabric_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "fabric_mac"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "inb_mgmt_addr"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "inb_mgmt_addr6"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "inb_mgmt_addr6_mask"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "inb_mgmt_addr_mask"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "inb_mgmt_gateway"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "inb_mgmt_gateway6"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "last_reboot_time"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "last_reset_reason"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "lc_own"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "mod_ts"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "mode"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "mon_pol_dn"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "name"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "node_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "oob_mgmt_addr"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "oob_mgmt_addr6"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "oob_mgmt_addr6_mask"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "oob_mgmt_addr_mask"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "oob_mgmt_gateway"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "oob_mgmt_gateway6"),
+					resource.TestCheckResourceAttr(dataSourceName, "pod_id", systemPodId),
+					resource.TestCheckResourceAttrSet(dataSourceName, "remote_network_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "remote_node"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rl_oper_pod_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rl_routable_mode"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "rldirect_mode"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "role"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "serial"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "server_type"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "site_id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "state"),
+					resource.TestCheckResourceAttr(dataSourceName, "system_id", systemNodeId),
+					resource.TestCheckResourceAttrSet(dataSourceName, "system_uptime"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "tep_pool"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "unicast_xr_ep_learn_disable"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "version"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "virtual_mode"),
+				),
+			},
+			{
+				Config:      CreateAccSystemDataSourceUpdate(systemPodId, systemNodeId, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccSystemDSWithInvalidSystemId(systemPodId, randomValue),
+				ExpectError: regexp.MustCompile(`Invalid RN`),
+			},
+			{
+				Config: CreateAccSystemConfigDataSource(systemPodId, systemNodeId),
+			},
+		},
+	})
+}
+
+func CreateAccSystemConfigDataSource(pid, sid string) string {
+	fmt.Println("=== STEP  testing system Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	data "aci_system" "test" {
+		pod_id  = "%s"
+		system_id = "%s"
+	}
+	`, pid, sid)
+	return resource
+}
+
+func CreateSystemDSWithoutRequired(pid, sid, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing system Data Source without ", attrName)
+	rBlock := `
+	`
+	switch attrName {
+	case "pod_id":
+		rBlock += `
+		data "aci_system" "test" {
+		#	pod_id = "%s"
+			system_id = "%s"
+		}
+		`
+	case "system_id":
+		rBlock += `
+		data "aci_system" "test" {
+			pod_id = "%s"
+		#	system_id = "%s"
+		}
+		`
+	}
+	return fmt.Sprintf(rBlock, pid, sid)
+}
+
+func CreateAccSystemDSWithInvalidSystemId(pid, sid string) string {
+	fmt.Println("=== STEP  testing system Data Source with invalid system id")
+	resource := fmt.Sprintf(`
+	data "aci_system" "test" {
+		pod_id = "%s"
+		system_id = "%s"
+	}
+	`, pid, sid)
+	return resource
+}
+
+func CreateAccSystemDataSourceUpdate(pid, sid, key, value string) string {
+	fmt.Println("=== STEP  testing system Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	data "aci_system" "test" {
+		pod_id = "%s"
+		system_id = "%s"
+		%s = "%s"
+	  }
+	`, pid, sid, key, value)
+	return resource
+}

--- a/testacc/resource_aci_ipnexthopp_test.go
+++ b/testacc/resource_aci_ipnexthopp_test.go
@@ -1,0 +1,553 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciL3outStaticRouteNextHop_Basic(t *testing.T) {
+	var l3out_static_route_next_hop_default models.L3outStaticRouteNextHop
+	var l3out_static_route_next_hop_updated models.L3outStaticRouteNextHop
+	resourceName := "aci_l3out_static_route_next_hop.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	rtrId, _ := acctest.RandIpAddress("20.2.0.0/16")
+	nhAddr, _ := acctest.RandIpAddress("20.3.0.0/16")
+	nhAddrUpdated, _ := acctest.RandIpAddress("20.4.0.0/16")
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3outStaticRouteNextHopDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateL3outStaticRouteNextHopWithoutRequired(rName, fabDn2, rtrId, nhAddr, "nh_addr"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateL3outStaticRouteNextHopWithoutRequired(rName, fabDn2, rtrId, nhAddr, "static_route_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccL3outStaticRouteNextHopConfig(rName, fabDn2, rtrId, nhAddr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outStaticRouteNextHopExists(resourceName, &l3out_static_route_next_hop_default),
+					resource.TestCheckResourceAttr(resourceName, "static_route_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s/rsnodeL3OutAtt-[%s]/rt-[%s]", rName, rName, rName, fabDn2, rtrId)),
+					resource.TestCheckResourceAttr(resourceName, "nh_addr", nhAddr),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "pref", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "nexthop_profile_type", "prefix"),
+				),
+			},
+			{
+				Config: CreateAccL3outStaticRouteNextHopConfigWithOptionalValues(rName, fabDn2, rtrId, nhAddr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outStaticRouteNextHopExists(resourceName, &l3out_static_route_next_hop_updated),
+					resource.TestCheckResourceAttr(resourceName, "static_route_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s/rsnodeL3OutAtt-[%s]/rt-[%s]", rName, rName, rName, fabDn2, rtrId)),
+					resource.TestCheckResourceAttr(resourceName, "nh_addr", nhAddr),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_l3out_static_route_next_hop"),
+					resource.TestCheckResourceAttr(resourceName, "pref", "1"),
+					testAccCheckAciL3outStaticRouteNextHopIdEqual(&l3out_static_route_next_hop_default, &l3out_static_route_next_hop_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: CreateAccL3outStaticRouteNextHopUpdatedAttr(rName, fabDn2, rtrId, nhAddr, "pref", "128"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outStaticRouteNextHopExists(resourceName, &l3out_static_route_next_hop_updated),
+					resource.TestCheckResourceAttr(resourceName, "pref", "128"),
+					testAccCheckAciL3outStaticRouteNextHopIdEqual(&l3out_static_route_next_hop_default, &l3out_static_route_next_hop_updated),
+				),
+			},
+			{
+				Config: CreateAccL3outStaticRouteNextHopUpdatedAttr(rName, fabDn2, rtrId, nhAddr, "pref", "255"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outStaticRouteNextHopExists(resourceName, &l3out_static_route_next_hop_updated),
+					resource.TestCheckResourceAttr(resourceName, "pref", "255"),
+					testAccCheckAciL3outStaticRouteNextHopIdEqual(&l3out_static_route_next_hop_default, &l3out_static_route_next_hop_updated),
+				),
+			},
+			{
+				Config:      CreateAccL3outStaticRouteNextHopWithInavalidIP(rName, fabDn2, rtrId),
+				ExpectError: regexp.MustCompile(`unknown property value (.)+`),
+			},
+
+			{
+				Config:      CreateAccL3outStaticRouteNextHopRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+
+			{
+				Config: CreateAccL3outStaticRouteNextHopConfigWithRequiredParams(rName, fabDn2, rtrId, nhAddrUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outStaticRouteNextHopExists(resourceName, &l3out_static_route_next_hop_updated),
+					resource.TestCheckResourceAttr(resourceName, "static_route_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s/rsnodeL3OutAtt-[%s]/rt-[%s]", rName, rName, rName, fabDn2, rtrId)),
+					resource.TestCheckResourceAttr(resourceName, "nh_addr", nhAddrUpdated),
+					testAccCheckAciL3outStaticRouteNextHopIdNotEqual(&l3out_static_route_next_hop_default, &l3out_static_route_next_hop_updated),
+				),
+			},
+			{
+				Config: CreateAccL3outStaticRouteNextHopConfig(rName, fabDn2, rtrId, nhAddr),
+			},
+			{
+				Config: CreateAccL3outStaticRouteNextHopConfigWithRequiredParams(rNameUpdated, fabDn2, rtrId, nhAddrUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outStaticRouteNextHopExists(resourceName, &l3out_static_route_next_hop_updated),
+					resource.TestCheckResourceAttr(resourceName, "static_route_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s/rsnodeL3OutAtt-[%s]/rt-[%s]", rNameUpdated, rNameUpdated, rNameUpdated, fabDn2, rtrId)),
+					resource.TestCheckResourceAttr(resourceName, "nh_addr", nhAddrUpdated),
+					testAccCheckAciL3outStaticRouteNextHopIdNotEqual(&l3out_static_route_next_hop_default, &l3out_static_route_next_hop_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciL3outStaticRouteNextHop_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	rtrId, _ := acctest.RandIpAddress("20.5.0.0/16")
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	nhAddr, _ := acctest.RandIpAddress("20.6.0.0/16")
+	randomValue := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3outStaticRouteNextHopDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccL3outStaticRouteNextHopConfig(rName, fabDn3, rtrId, nhAddr),
+			},
+			{
+				Config:      CreateAccL3outStaticRouteNextHopConfigInvalidParentDn(rName, nhAddr),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccL3outStaticRouteNextHopUpdatedAttr(rName, fabDn3, rtrId, nhAddr, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccL3outStaticRouteNextHopUpdatedAttr(rName, fabDn3, rtrId, nhAddr, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccL3outStaticRouteNextHopUpdatedAttr(rName, fabDn3, rtrId, nhAddr, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccL3outStaticRouteNextHopUpdatedAttr(rName, fabDn3, rtrId, nhAddr, "pref", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccL3outStaticRouteNextHopUpdatedAttr(rName, fabDn3, rtrId, nhAddr, "pref", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccL3outStaticRouteNextHopUpdatedAttr(rName, fabDn3, rtrId, nhAddr, "pref", "256"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccL3outStaticRouteNextHopUpdatedAttr(rName, fabDn3, rtrId, nhAddr, "nexthop_profile_type", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccL3outStaticRouteNextHopUpdatedAttr(rName, fabDn3, rtrId, nhAddr, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccL3outStaticRouteNextHopConfig(rName, fabDn3, rtrId, nhAddr),
+			},
+		},
+	})
+}
+
+func TestAccAciL3outStaticRouteNextHop_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3outStaticRouteNextHopDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccL3outStaticRouteNextHopConfigMultiple(rName, fabDn4),
+			},
+		},
+	})
+}
+
+func testAccCheckAciL3outStaticRouteNextHopExists(name string, l3out_static_route_next_hop *models.L3outStaticRouteNextHop) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("L3out Static Route Next Hop %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No L3out Static Route Next Hop dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		l3out_static_route_next_hopFound := models.L3outStaticRouteNextHopFromContainer(cont)
+		if l3out_static_route_next_hopFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("L3out Static Route Next Hop %s not found", rs.Primary.ID)
+		}
+		*l3out_static_route_next_hop = *l3out_static_route_next_hopFound
+		return nil
+	}
+}
+
+func testAccCheckAciL3outStaticRouteNextHopDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing l3out_static_route_next_hop destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_l3out_static_route_next_hop" {
+			cont, err := client.Get(rs.Primary.ID)
+			l3out_static_route_next_hop := models.L3outStaticRouteNextHopFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("L3out Static Route Next Hop %s Still exists", l3out_static_route_next_hop.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciL3outStaticRouteNextHopIdEqual(m1, m2 *models.L3outStaticRouteNextHop) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("l3out_static_route_next_hop DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciL3outStaticRouteNextHopIdNotEqual(m1, m2 *models.L3outStaticRouteNextHop) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("l3out_static_route_next_hop DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateL3outStaticRouteNextHopWithoutRequired(rName, tdn, rtrId, nhAddr, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing l3out_static_route_next_hop creation without ", attrName)
+	rBlock := `
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+	}
+
+	resource "aci_l3out_static_route" "test" {
+		fabric_node_dn = aci_logical_node_to_fabric_node.test.id
+		ip  = "%s"
+	}
+	`
+	switch attrName {
+	case "nh_addr":
+		rBlock += `
+	resource "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn  = aci_l3out_static_route.test.id
+	#	nh_addr  = "%s"
+	}
+		`
+	case "static_route_dn":
+		rBlock += `
+	resource "aci_l3out_static_route_next_hop" "test" {
+	#	static_route_dn  = aci_l3out_static_route.test.id
+		nh_addr  = "%s"
+	}
+		`
+	}
+
+	return fmt.Sprintf(rBlock, rName, rName, rName, tdn, rtrId, rtrId, nhAddr)
+}
+
+func CreateAccL3outStaticRouteNextHopConfigWithRequiredParams(rName, tdn, rtrId, nhAddr string) string {
+	fmt.Printf("=== STEP  testing l3out_static_route_next_hop creation with parent resource name %s,tdn %s, rtr_id %s and nh_addr %s,\n", rName, tdn, rtrId, nhAddr)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+	}
+
+	resource "aci_l3out_static_route" "test" {
+		fabric_node_dn = aci_logical_node_to_fabric_node.test.id
+		ip  = "%s"
+	}
+	resource "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn  = aci_l3out_static_route.test.id
+		nh_addr  = "%s"
+	}
+	`, rName, rName, rName, tdn, rtrId, rtrId, nhAddr)
+	return resource
+}
+
+func CreateAccL3outStaticRouteNextHopWithInavalidIP(rName, tdn, rtrId string) string {
+	fmt.Println("=== STEP  testing l3out_static_route_next_hop creation with invalid IP")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+	}
+
+	resource "aci_l3out_static_route" "test" {
+		fabric_node_dn = aci_logical_node_to_fabric_node.test.id
+		ip  = "%s"
+	}
+
+	resource "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn  = aci_l3out_static_route.test.id
+		nh_addr  = "%s"
+	}
+	`, rName, rName, rName, tdn, rtrId, rtrId, rName)
+	return resource
+}
+
+func CreateAccL3outStaticRouteNextHopConfigInvalidParentDn(rName, nhAddr string) string {
+	fmt.Println("=== STEP  testing l3out_static_route_next_hop creation with invalid parent dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn  = aci_tenant.test.id
+		nh_addr  = "%s"
+	}
+	`, rName, nhAddr)
+	return resource
+}
+
+func CreateAccL3outStaticRouteNextHopConfig(rName, tdn, rtrId, nhAddr string) string {
+	fmt.Println("=== STEP  testing l3out_static_route_next_hop creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+	}
+
+	resource "aci_l3out_static_route" "test" {
+		fabric_node_dn = aci_logical_node_to_fabric_node.test.id
+		ip  = "%s"
+	}
+
+	resource "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn  = aci_l3out_static_route.test.id
+		nh_addr  = "%s"
+	}
+	`, rName, rName, rName, tdn, rtrId, rtrId, nhAddr)
+	return resource
+}
+
+func CreateAccL3outStaticRouteNextHopConfigMultiple(rName, tdn string) string {
+	fmt.Println("=== STEP  testing multiple l3out_static_route_next_hop creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "20.7.0.0"
+	}
+
+	resource "aci_l3out_static_route" "test" {
+		fabric_node_dn = aci_logical_node_to_fabric_node.test.id
+		ip  = "20.7.0.0"
+	}
+
+	resource "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn  = aci_l3out_static_route.test.id
+		nh_addr  = "20.8.0.${count.index}"
+		count = 5
+	}
+	`, rName, rName, rName, tdn)
+	return resource
+}
+
+func CreateAccL3outStaticRouteNextHopConfigWithOptionalValues(rName, tdn, rtrId, nhAddr string) string {
+	fmt.Println("=== STEP  Basic: testing l3out_static_route_next_hop creation with optional parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+	}
+
+	resource "aci_l3out_static_route" "test" {
+		fabric_node_dn = aci_logical_node_to_fabric_node.test.id
+		ip  = "%s"
+	}
+
+	resource "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn  = aci_l3out_static_route.test.id
+		nh_addr  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_l3out_static_route_next_hop"
+		pref = "1"
+	}
+	`, rName, rName, rName, tdn, rtrId, rtrId, nhAddr)
+
+	return resource
+}
+
+func CreateAccL3outStaticRouteNextHopRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing l3out_static_route_next_hop updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_l3out_static_route_next_hop" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_l3out_static_route_next_hop"
+		pref = "2"
+		nexthop_profile_type = "none"
+	}
+	`)
+	return resource
+}
+
+func CreateAccL3outStaticRouteNextHopUpdatedAttr(rName, tdn, rtrId, nhAddr, attribute, value string) string {
+	fmt.Printf("=== STEP  testing l3out_static_route_next_hop attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+
+	resource "aci_logical_node_to_fabric_node" "test" {
+		logical_node_profile_dn  = aci_logical_node_profile.test.id
+		tdn  = "%s"
+		rtr_id = "%s"
+	}
+
+	resource "aci_l3out_static_route" "test" {
+		fabric_node_dn = aci_logical_node_to_fabric_node.test.id
+		ip  = "%s"
+	}
+
+	resource "aci_l3out_static_route_next_hop" "test" {
+		static_route_dn  = aci_l3out_static_route.test.id
+		nh_addr  = "%s"
+		%s = "%s"
+	}
+	`, rName, rName, rName, tdn, rtrId, rtrId, nhAddr, attribute, value)
+	return resource
+}


### PR DESCRIPTION
$ go test -v -run TestAccAciKeypairforSAMLEncryptionDataSource_Basic -timeout=60m
=== RUN   TestAccAciKeypairforSAMLEncryptionDataSource_Basic
=== STEP  testing saml_certificate Data Source with required arguments only
=== STEP  testing saml_certificate Data Source with random attribute
=== STEP  testing saml_certificate Data Source with required arguments only
=== PAUSE TestAccAciKeypairforSAMLEncryptionDataSource_Basic
=== CONT  TestAccAciKeypairforSAMLEncryptionDataSource_Basic
--- PASS: TestAccAciKeypairforSAMLEncryptionDataSource_Basic (35.62s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   39.996s
$ go test -v -run TestAccAciFabricPathEpDataSource_Basic -timeout=60m
=== RUN   TestAccAciFabricPathEpDataSource_Basic
=== STEP  Basic: testing fabric_path_ep Data Source without  pod_id
=== STEP  Basic: testing fabric_path_ep Data Source without  name
=== STEP  Basic: testing fabric_path_ep Data Source without  node_id
=== STEP  testing fabric_path_ep Data Source with required arguments only
=== STEP  testing fabric_path_ep Data Source with random attribute
=== STEP  testing fabric_path_ep Data Source with Invalid Parent Dn
=== STEP  testing fabric_path_ep Data Source with required arguments only
=== PAUSE TestAccAciFabricPathEpDataSource_Basic
=== CONT  TestAccAciFabricPathEpDataSource_Basic
--- PASS: TestAccAciFabricPathEpDataSource_Basic (93.54s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   96.063s
$ go test -v -run TestAccAciSystemDataSource_Basic -timeout=60m
=== RUN   TestAccAciSystemDataSource_Basic
=== STEP  Basic: testing system Data Source without  pod_id
=== STEP  Basic: testing system Data Source without  system_id
=== STEP  testing system Data Source with required arguments only
=== STEP  testing system Data Source with random attribute
=== STEP  testing system Data Source with invalid system id
=== STEP  testing system Data Source with required arguments only
=== PAUSE TestAccAciSystemDataSource_Basic
=== CONT  TestAccAciSystemDataSource_Basic
--- PASS: TestAccAciSystemDataSource_Basic (28.71s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   30.155s
$ go test -v -run TestAccAciFvCEpDataSource_Basic -timeout=60m
=== RUN   TestAccAciFvCEpDataSource_Basic
=== STEP  testing client_end_point Data Source with required arguments only
=== STEP  testing client_end_point Data Source with random parameters
=== STEP  testing client_end_point Data Source with required arguments only
=== PAUSE TestAccAciFvCEpDataSource_Basic
=== CONT  TestAccAciFvCEpDataSource_Basic
--- PASS: TestAccAciFvCEpDataSource_Basic (22.86s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   24.110s
$ go test -v -run TestAccAciDHCPOptionDataSource_Basic -timeout=60m
=== RUN   TestAccAciDHCPOptionDataSource_Basic
=== STEP  Basic: testing dhcp_option Data Source without  dhcp_option_policy_dn
=== STEP  Basic: testing dhcp_option Data Source without  name
=== STEP  testing dhcp_option Data Source with required arguments only
=== STEP  testing dhcp_option Data Source with random attribute
=== STEP  testing dhcp_option Data Source with invalid name
=== STEP  testing dhcp_option Data Source with updated resource
=== PAUSE TestAccAciDHCPOptionDataSource_Basic
=== CONT  TestAccAciDHCPOptionDataSource_Basic
--- PASS: TestAccAciDHCPOptionDataSource_Basic (52.55s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   54.889s
$ go test -v -run TestAccAciL3outStaticRouteNextHop -timeout=60m
=== RUN   TestAccAciL3outStaticRouteNextHopDataSource_Basic
=== STEP  Basic: testing l3out_static_route_next_hop Data Source without  nh_addr
=== STEP  Basic: testing l3out_static_route_next_hop Data Source without  static_route_dn
=== STEP  testing l3out_static_route_next_hop Data Source with required arguments only
=== STEP  testing l3out_static_route_next_hop Data Source with random attribute
=== STEP  testing l3out_static_route_next_hop Data Source with required arguments only
=== STEP  testing l3out_static_route_next_hop Data Source with updated resource
=== PAUSE TestAccAciL3outStaticRouteNextHopDataSource_Basic
=== RUN   TestAccAciL3outStaticRouteNextHop_Basic
=== STEP  Basic: testing l3out_static_route_next_hop creation without  nh_addr
=== STEP  Basic: testing l3out_static_route_next_hop creation without  static_route_dn
=== STEP  testing l3out_static_route_next_hop creation with required arguments only
=== STEP  Basic: testing l3out_static_route_next_hop creation with optional parameters
=== STEP  testing l3out_static_route_next_hop attribute: pref = 128
=== STEP  testing l3out_static_route_next_hop attribute: pref = 255
=== STEP  testing l3out_static_route_next_hop creation with invalid IP
=== STEP  Basic: testing l3out_static_route_next_hop updation without required parameters
=== STEP  testing l3out_static_route_next_hop creation with parent resource name acctest_t7zax,tdn topology/pod-1/node-201, rtr_id 20.2.85.189 and nh_addr 20.4.85.189,
=== STEP  testing l3out_static_route_next_hop creation with required arguments only
=== STEP  testing l3out_static_route_next_hop creation with parent resource name acctest_e0bqi,tdn topology/pod-1/node-201, rtr_id 20.2.85.189 and nh_addr 20.4.85.189,
=== PAUSE TestAccAciL3outStaticRouteNextHop_Basic
=== RUN   TestAccAciL3outStaticRouteNextHop_Negative
=== STEP  testing l3out_static_route_next_hop creation with required arguments only
=== STEP  testing l3out_static_route_next_hop creation with invalid parent dn
=== STEP  testing l3out_static_route_next_hop attribute: description = 47cbgydigor2hxs0ixyg1vusxkz6wwfevvrz2nz1gwl0gshzarz3vuig8hpxbayioy3v7gkrr2ccmzo9es6kglmv2fz0uqcfa94kufgrnawt2wa240j6vzkztf3nuueg4
=== STEP  testing l3out_static_route_next_hop attribute: annotation = jvcsulrdmil12yisywcygcw2a6w83sb0rntwb9yk7faqtarrife0je68b07ubt6osryudyr72rcqvirkztb7tzxzqgu9kfj3giya4m2rt8hdhha4l3ia3k92sdexkgrdd
=== STEP  testing l3out_static_route_next_hop attribute: name_alias = lrt66xne1934ocmt7go0t223rfzqwrya913dwcjkphdu3bespjc8goe0qxounyid
=== STEP  testing l3out_static_route_next_hop attribute: pref = s9cyc
=== STEP  testing l3out_static_route_next_hop attribute: pref = -1
=== STEP  testing l3out_static_route_next_hop attribute: pref = 256
=== STEP  testing l3out_static_route_next_hop attribute: nexthop_profile_type = s9cyc
=== STEP  testing l3out_static_route_next_hop attribute: yehbt = s9cyc
=== STEP  testing l3out_static_route_next_hop destroyn with required arguments only
--- PASS: TestAccAciL3outStaticRouteNextHop_MultipleCreateDelete (27.79s)
=== STEP  testing l3out_static_route_next_hop destroyreateDelete
--- PASS: TestAccAciL3outStaticRouteNextHopDataSource_Basic (53.47s) required arguments only
=== PAUSE TestAccAciL3outStaticRouteNextHop_MultipleCreateDelete
=== CONT  TestAccAciL3outStaticRouteNextHopDataSource_Basic
=== CONT  TestAccAciL3outStaticRouteNextHop_Negative
=== CONT  TestAccAciL3outStaticRouteNextHop_MultipleCreateDelete
=== CONT  TestAccAciL3outStaticRouteNextHop_Basic
=== STEP  testing l3out_static_route_next_hop destroy
--- PASS: TestAccAciL3outStaticRouteNextHop_Negative (80.62s)
=== STEP  testing l3out_static_route_next_hop destroy
--- PASS: TestAccAciL3outStaticRouteNextHop_Basic (111.37s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   112.767s
$ go test -v -run TestAccAciTopologyFabricNodeDataSource_Basic -timeout=60m
=== RUN   TestAccAciTopologyFabricNodeDataSource_Basic
=== STEP  Basic: testing fabric_node Data Source without  fabric_pod_dn
=== STEP  Basic: testing fabric_node Data Source without  fabric_node_id
=== STEP  testing fabric_node Data Source with required arguments only
=== STEP  testing fabric_node Data Source with random attribute
=== STEP  testing fabric_node Data Source with invalid fabric_node_id
=== STEP  testing fabric_node Data Source with required arguments only
=== PAUSE TestAccAciTopologyFabricNodeDataSource_Basic
=== CONT  TestAccAciTopologyFabricNodeDataSource_Basic
--- PASS: TestAccAciTopologyFabricNodeDataSource_Basic (54.74s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   57.828s
