### PR TITLE
added test file for some cloud resources

### DIFF
--- a/aci/data_source_aci_cloudctxprofile.go
+++ b/aci/data_source_aci_cloudctxprofile.go
@@ -65,7 +65,7 @@ func dataSourceAciCloudContextProfileRead(ctx context.Context, d *schema.Resourc
 
 	dn := fmt.Sprintf("%s/%s", TenantDn, rn)
 
-	cloudCtxProfile, err := getRemoteCloudContextProfile(aciClient, dn)
+	cloudCtxProfile, err := GetRemoteCloudContextProfile(aciClient, dn)
 
 	if err != nil {
 		return diag.FromErr(err)

--- a/aci/resource_aci_cloudctxprofile.go
+++ b/aci/resource_aci_cloudctxprofile.go
@@ -101,7 +101,7 @@ func resourceAciCloudContextProfile() *schema.Resource {
 	}
 }
 
-func getRemoteCloudContextProfile(client *client.Client, dn string) (*models.CloudContextProfile, error) {
+func GetRemoteCloudContextProfile(client *client.Client, dn string) (*models.CloudContextProfile, error) {
 	baseurlStr := "/api/node/mo"
 	dnUrl := fmt.Sprintf("%s/%s.json?rsp-subtree=children", baseurlStr, dn)
 	cloudCtxProfileCont, err := client.GetViaURL(dnUrl)
@@ -148,7 +148,7 @@ func resourceAciCloudContextProfileImport(d *schema.ResourceData, m interface{})
 
 	dn := d.Id()
 
-	cloudCtxProfile, err := getRemoteCloudContextProfile(aciClient, dn)
+	cloudCtxProfile, err := GetRemoteCloudContextProfile(aciClient, dn)
 
 	if err != nil {
 		return nil, err
@@ -379,7 +379,7 @@ func resourceAciCloudContextProfileRead(ctx context.Context, d *schema.ResourceD
 	aciClient := m.(*client.Client)
 
 	dn := d.Id()
-	cloudCtxProfile, err := getRemoteCloudContextProfile(aciClient, dn)
+	cloudCtxProfile, err := GetRemoteCloudContextProfile(aciClient, dn)
 
 	if err != nil {
 		return diag.FromErr(err)

--- a/testacc/data_source_aci_cloudbgpasp_test.go
+++ b/testacc/data_source_aci_cloudbgpasp_test.go
@@ -1,0 +1,54 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciAutonomousSystemProfileDataSource_Basic(t *testing.T) {
+	dataSourceName := "data.aci_autonomous_system_profile.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccAutonomousSystemProfileConfigDataSource(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(dataSourceName, "asn"),
+				),
+			},
+			{
+				Config:      CreateAccAutonomousSystemProfileDataSourceUpdate(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccAutonomousSystemProfileConfigDataSource(),
+			},
+		},
+	})
+}
+
+func CreateAccAutonomousSystemProfileConfigDataSource() string {
+	fmt.Println("=== STEP  testing autonomous_system_profile Data Source with required arguments only")
+	resource := fmt.Sprintln(`
+	data "aci_autonomous_system_profile" "test" {}
+	`)
+	return resource
+}
+
+func CreateAccAutonomousSystemProfileDataSourceUpdate(key, value string) string {
+	fmt.Println("=== STEP  testing autonomous_system_profile Data Source with random attribute")
+	resource := fmt.Sprintf(`
+
+	data "aci_autonomous_system_profile" "test" {
+		%s = "%s"
+	}
+	`, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_cloudctxprofile_test.go
+++ b/testacc/data_source_aci_cloudctxprofile_test.go
@@ -1,0 +1,228 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+const region = "us-west-1"
+
+func TestAccAciCloudContextProfileDataSource_Basic(t *testing.T) {
+	resourceName := "aci_cloud_context_profile.test"
+	dataSourceName := "data.aci_cloud_context_profile.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	cidr, _ := acctest.RandIpAddress("30.1.0.0/16")
+	cidr = fmt.Sprintf("%s/16", cidr)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudContextProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateCloudContextProfileDSWithoutRequired(rName, rName, cidr, "tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateCloudContextProfileDSWithoutRequired(rName, rName, cidr, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudContextProfileConfigDataSource(rName, rName, cidr),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "tenant_dn", resourceName, "tenant_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+			{
+				Config:      CreateAccCloudContextProfileDataSourceUpdate(rName, rName, cidr, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccCloudContextProfileDSWithInvalidName(rName, rName, cidr),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+
+			{
+				Config: CreateAccCloudContextProfileDataSourceUpdatedResource(rName, rName, cidr, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccCloudContextProfileConfigDataSource(fvTenantName, rName, cidr string) string {
+	fmt.Println("=== STEP  testing cloud_context_profile Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+
+	data "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_cloud_context_profile.test.name
+		depends_on = [ aci_cloud_context_profile.test ]
+	}
+	`, fvTenantName, rName, rName, cidr, region, cloudVendor)
+	return resource
+}
+
+func CreateCloudContextProfileDSWithoutRequired(fvTenantName, rName, cidr, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_context_profile Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%S"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	data "aci_cloud_context_profile" "test" {
+	#	tenant_dn  = aci_tenant.test.id
+		name  = aci_cloud_context_profile.test.name
+		depends_on = [ aci_cloud_context_profile.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+	#	name  = aci_cloud_context_profile.test.name
+		depends_on = [ aci_cloud_context_profile.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, rName, rName, cidr, region, cloudVendor)
+}
+
+func CreateAccCloudContextProfileDSWithInvalidName(fvTenantName, rName, cidr string) string {
+	fmt.Println("=== STEP  testing cloud_context_profile Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+
+	data "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "${aci_cloud_context_profile.test.name}_invalid"
+		depends_on = [ aci_cloud_context_profile.test ]
+	}
+	`, fvTenantName, rName, rName, cidr, region, cloudVendor)
+	return resource
+}
+
+func CreateAccCloudContextProfileDataSourceUpdate(fvTenantName, rName, cidr, key, value string) string {
+	fmt.Println("=== STEP  testing cloud_context_profile Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+
+	data "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_cloud_context_profile.test.name
+		%s = "%s"
+		depends_on = [ aci_cloud_context_profile.test ]
+	}
+	`, fvTenantName, rName, rName, cidr, region, cloudVendor, key, value)
+	return resource
+}
+
+func CreateAccCloudContextProfileDataSourceUpdatedResource(fvTenantName, rName, cidr, key, value string) string {
+	fmt.Println("=== STEP  testing cloud_context_profile Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+		%s = "%s"
+	}
+
+	data "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_cloud_context_profile.test.name
+		depends_on = [ aci_cloud_context_profile.test ]
+	}
+	`, fvTenantName, rName, rName, cidr, region, cloudVendor, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_fabricnode_test.go
+++ b/testacc/data_source_aci_fabricnode_test.go
@@ -117,27 +117,3 @@ func CreateAccTopologyFabricNodeDataSourceUpdate(podId, nodeId, key, value strin
 	`, podId, nodeId, key, value)
 	return resource
 }
-
-func CreateAccTopologyFabricNodeDataSourceUpdatedResource(fabricPodName, fabric_node_id, key, value string) string {
-	fmt.Println("=== STEP  testing fabric_node Data Source with updated resource")
-	resource := fmt.Sprintf(`
-	
-	resource "aci_fabric_pod" "test" {
-		name 		= "%s"
-	
-	}
-	
-	resource "aci_fabric_node" "test" {
-		fabric_pod_dn  = aci_fabric_pod.test.id
-		fabric_node_id  = "%s"
-		%s = "%s"
-	}
-
-	data "aci_fabric_node" "test" {
-		fabric_pod_dn  = aci_fabric_pod.test.id
-		fabric_node_id  = aci_fabric_node.test.fabric_node_id
-		depends_on = [ aci_fabric_node.test ]
-	}
-	`, fabricPodName, fabric_node_id, key, value)
-	return resource
-}

--- a/testacc/data_source_aci_fabricpathep_test.go
+++ b/testacc/data_source_aci_fabricpathep_test.go
@@ -39,6 +39,7 @@ func TestAccAciFabricPathEpDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "pod_id", podId),
 					resource.TestCheckResourceAttr(dataSourceName, "name", pathEpName),
 					resource.TestCheckResourceAttr(dataSourceName, "node_id", nodeId),
+					resource.TestCheckResourceAttrSet(dataSourceName, "vpc"),
 				),
 			},
 			{

--- a/testacc/resource_aci_cloudctxprofile_test.go
+++ b/testacc/resource_aci_cloudctxprofile_test.go
@@ -1,0 +1,623 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/terraform-providers/terraform-provider-aci/aci"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const hubNetwork = "uni/tn-infra/gwrouterp-default"
+
+func TestAccAciCloudContextProfile_Basic(t *testing.T) {
+	var cloud_context_profile_default models.CloudContextProfile
+	var cloud_context_profile_updated models.CloudContextProfile
+	resourceName := "aci_cloud_context_profile.test"
+	cidr, _ := acctest.RandIpAddress("30.2.0.0/16")
+	cidr = fmt.Sprintf("%s/16", cidr)
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudContextProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateCloudContextProfileWithoutRequired(rName, rName, cidr, "tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateCloudContextProfileWithoutRequired(rName, rName, cidr, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateCloudContextProfileWithoutRequired(rName, rName, cidr, "primary_cidr"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateCloudContextProfileWithoutRequired(rName, rName, cidr, "region"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateCloudContextProfileWithoutRequired(rName, rName, cidr, "cloud_vendor"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateCloudContextProfileWithoutRsToCtx(rName, cidr, "relation_cloud_rs_to_ctx"),
+				ExpectError: regexp.MustCompile(`Invalid Configuration`),
+			},
+			{
+				Config: CreateAccCloudContextProfileConfig(rName, rName, cidr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudContextProfileExists(resourceName, &cloud_context_profile_default),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "cloud_vendor", cloudVendor),
+					resource.TestCheckResourceAttr(resourceName, "primary_cidr", cidr),
+					resource.TestCheckResourceAttr(resourceName, "region", region),
+					resource.TestCheckResourceAttr(resourceName, "relation_cloud_rs_to_ctx", fmt.Sprintf("uni/tn-%s/ctx-%s", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "type", "regular"),
+				),
+			},
+			{
+				Config: CreateAccCloudContextProfileConfigWithOptionalValues(rName, rName, cidr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudContextProfileExists(resourceName, &cloud_context_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_cloud_context_profile"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_vendor", cloudVendor),
+					resource.TestCheckResourceAttr(resourceName, "primary_cidr", cidr),
+					resource.TestCheckResourceAttr(resourceName, "region", region),
+					resource.TestCheckResourceAttr(resourceName, "relation_cloud_rs_to_ctx", fmt.Sprintf("uni/tn-%s/ctx-%s", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "type", "shadow"),
+					resource.TestCheckResourceAttr(resourceName, "hub_network", hubNetwork),
+					testAccCheckAciCloudContextProfileIdEqual(&cloud_context_profile_default, &cloud_context_profile_updated),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"cloud_vendor", "hub_network", "relation_cloud_rs_to_ctx"},
+			},
+			{
+				Config:      CreateAccCloudContextProfileConfigUpdatedName(rName, acctest.RandString(65), cidr),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			{
+				Config:      CreateAccCloudContextProfileConfigWithInvalidCidr(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccCloudContextProfileConfigWithInvalidRegion(rName, cidr),
+				ExpectError: regexp.MustCompile(`Invalid Configuration`),
+			},
+			{
+				Config:      CreateAccCloudContextProfileConfigWithInvalidVendor(rName, cidr),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccCloudContextProfileRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudContextProfileConfigWithRequiredParams(rNameUpdated, rName, cidr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudContextProfileExists(resourceName, &cloud_context_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciCloudContextProfileIdNotEqual(&cloud_context_profile_default, &cloud_context_profile_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudContextProfileConfig(rName, rName, cidr),
+			},
+			{
+				Config: CreateAccCloudContextProfileConfigWithRequiredParams(rName, rNameUpdated, cidr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudContextProfileExists(resourceName, &cloud_context_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciCloudContextProfileIdNotEqual(&cloud_context_profile_default, &cloud_context_profile_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciCloudContextProfile_Update(t *testing.T) {
+	var cloud_context_profile_default models.CloudContextProfile
+	var cloud_context_profile_updated models.CloudContextProfile
+	resourceName := "aci_cloud_context_profile.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	cidr, _ := acctest.RandIpAddress("30.3.0.0/16")
+	cidr = fmt.Sprintf("%s/16", cidr)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudContextProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccCloudContextProfileConfig(rName, rName, cidr),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudContextProfileExists(resourceName, &cloud_context_profile_default),
+				),
+			},
+
+			{
+				Config: CreateAccCloudContextProfileUpdatedAttr(rName, rName, cidr, "type", "hosted"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudContextProfileExists(resourceName, &cloud_context_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "type", "hosted"),
+					testAccCheckAciCloudContextProfileIdEqual(&cloud_context_profile_default, &cloud_context_profile_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudContextProfileUpdatedAttr(rName, rName, cidr, "type", "container-overlay"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudContextProfileExists(resourceName, &cloud_context_profile_updated),
+					resource.TestCheckResourceAttr(resourceName, "type", "container-overlay"),
+					testAccCheckAciCloudContextProfileIdEqual(&cloud_context_profile_default, &cloud_context_profile_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudContextProfileConfig(rName, rName, cidr),
+			},
+		},
+	})
+}
+
+func TestAccAciCloudContextProfile_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	cidr, _ := acctest.RandIpAddress("30.4.0.0/16")
+	cidr = fmt.Sprintf("%s/16", cidr)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudContextProfileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccCloudContextProfileConfig(rName, rName, cidr),
+			},
+			{
+				Config:      CreateAccCloudContextProfileWithInValidParentDn(rName, cidr),
+				ExpectError: regexp.MustCompile(`Invalid DN`),
+			},
+			{
+				Config:      CreateAccCloudContextProfileUpdatedAttr(rName, rName, cidr, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccCloudContextProfileUpdatedAttr(rName, rName, cidr, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccCloudContextProfileUpdatedAttr(rName, rName, cidr, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccCloudContextProfileUpdatedAttr(rName, rName, cidr, "type", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccCloudContextProfileUpdatedAttr(rName, rName, cidr, "hub_network", randomValue),
+				ExpectError: regexp.MustCompile(`Relation target dn (.)+ not found`),
+			},
+			{
+				Config:      CreateAccCloudContextProfileUpdatedAttr(rName, rName, cidr, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccCloudContextProfileConfig(rName, rName, cidr),
+			},
+		},
+	})
+}
+
+func testAccCheckAciCloudContextProfileExists(name string, cloud_context_profile *models.CloudContextProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Cloud Context Profile %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Cloud Context Profile dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cloud_context_profileFound, err := aci.GetRemoteCloudContextProfile(client, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if cloud_context_profileFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Cloud Context Profile %s not found", rs.Primary.ID)
+		}
+		*cloud_context_profile = *cloud_context_profileFound
+		return nil
+	}
+}
+
+func testAccCheckAciCloudContextProfileDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing cloud_context_profile destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_cloud_context_profile" {
+			cont, err := client.Get(rs.Primary.ID)
+			cloud_context_profile := models.CloudContextProfileFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Cloud Context Profile %s Still exists", cloud_context_profile.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciCloudContextProfileIdEqual(m1, m2 *models.CloudContextProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("cloud_context_profile DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciCloudContextProfileIdNotEqual(m1, m2 *models.CloudContextProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("cloud_context_profile DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateCloudContextProfileWithoutRsToCtx(rName, ip, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_context_profile creation without relation_cloud_rs_to_ctx")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%s"
+	}
+	`, rName, rName, ip, region, cloudVendor)
+	return resource
+}
+
+func CreateCloudContextProfileWithoutRequired(fvTenantName, rName, ip, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_context_profile creation without ", attrName)
+	rBlock := `
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	resource "aci_cloud_context_profile" "test" {
+	#	tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+	#	name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+		`
+	case "primary_cidr":
+		rBlock += `
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	#	primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+		`
+	case "region":
+		rBlock += `
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+	#	region = "%s"
+		cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	`
+	case "cloud_vendor":
+		rBlock += `
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+	#	cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, rName, rName, ip, region, cloudVendor)
+}
+
+func CreateAccCloudContextProfileConfigWithRequiredParams(fvTenantName, rName, ip string) string {
+	fmt.Printf("=== STEP  testing cloud_context_profile creation with parent resource name %s, resource name %s and cidr %s\n", fvTenantName, rName, ip)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	`, fvTenantName, fvTenantName, rName, ip, region, cloudVendor)
+	return resource
+}
+
+func CreateAccCloudContextProfileConfigWithInvalidVendor(rName, ip string) string {
+	fmt.Println("=== STEP  testing cloud_context_profile creation with invalid cloud_vendor")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	`, rName, rName, rName, ip, region, rName)
+	return resource
+}
+
+func CreateAccCloudContextProfileConfigWithInvalidRegion(rName, ip string) string {
+	fmt.Println("=== STEP  testing cloud_context_profile creation with invalid region")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	`, rName, rName, rName, ip, rName, cloudVendor)
+	return resource
+}
+
+func CreateAccCloudContextProfileConfigWithInvalidCidr(rName string) string {
+	fmt.Println("=== STEP  testing cloud_context_profile creation with invalid primary_cidr")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	`, rName, rName, rName, rName, region, cloudVendor)
+	return resource
+}
+
+func CreateAccCloudContextProfileConfigUpdatedName(fvTenantName, rName, ip string) string {
+	fmt.Println("=== STEP  testing cloud_context_profile creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	`, fvTenantName, fvTenantName, rName, ip, region, cloudVendor)
+	return resource
+}
+
+func CreateAccCloudContextProfileConfig(fvTenantName, rName, ip string) string {
+	fmt.Println("=== STEP  testing cloud_context_profile creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	`, fvTenantName, fvTenantName, rName, ip, region, cloudVendor)
+	return resource
+}
+
+func CreateAccCloudContextProfileWithInValidParentDn(rName, ip string) string {
+	fmt.Println("=== STEP  Negative Case: testing cloud_context_profile creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_vrf.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+	}
+	`, rName, rName, rName, ip, region, cloudVendor)
+	return resource
+}
+
+func CreateAccCloudContextProfileConfigWithOptionalValues(fvTenantName, rName, ip string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_context_profile creation with optional parameters")
+	resource := fmt.Sprintf(`
+
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+		name_alias = "test_cloud_context_profile"
+		annotation = "orchestrator:terraform_testacc"
+		description = "created while acceptance testing"
+		type = "shadow"
+		hub_network = "%s"
+	}
+	`, fvTenantName, rName, rName, ip, region, cloudVendor, hubNetwork)
+
+	return resource
+}
+
+func CreateAccCloudContextProfileRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing cloud_context_profile updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_cloud_context_profile" "test" {
+		name_alias = "test_cloud_context_profile"
+		annotation = "orchestrator:terraform_testacc"
+		description = "created while acceptance testing"
+		type = "shadow"
+		hub_network = "%s"
+	}
+	`, hubNetwork)
+
+	return resource
+}
+
+func CreateAccCloudContextProfileUpdatedAttr(fvTenantName, rName, ip, attribute, value string) string {
+	fmt.Printf("=== STEP  testing cloud_context_profile attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+
+	resource "aci_vrf" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+
+	resource "aci_cloud_context_profile" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		primary_cidr = "%s"
+		region = "%s"
+		cloud_vendor = "%s"
+		relation_cloud_rs_to_ctx = aci_vrf.test.id
+		%s = "%s"
+	}
+	`, fvTenantName, fvTenantName, rName, ip, region, cloudVendor, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_ipnexthopp_test.go
+++ b/testacc/resource_aci_ipnexthopp_test.go
@@ -82,7 +82,7 @@ func TestAccAciL3outStaticRouteNextHop_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config:      CreateAccL3outStaticRouteNextHopWithInavalidIP(rName, fabDn2, rtrId),
+				Config:      CreateAccL3outStaticRouteNextHopWithInvalidIP(rName, fabDn2, rtrId),
 				ExpectError: regexp.MustCompile(`unknown property value (.)+`),
 			},
 
@@ -336,7 +336,7 @@ func CreateAccL3outStaticRouteNextHopConfigWithRequiredParams(rName, tdn, rtrId,
 	return resource
 }
 
-func CreateAccL3outStaticRouteNextHopWithInavalidIP(rName, tdn, rtrId string) string {
+func CreateAccL3outStaticRouteNextHopWithInvalidIP(rName, tdn, rtrId string) string {
 	fmt.Println("=== STEP  testing l3out_static_route_next_hop creation with invalid IP")
 	resource := fmt.Sprintf(`
 	resource "aci_tenant" "test" {


### PR DESCRIPTION
$ go test -v -run TestAccAciFabricPathEpDataSource_Basic -timeout=60m
=== RUN   TestAccAciFabricPathEpDataSource_Basic
=== STEP  Basic: testing fabric_path_ep Data Source without  pod_id
=== STEP  Basic: testing fabric_path_ep Data Source without  name
=== STEP  Basic: testing fabric_path_ep Data Source without  node_id
=== STEP  testing fabric_path_ep Data Source with required arguments only
=== STEP  testing fabric_path_ep Data Source with random attribute
=== STEP  testing fabric_path_ep Data Source with Invalid Parent Dn
=== STEP  testing fabric_path_ep Data Source with required arguments only
=== PAUSE TestAccAciFabricPathEpDataSource_Basic
=== CONT  TestAccAciFabricPathEpDataSource_Basic
--- PASS: TestAccAciFabricPathEpDataSource_Basic (51.65s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   52.952s
$ go test -v -run TestAccAciL3outStaticRouteNextHop_Basic -timeout=60m
=== RUN   TestAccAciL3outStaticRouteNextHop_Basic
=== STEP  Basic: testing l3out_static_route_next_hop creation without  nh_addr
=== STEP  Basic: testing l3out_static_route_next_hop creation without  static_route_dn
=== STEP  testing l3out_static_route_next_hop creation with required arguments only
=== STEP  Basic: testing l3out_static_route_next_hop creation with optional parameters
=== STEP  testing l3out_static_route_next_hop attribute: pref = 128
=== STEP  testing l3out_static_route_next_hop attribute: pref = 255
=== STEP  testing l3out_static_route_next_hop creation with invalid IP
=== STEP  Basic: testing l3out_static_route_next_hop updation without required parameters
=== STEP  testing l3out_static_route_next_hop creation with parent resource name acctest_2igoa,tdn topology/pod-1/node-201, rtr_id 20.2.37.193 and nh_addr 20.4.37.193,
=== STEP  testing l3out_static_route_next_hop creation with required arguments only
=== STEP  testing l3out_static_route_next_hop creation with parent resource name acctest_nwx6i,tdn topology/pod-1/node-201, rtr_id 20.2.37.193 and nh_addr 20.4.37.193,
=== PAUSE TestAccAciL3outStaticRouteNextHop_Basic
=== CONT  TestAccAciL3outStaticRouteNextHop_Basic
=== STEP  testing l3out_static_route_next_hop destroy
--- PASS: TestAccAciL3outStaticRouteNextHop_Basic (138.42s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   140.894s
=== RUN   TestAccAciCloudContextProfileDataSource_Basic
=== STEP  Basic: testing cloud_context_profile Data Source without  tenant_dn
=== STEP  Basic: testing cloud_context_profile Data Source without  name
=== STEP  testing cloud_context_profile Data Source with required arguments only
=== STEP  testing cloud_context_profile Data Source with random attribute
=== STEP  testing cloud_context_profile Data Source with invalid name
=== STEP  testing cloud_context_profile Data Source with updated resource
=== PAUSE TestAccAciCloudContextProfileDataSource_Basic
=== RUN   TestAccAciCloudContextProfile_Basic
=== STEP  Basic: testing cloud_context_profile creation without  tenant_dn
=== STEP  Basic: testing cloud_context_profile creation without  name
=== STEP  Basic: testing cloud_context_profile creation without  primary_cidr
=== STEP  Basic: testing cloud_context_profile creation without  region
=== STEP  Basic: testing cloud_context_profile creation without  cloud_vendor
=== STEP  Basic: testing cloud_context_profile creation without relation_cloud_rs_to_ctx
=== STEP  testing cloud_context_profile creation with required arguments only
=== STEP  Basic: testing cloud_context_profile creation with optional parameters
=== STEP  testing cloud_context_profile creation with invalid name =  uv6pveqw19oofwvy1pw278dpes0aga1hu770ozm12tq4coclnxspyvf0frnp6zint
=== STEP  testing cloud_context_profile creation with invalid primary_cidr
=== STEP  testing cloud_context_profile creation with invalid region
=== STEP  testing cloud_context_profile creation with invalid cloud_vendor
=== STEP  Basic: testing cloud_context_profile updation without required parameters
=== STEP  testing cloud_context_profile creation with parent resource name acctest_3rx7s, resource name acctest_uxppy and cidr 30.2.255.107/16
=== STEP  testing cloud_context_profile creation with required arguments only
=== STEP  testing cloud_context_profile creation with parent resource name acctest_uxppy, resource name acctest_3rx7s and cidr 30.2.255.107/16
=== PAUSE TestAccAciCloudContextProfile_Basic
=== RUN   TestAccAciCloudContextProfile_Update
=== STEP  testing cloud_context_profile creation with required arguments only
=== STEP  testing cloud_context_profile attribute: type = hosted
=== STEP  testing cloud_context_profile attribute: type = container-overlay
=== STEP  testing cloud_context_profile creation with required arguments only
=== PAUSE TestAccAciCloudContextProfile_Update
=== RUN   TestAccAciCloudContextProfile_Negative
=== STEP  testing cloud_context_profile creation with required arguments only
=== STEP  Negative Case: testing cloud_context_profile creation with invalid parent Dn
=== STEP  testing cloud_context_profile attribute: description = or97ieg0cvammorazrj9fuzjjqag3ma1yhq03ejun7ctlf0bwoo8k7jwb0f6fu8u37fobd4xlxm6whzw4z4c2skvbwz2vpm81ybzc4mvf2o74zcvcntx9ymkrgx3mx0qz
=== STEP  testing cloud_context_profile attribute: annotation = ahfqr90ncccugchlibsg4ur37lsosslwp240fqv1sf6ti0zmqxsk2xp6jmlbia8srfaxm7ho0k60428nmgpqwvibqrg372dqpxfbore9d7rf7dp02rw78pkmq0u48xvg8
=== STEP  testing cloud_context_profile attribute: name_alias = 3do0uw9dmyagzh0wryiimz9rbuquxfiiwjlvh99c8guj3ml8nwqy8j4id8oflvgg
=== STEP  testing cloud_context_profile attribute: type = j8pxa
=== STEP  testing cloud_context_profile attribute: hub_network = j8pxa
=== STEP  testing cloud_context_profile attribute: vcass = j8pxa
=== STEP  testing cloud_context_profile creation with required arguments only
=== PAUSE TestAccAciCloudContextProfile_Negative
=== CONT  TestAccAciCloudContextProfileDataSource_Basic
=== CONT  TestAccAciCloudContextProfile_Update
=== CONT  TestAccAciCloudContextProfile_Negative
=== CONT  TestAccAciCloudContextProfile_Basic
=== STEP  testing cloud_context_profile destroy
--- PASS: TestAccAciCloudContextProfileDataSource_Basic (145.97s)
=== STEP  testing cloud_context_profile destroy
--- PASS: TestAccAciCloudContextProfile_Update (203.44s)
=== STEP  testing cloud_context_profile destroy
--- PASS: TestAccAciCloudContextProfile_Negative (207.04s)
=== STEP  testing cloud_context_profile destroy
--- PASS: TestAccAciCloudContextProfile_Basic (368.92s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   372.208s
=== RUN   TestAccAciAutonomousSystemProfileDataSource_Basic
=== STEP  testing autonomous_system_profile Data Source with required arguments only
=== STEP  testing autonomous_system_profile Data Source with random attribute
=== STEP  testing autonomous_system_profile Data Source with required arguments only
=== PAUSE TestAccAciAutonomousSystemProfileDataSource_Basic
=== CONT  TestAccAciAutonomousSystemProfileDataSource_Basic
--- PASS: TestAccAciAutonomousSystemProfileDataSource_Basic (50.57s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   53.545s