### PR TITLE
Added Ranges and Vmm Controller

### DIFF
--- a/aci/resource_aci_vmmctrlrp.go
+++ b/aci/resource_aci_vmmctrlrp.go
@@ -362,6 +362,10 @@ func resourceAciVMMControllerCreate(ctx context.Context, d *schema.ResourceData,
 		for _, val := range MsftConfigIssues.([]interface{}) {
 			msftConfigIssuesList = append(msftConfigIssuesList, val.(string))
 		}
+		err := checkDuplicate(msftConfigIssuesList)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 		MsftConfigIssues := strings.Join(msftConfigIssuesList, ",")
 		vmmCtrlrPAttr.MsftConfigIssues = MsftConfigIssues
 	}
@@ -590,6 +594,10 @@ func resourceAciVMMControllerUpdate(ctx context.Context, d *schema.ResourceData,
 		msftConfigIssuesList := make([]string, 0, 1)
 		for _, val := range MsftConfigIssues.([]interface{}) {
 			msftConfigIssuesList = append(msftConfigIssuesList, val.(string))
+		}
+		err := checkDuplicate(msftConfigIssuesList)
+		if err != nil {
+			return diag.FromErr(err)
 		}
 		MsftConfigIssues := strings.Join(msftConfigIssuesList, ",")
 		vmmCtrlrPAttr.MsftConfigIssues = MsftConfigIssues

--- a/testacc/data_source_aci_fvnsencapblk_test.go
+++ b/testacc/data_source_aci_fvnsencapblk_test.go
@@ -1,0 +1,218 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciRangesDataSource_Basic(t *testing.T) {
+	resourceName := "aci_ranges.test"
+	dataSourceName := "data.aci_ranges.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	from := strconv.Itoa(acctest.RandIntRange(1, 10))
+	to := strconv.Itoa(acctest.RandIntRange(11, 20))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciRangesDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateRangesDSWithoutRequired(rName, from, to, "vlan_pool_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateRangesDSWithoutRequired(rName, from, to, "from"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateRangesDSWithoutRequired(rName, from, to, "to"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccRangesConfigDataSource(rName, from, to),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "from", resourceName, "from"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "to", resourceName, "to"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "alloc_mode", resourceName, "alloc_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "vlan_pool_dn", resourceName, "vlan_pool_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "role", resourceName, "role"),
+				),
+			},
+			{
+				Config:      CreateAccRangesDataSourceUpdate(rName, from, to, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccRangesDSWithInvalidName(rName, from, to),
+				ExpectError: regexp.MustCompile(`Invalid RN`),
+			},
+			{
+				Config: CreateAccRangesDataSourceUpdatedResource(rName, from, to, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccRangesConfigDataSource(rName, from, to string) string {
+	fmt.Println("=== STEP  testing ranges Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_vlan_pool" "test" {
+		name = "%s"
+		alloc_mode = "dynamic"
+	}	
+	
+	resource "aci_ranges" "test" {
+		vlan_pool_dn = aci_vlan_pool.test.id
+		from  = "vlan-%s"
+		to  = "vlan-%s"
+	}
+
+	data "aci_ranges" "test" {
+		vlan_pool_dn = aci_ranges.test.vlan_pool_dn
+		from  = aci_ranges.test.from
+		to  = aci_ranges.test.to
+		depends_on = [ aci_ranges.test ]
+	}
+	`, rName, from, to)
+	return resource
+}
+
+func CreateRangesDSWithoutRequired(rName, from, to, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing ranges Data Source without ", attrName)
+	rBlock := `
+
+	resource "aci_vlan_pool" "test" {
+		name = "%s"
+		alloc_mode = "dynamic"
+	}
+
+	resource "aci_ranges" "test" {
+		vlan_pool_dn = aci_vlan_pool.test.id
+		from  = "vlan-%s"
+		to  = "vlan-%s"
+	}
+	`
+	switch attrName {
+	case "from":
+		rBlock += `
+	data "aci_ranges" "test" {
+		vlan_pool_dn = aci_ranges.test.vlan_pool_dn
+	#	from  = aci_ranges.test.from
+		to  = aci_ranges.test.to
+		depends_on = [ aci_ranges.test ]
+	}
+		`
+	case "to":
+		rBlock += `
+	data "aci_ranges" "test" {
+		vlan_pool_dn = aci_ranges.test.vlan_pool_dn
+		from  = aci_ranges.test.from
+	#	to  = aci_ranges.test.to
+		depends_on = [ aci_ranges.test ]
+	}
+	`
+	case "vlan_pool_dn":
+		rBlock += `
+	data "aci_ranges" "test" {
+	#	vlan_pool_dn = aci_ranges.test.vlan_pool_dn
+		from  = aci_ranges.test.from
+		to  = aci_ranges.test.to
+		depends_on = [ aci_ranges.test ]
+	}
+	`
+	}
+	return fmt.Sprintf(rBlock, rName, from, to)
+}
+
+func CreateAccRangesDSWithInvalidName(rName, from, to string) string {
+	fmt.Println("=== STEP  testing ranges Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_vlan_pool" "test" {
+		name = "%s"
+		alloc_mode = "dynamic"
+	}
+
+	resource "aci_ranges" "test" {
+		vlan_pool_dn = aci_vlan_pool.test.id
+		from  = "vlan-%s"
+		to  = "vlan-%s"
+	}
+
+	data "aci_ranges" "test" {
+		vlan_pool_dn = "${aci_ranges.test.vlan_pool_dn}_invalid"
+		from  = aci_ranges.test.from
+		to  = aci_ranges.test.to
+		depends_on = [ aci_ranges.test ]
+	}
+	`, rName, from, to)
+	return resource
+}
+
+func CreateAccRangesDataSourceUpdate(rName, from, to, key, value string) string {
+	fmt.Println("=== STEP  testing ranges Data Source with random attribute")
+	resource := fmt.Sprintf(`
+
+	resource "aci_vlan_pool" "test" {
+		name = "%s"
+		alloc_mode = "dynamic"
+	}
+
+	resource "aci_ranges" "test" {
+		vlan_pool_dn = aci_vlan_pool.test.id
+		from  = "vlan-%s"
+		to  = "vlan-%s"
+	}
+
+	data "aci_ranges" "test" {
+		vlan_pool_dn = aci_ranges.test.vlan_pool_dn
+		from  = aci_ranges.test.from
+		to  = aci_ranges.test.to
+		%s = "%s"
+		depends_on = [ aci_ranges.test ]
+	}
+	`, rName, from, to, key, value)
+	return resource
+}
+
+func CreateAccRangesDataSourceUpdatedResource(rName, from, to, key, value string) string {
+	fmt.Println("=== STEP  testing ranges Data Source with updated resource")
+	resource := fmt.Sprintf(`
+
+	resource "aci_vlan_pool" "test" {
+		name = "%s"
+		alloc_mode = "dynamic"
+	}
+
+	resource "aci_ranges" "test" {
+		vlan_pool_dn = aci_vlan_pool.test.id
+		from  = "vlan-%s"
+		to  = "vlan-%s"
+		%s = "%s"
+	}
+
+	data "aci_ranges" "test" {
+		vlan_pool_dn = aci_ranges.test.vlan_pool_dn
+		from  = aci_ranges.test.from
+		to  = aci_ranges.test.to
+		depends_on = [ aci_ranges.test ]
+	}
+	`, rName, from, to, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_vmmctrlrp_test.go
+++ b/testacc/data_source_aci_vmmctrlrp_test.go
@@ -1,0 +1,222 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciVMMControllerDataSource_Basic(t *testing.T) {
+	resourceName := "aci_vmm_controller.test"
+	dataSourceName := "data.aci_vmm_controller.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	ip, _ := acctest.RandIpAddress("10.2.0.0/16")
+	rootContName := makeTestVariable(acctest.RandString(5))
+	vmmDomPName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVMMControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateVMMControllerDSWithoutRequired(vmmDomPName, rName, ip, rootContName, "vmm_domain_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateVMMControllerDSWithoutRequired(vmmDomPName, rName, ip, rootContName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccVMMControllerConfigDataSource(vmmDomPName, rName, ip, rootContName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "vmm_domain_dn", resourceName, "vmm_domain_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "dvs_version", resourceName, "dvs_version"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "host_or_ip", resourceName, "host_or_ip"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "inventory_trig_st", resourceName, "inventory_trig_st"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "mode", resourceName, "mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "msft_config_err_msg", resourceName, "msft_config_err_msg"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "msft_config_issues.#", resourceName, "msft_config_issues.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "msft_config_issues.0", resourceName, "msft_config_issues.0"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "n1kv_stats_mode", resourceName, "n1kv_stats_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "port", resourceName, "port"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "root_cont_name", resourceName, "root_cont_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "scope", resourceName, "scope"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "seq_num", resourceName, "seq_num"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "stats_mode", resourceName, "stats_mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "vxlan_depl_pref", resourceName, "vxlan_depl_pref"),
+				),
+			},
+			{
+				Config:      CreateAccVMMControllerDataSourceUpdate(vmmDomPName, rName, ip, rootContName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccVMMControllerDSWithInvalidParentDn(vmmDomPName, rName, ip, rootContName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccVMMControllerDataSourceUpdatedResource(vmmDomPName, rName, ip, rootContName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccVMMControllerConfigDataSource(vmmDomPName, rName, ip, rootContName string) string {
+	fmt.Println("=== STEP  testing vmm_controller Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "%v"
+	}
+	
+	resource "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+		host_or_ip = "%s"
+		root_cont_name = "%s"
+	}
+
+	data "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = aci_vmm_controller.test.name
+		host_or_ip  = aci_vmm_controller.test.host_or_ip
+		root_cont_name  = aci_vmm_controller.test.root_cont_name
+		depends_on = [ aci_vmm_controller.test ]
+	}
+	`, vmmDomPName, providerProfileDn, rName, ip, rootContName)
+	return resource
+}
+
+func CreateVMMControllerDSWithoutRequired(vmmDomPName, rName, ip, rootContName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing vmm_controller Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "%v"
+	}
+	
+	resource "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+		host_or_ip = "%s"
+		root_cont_name = "%s"
+	}
+	`
+	switch attrName {
+	case "vmm_domain_dn":
+		rBlock += `
+		data "aci_vmm_controller" "test" {
+		#	vmm_domain_dn  = aci_vmm_domain.test.id
+			name  = aci_vmm_controller.test.name
+			host_or_ip  = aci_vmm_controller.test.host_or_ip
+			root_cont_name  = aci_vmm_controller.test.root_cont_name
+			depends_on = [ aci_vmm_controller.test ]
+		}
+		`
+	case "name":
+		rBlock += `
+		data "aci_vmm_controller" "test" {
+			vmm_domain_dn  = aci_vmm_domain.test.id
+		#	name  = aci_vmm_controller.test.name
+			host_or_ip  = aci_vmm_controller.test.host_or_ip
+			root_cont_name  = aci_vmm_controller.test.root_cont_name
+			depends_on = [ aci_vmm_controller.test ]
+		}
+		`
+	}
+	return fmt.Sprintf(rBlock, vmmDomPName, providerProfileDn, rName, ip, rootContName)
+}
+
+func CreateAccVMMControllerDSWithInvalidParentDn(vmmDomPName, rName, ip, rootContName string) string {
+	fmt.Println("=== STEP  testing vmm_controller Data Source with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "%v"
+	}
+	
+	resource "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+		host_or_ip = "%s"
+		root_cont_name = "%s"
+	}
+
+	data "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "${aci_vmm_controller.test.name}_invalid"
+		host_or_ip  = aci_vmm_controller.test.host_or_ip
+		root_cont_name  = aci_vmm_controller.test.root_cont_name
+		depends_on = [ aci_vmm_controller.test ]
+	}
+	`, vmmDomPName, providerProfileDn, rName, ip, rootContName)
+	return resource
+}
+
+func CreateAccVMMControllerDataSourceUpdate(vmmDomPName, rName, ip, rootContName, key, value string) string {
+	fmt.Println("=== STEP  testing vmm_controller Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "%v"
+	}
+	
+	resource "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+		host_or_ip = "%s"
+		root_cont_name = "%s"
+	}
+
+	data "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = aci_vmm_controller.test.name
+		%s = "%s"
+		depends_on = [ aci_vmm_controller.test ]
+	}
+	`, vmmDomPName, providerProfileDn, rName, ip, rootContName, key, value)
+	return resource
+}
+
+func CreateAccVMMControllerDataSourceUpdatedResource(vmmDomPName, rName, ip, rootContName, key, value string) string {
+	fmt.Println("=== STEP  testing vmm_controller Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "%v"
+	}
+	
+	resource "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+		host_or_ip = "%s"
+		root_cont_name = "%s"
+		%s = "%s"
+	}
+
+	data "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = aci_vmm_controller.test.name
+		host_or_ip  = aci_vmm_controller.test.host_or_ip
+		root_cont_name  = aci_vmm_controller.test.root_cont_name
+		depends_on = [ aci_vmm_controller.test ]
+	}
+	`, vmmDomPName, providerProfileDn, rName, ip, rootContName, key, value)
+	return resource
+}

--- a/testacc/resource_aci_fvnsencapblk_test.go
+++ b/testacc/resource_aci_fvnsencapblk_test.go
@@ -1,0 +1,469 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciRanges_Basic(t *testing.T) {
+	var ranges_default models.Ranges
+	var ranges_updated models.Ranges
+	resourceName := "aci_ranges.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	from := strconv.Itoa(acctest.RandIntRange(1, 5))
+	fromUpdated := strconv.Itoa(acctest.RandIntRange(5, 10))
+	to := strconv.Itoa(acctest.RandIntRange(11, 15))
+	toUpdated := strconv.Itoa(acctest.RandIntRange(15, 20))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciRangesDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateRangesWithoutRequired(rName, from, to, "vlan_pool_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateRangesWithoutRequired(rName, from, to, "from"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateRangesWithoutRequired(rName, from, to, "to"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccRangesConfig(rName, from, to),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRangesExists(resourceName, &ranges_default),
+					resource.TestCheckResourceAttr(resourceName, "vlan_pool_dn", fmt.Sprintf("uni/infra/vlanns-[%s]-dynamic", rName)),
+					resource.TestCheckResourceAttr(resourceName, "from", fmt.Sprintf("vlan-%s", from)),
+					resource.TestCheckResourceAttr(resourceName, "to", fmt.Sprintf("vlan-%s", to)),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "alloc_mode", "inherit"),
+					resource.TestCheckResourceAttr(resourceName, "role", "external"),
+				),
+			},
+			{
+				Config: CreateAccRangesConfigWithOptionalValues(rName, from, to),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRangesExists(resourceName, &ranges_updated),
+					resource.TestCheckResourceAttr(resourceName, "vlan_pool_dn", fmt.Sprintf("uni/infra/vlanns-[%s]-dynamic", rName)),
+					resource.TestCheckResourceAttr(resourceName, "from", fmt.Sprintf("vlan-%s", from)),
+					resource.TestCheckResourceAttr(resourceName, "to", fmt.Sprintf("vlan-%s", to)),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_ranges"),
+					resource.TestCheckResourceAttr(resourceName, "alloc_mode", "dynamic"),
+					resource.TestCheckResourceAttr(resourceName, "role", "internal"),
+					testAccCheckAciRangesIdEqual(&ranges_default, &ranges_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccRangesRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccRangesConfigWithRequiredParams(rNameUpdated, from, to),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRangesExists(resourceName, &ranges_updated),
+					resource.TestCheckResourceAttr(resourceName, "vlan_pool_dn", fmt.Sprintf("uni/infra/vlanns-[%s]-dynamic", rNameUpdated)),
+					testAccCheckAciRangesIdNotEqual(&ranges_default, &ranges_updated),
+				),
+			},
+			{
+				Config: CreateAccRangesConfig(rName, from, to),
+			},
+			{
+				Config: CreateAccRangesConfigWithRequiredParams(rName, fromUpdated, to),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRangesExists(resourceName, &ranges_updated),
+					resource.TestCheckResourceAttr(resourceName, "from", fmt.Sprintf("vlan-%s", fromUpdated)),
+					testAccCheckAciRangesIdNotEqual(&ranges_default, &ranges_updated),
+				),
+			},
+			{
+				Config: CreateAccRangesConfig(rName, from, to),
+			},
+			{
+				Config: CreateAccRangesConfigWithRequiredParams(rName, from, toUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRangesExists(resourceName, &ranges_updated),
+					resource.TestCheckResourceAttr(resourceName, "to", fmt.Sprintf("vlan-%s", toUpdated)),
+					testAccCheckAciRangesIdNotEqual(&ranges_default, &ranges_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciRanges_Update(t *testing.T) {
+	var ranges_default models.Ranges
+	var ranges_updated models.Ranges
+	resourceName := "aci_ranges.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	from := strconv.Itoa(acctest.RandIntRange(1, 10))
+	to := strconv.Itoa(acctest.RandIntRange(11, 20))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciRangesDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccRangesConfig(rName, from, to),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRangesExists(resourceName, &ranges_default),
+				),
+			},
+			{
+				Config: CreateAccRangesUpdatedAttr(rName, from, to, "alloc_mode", "static"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRangesExists(resourceName, &ranges_updated),
+					resource.TestCheckResourceAttr(resourceName, "alloc_mode", "static"),
+					testAccCheckAciRangesIdEqual(&ranges_default, &ranges_updated),
+				),
+			},
+			{
+				Config: CreateAccRangesConfig(rName, from, to),
+			},
+		},
+	})
+}
+
+func TestAccAciRanges_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	from := strconv.Itoa(acctest.RandIntRange(1, 10))
+	to := strconv.Itoa(acctest.RandIntRange(11, 20))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciRangesDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccRangesConfig(rName, from, to),
+			},
+			{
+				Config:      CreateAccRangesWithInvalidVlanPoolDn(rName, from, to),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccRangesConfig(rName, randomValue, to),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccRangesConfig(rName, from, randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccRangesConfig(rName, to, from),
+				ExpectError: regexp.MustCompile(`Range (.)* is invalid. From value cannot be larger than To value`),
+			},
+			{
+				Config:      CreateAccRangesUpdatedAttr(rName, from, to, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccRangesUpdatedAttr(rName, from, to, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccRangesUpdatedAttr(rName, from, to, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccRangesUpdatedAttr(rName, from, to, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccRangesUpdatedAttr(rName, from, to, "alloc_mode", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccRangesUpdatedAttr(rName, from, to, "role", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccRangesUpdatedAttr(rName, from, to, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccRangesConfig(rName, from, to),
+			},
+		},
+	})
+}
+
+func TestAccAciRanges_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciRangesDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccRangesConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciRangesExists(name string, ranges *models.Ranges) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Ranges %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Ranges dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		rangesFound := models.RangesFromContainer(cont)
+		if rangesFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Ranges %s not found", rs.Primary.ID)
+		}
+		*ranges = *rangesFound
+		return nil
+	}
+}
+
+func testAccCheckAciRangesDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing ranges destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_ranges" {
+			cont, err := client.Get(rs.Primary.ID)
+			ranges := models.RangesFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Ranges %s Still exists", ranges.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciRangesIdEqual(m1, m2 *models.Ranges) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("ranges DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciRangesIdNotEqual(m1, m2 *models.Ranges) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("ranges DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateRangesWithoutRequired(rName, from, to, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing ranges creation without ", attrName)
+	rBlock := `
+	resource "aci_vlan_pool" "test" {
+		name = "%s"
+		alloc_mode = "dynamic"
+	}	
+	`
+	switch attrName {
+	case "vlan_pool_dn":
+		rBlock += `
+	resource "aci_ranges" "test" {
+	#    vlan_pool_dn = aci_vlan_pool.test.id
+		from  = "vlan-%s"
+		to  = "vlan-%s"
+	}
+	`
+	case "from":
+		rBlock += `
+	resource "aci_ranges" "test" {
+		vlan_pool_dn = aci_vlan_pool.test.id
+	#	from  = "vlan-%s"
+		to  = "vlan-%s"
+	}
+	`
+	case "to":
+		rBlock += `
+	resource "aci_ranges" "test" {
+		vlan_pool_dn = aci_vlan_pool.test.id
+		from  = "vlan-%s"
+	#	to  = "vlan-%s"
+	}
+	`
+	}
+	return fmt.Sprintf(rBlock, rName, from, to)
+}
+
+func CreateAccRangesConfigWithRequiredParams(rName, from, to string) string {
+	fmt.Println("=== STEP  testing ranges creation with updated Required arguments")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vlan_pool" "test" {
+		name = "%s"
+		alloc_mode = "dynamic"
+	}	
+	
+	resource "aci_ranges" "test" {
+		vlan_pool_dn = aci_vlan_pool.test.id
+		from  = "vlan-%s"
+		to  = "vlan-%s"
+	}
+	`, rName, from, to)
+	return resource
+}
+
+func CreateAccRangesConfig(rName, from, to string) string {
+	fmt.Println("=== STEP  testing ranges creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vlan_pool" "test" {
+		name = "%s"
+		alloc_mode = "dynamic"
+	}	
+	
+	resource "aci_ranges" "test" {
+		vlan_pool_dn = aci_vlan_pool.test.id
+		from  = "vlan-%s"
+		to  = "vlan-%s"
+	}
+	`, rName, from, to)
+	return resource
+}
+
+func CreateAccRangesWithInvalidVlanPoolDn(rName, from, to string) string {
+	fmt.Println("=== STEP  testing ranges creation with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}	
+	
+	resource "aci_ranges" "test" {
+		vlan_pool_dn = aci_tenant.test.id
+		from  = "vlan-%s"
+		to  = "vlan-%s"
+	}
+	`, rName, from, to)
+	return resource
+}
+
+func CreateAccRangesConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple ranges creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_vlan_pool" "test" {
+		name = "%s"
+		alloc_mode = "dynamic"
+	}	
+	
+	resource "aci_ranges" "test" {
+		vlan_pool_dn = aci_vlan_pool.test.id
+		from  = "vlan-1"
+		to  = "vlan-2"
+	}
+	
+	resource "aci_ranges" "test1" {
+		vlan_pool_dn = aci_vlan_pool.test.id
+		from  = "vlan-3"
+		to  = "vlan-4"
+	}
+
+	resource "aci_ranges" "test2" {
+		vlan_pool_dn = aci_vlan_pool.test.id
+		from  = "vlan-5"
+		to  = "vlan-6"
+	}
+
+	resource "aci_ranges" "test3" {
+		vlan_pool_dn = aci_vlan_pool.test.id
+		from  = "vlan-7"
+		to  = "vlan-8"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccRangesConfigWithOptionalValues(rName, from, to string) string {
+	fmt.Println("=== STEP  Basic: testing ranges creation with optional parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_vlan_pool" "test" {
+		name = "%s"
+		alloc_mode = "dynamic"
+	}	
+	
+	resource "aci_ranges" "test" {
+		vlan_pool_dn = aci_vlan_pool.test.id
+		from  = "vlan-%s"
+		to  = "vlan-%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_ranges"
+		alloc_mode = "dynamic"
+		role = "internal"
+	}
+	`, rName, from, to)
+
+	return resource
+}
+
+func CreateAccRangesRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing ranges updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_ranges" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_ranges"
+		alloc_mode = "dynamic"
+		role = "internal"		
+	}
+	`)
+	return resource
+}
+
+func CreateAccRangesUpdatedAttr(rName, from, to, attribute, value string) string {
+	fmt.Printf("=== STEP  testing ranges attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_vlan_pool" "test" {
+		name = "%s"
+		alloc_mode = "dynamic"
+	}	
+	
+	resource "aci_ranges" "test" {
+		vlan_pool_dn = aci_vlan_pool.test.id
+		from  = "vlan-%s"
+		to  = "vlan-%s"
+		%s = "%s"
+	}
+	`, rName, from, to, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_vmmctrlrp_test.go
+++ b/testacc/resource_aci_vmmctrlrp_test.go
@@ -1,0 +1,603 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciVMMController_Basic(t *testing.T) {
+	var vmm_controller_default models.VMMController
+	var vmm_controller_updated models.VMMController
+	resourceName := "aci_vmm_controller.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	ip, _ := acctest.RandIpAddress("10.0.0.0/16")
+	ipUpdated, _ := acctest.RandIpAddress("10.0.0.0/16")
+	rootContName := makeTestVariable(acctest.RandString(5))
+	rootContNameUpdated := makeTestVariable(acctest.RandString(5))
+	vmmDomPName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVMMControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateVMMControllerWithoutRequired(vmmDomPName, rName, ip, rootContName, "vmm_domain_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateVMMControllerWithoutRequired(vmmDomPName, rName, ip, rootContName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateVMMControllerWithoutRequired(vmmDomPName, rName, ip, rootContName, "host_or_ip"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateVMMControllerWithoutRequired(vmmDomPName, rName, ip, rootContName, "root_cont_name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccVMMControllerConfig(vmmDomPName, rName, ip, rootContName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVMMControllerExists(resourceName, &vmm_controller_default),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("%v/dom-%s", providerProfileDn, vmmDomPName)),
+					resource.TestCheckResourceAttr(resourceName, "host_or_ip", ip),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "root_cont_name", rootContName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "dvs_version", "unmanaged"),
+					resource.TestCheckResourceAttr(resourceName, "mode", "default"),
+					resource.TestCheckResourceAttr(resourceName, "msft_config_err_msg", ""),
+					resource.TestCheckResourceAttr(resourceName, "msft_config_issues.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "msft_config_issues.0", ""),
+					resource.TestCheckResourceAttr(resourceName, "n1kv_stats_mode", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "port", "0"),
+					resource.TestCheckResourceAttr(resourceName, "scope", "vm"),
+					resource.TestCheckResourceAttr(resourceName, "seq_num", "0"),
+					resource.TestCheckResourceAttr(resourceName, "stats_mode", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "vxlan_depl_pref", "vxlan"),
+				),
+			},
+			{
+				Config: CreateAccVMMControllerConfigWithOptionalValues(vmmDomPName, rNameUpdated, ip, rootContName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVMMControllerExists(resourceName, &vmm_controller_updated),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("%v/dom-%s", providerProfileDn, vmmDomPName)),
+					resource.TestCheckResourceAttr(resourceName, "host_or_ip", ip),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "root_cont_name", rootContName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_vmm_controller"),
+					resource.TestCheckResourceAttr(resourceName, "dvs_version", "5.1"),
+					resource.TestCheckResourceAttr(resourceName, "inventory_trig_st", "autoTriggered"),
+					resource.TestCheckResourceAttr(resourceName, "mode", "cf"),
+					resource.TestCheckResourceAttr(resourceName, "msft_config_err_msg", "Error"),
+					resource.TestCheckResourceAttr(resourceName, "msft_config_issues.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "msft_config_issues.0", "aaacert-invalid"),
+					resource.TestCheckResourceAttr(resourceName, "n1kv_stats_mode", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "port", "1"),
+					resource.TestCheckResourceAttr(resourceName, "scope", "MicrosoftSCVMM"),
+					resource.TestCheckResourceAttr(resourceName, "stats_mode", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "vxlan_depl_pref", "nsx"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"inventory_trig_st"},
+			},
+			{
+				Config:      CreateAccVMMControllerConfigUpdatedName(vmmDomPName, acctest.RandString(65), ip, rootContName),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccVMMControllerRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccVMMControllerConfigWithRequiredParams(rNameUpdated, rName, ip, rootContName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVMMControllerExists(resourceName, &vmm_controller_updated),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("%v/dom-%s", providerProfileDn, rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciVMMControllerIdNotEqual(&vmm_controller_default, &vmm_controller_updated),
+				),
+			},
+			{
+				Config: CreateAccVMMControllerConfig(vmmDomPName, rName, ip, rootContName),
+			},
+			{
+				Config: CreateAccVMMControllerConfigWithRequiredParams(vmmDomPName, rNameUpdated, ipUpdated, rootContNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVMMControllerExists(resourceName, &vmm_controller_updated),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("%v/dom-%s", providerProfileDn, vmmDomPName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "ip", ipUpdated),
+					resource.TestCheckResourceAttr(resourceName, "root_cont_name", rootContNameUpdated),
+					testAccCheckAciVMMControllerIdNotEqual(&vmm_controller_default, &vmm_controller_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciVMMController_Update(t *testing.T) {
+	var vmm_controller_default models.VMMController
+	var vmm_controller_updated models.VMMController
+	resourceName := "aci_vmm_controller.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	ip, _ := acctest.RandIpAddress("10.1.0.0/16")
+	rootContName := makeTestVariable(acctest.RandString(5))
+	vmmDomPName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVMMControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccVMMControllerConfig(vmmDomPName, rName, ip, rootContName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVMMControllerExists(resourceName, &vmm_controller_default),
+				),
+			},
+			{
+				Config: CreateAccVMMControllerUpdatedAttr(vmmDomPName, rName, ip, rootContName, "mode", "unknown"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVMMControllerExists(resourceName, &vmm_controller_updated),
+					resource.TestCheckResourceAttr(resourceName, "mode", "unknown"),
+					testAccCheckAciVMMControllerIdEqual(&vmm_controller_default, &vmm_controller_updated),
+				),
+			},
+			{
+				Config: CreateAccVMMControllerUpdatedAttrList(vmmDomPName, rName, ip, rootContName, "msft_config_issues", StringListtoString([]string{"aaacert-invalid", "duplicate-mac-in-inventory", "duplicate-rootContName", "invalid-object-in-inventory", "invalid-rootContName", "inventory-failed", "missing-hostGroup-in-cloud", "missing-rootContName", "zero-mac-in-inventory"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVMMControllerExists(resourceName, &vmm_controller_updated),
+					resource.TestCheckResourceAttr(resourceName, "msft_config_issues.#", "9"),
+					resource.TestCheckResourceAttr(resourceName, "msft_config_issues.0", "aaacert-invalid"),
+					resource.TestCheckResourceAttr(resourceName, "msft_config_issues.1", "duplicate-mac-in-inventory"),
+					resource.TestCheckResourceAttr(resourceName, "msft_config_issues.2", "duplicate-rootContName"),
+					resource.TestCheckResourceAttr(resourceName, "msft_config_issues.3", "invalid-object-in-inventory"),
+					resource.TestCheckResourceAttr(resourceName, "msft_config_issues.4", "invalid-rootContName"),
+					resource.TestCheckResourceAttr(resourceName, "msft_config_issues.5", "inventory-failed"),
+					resource.TestCheckResourceAttr(resourceName, "msft_config_issues.6", "missing-hostGroup-in-cloud"),
+					resource.TestCheckResourceAttr(resourceName, "msft_config_issues.7", "missing-rootContName"),
+					resource.TestCheckResourceAttr(resourceName, "msft_config_issues.8", "zero-mac-in-inventory"),
+					testAccCheckAciVMMControllerIdEqual(&vmm_controller_default, &vmm_controller_updated),
+				),
+			},
+			{
+				Config: CreateAccVMMControllerConfig(vmmDomPName, rName, ip, rootContName),
+			},
+		},
+	})
+}
+
+func TestAccAciVMMController_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	vmmDomPName := makeTestVariable(acctest.RandString(5))
+	ip, _ := acctest.RandIpAddress("10.2.0.0/16")
+	rootContName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVMMControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccVMMControllerConfig(vmmDomPName, rName, ip, rootContName),
+			},
+			{
+				Config:      CreateAccVMMControllerWithInValidParentDn(vmmDomPName, rName, ip, rootContName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccVMMControllerConfig(vmmDomPName, rName, rName, rootContName),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccVMMControllerUpdatedAttr(vmmDomPName, rName, ip, rootContName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccVMMControllerUpdatedAttr(vmmDomPName, rName, ip, rootContName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccVMMControllerUpdatedAttr(vmmDomPName, rName, ip, rootContName, "dvs_version", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccVMMControllerUpdatedAttr(vmmDomPName, rName, ip, rootContName, "inventory_trig_st", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccVMMControllerUpdatedAttr(vmmDomPName, rName, ip, rootContName, "mode", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccVMMControllerUpdatedAttrList(vmmDomPName, rName, ip, rootContName, "msft_config_issues", StringListtoString([]string{randomValue})),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccVMMControllerUpdatedAttrList(vmmDomPName, rName, ip, rootContName, "msft_config_issues", StringListtoString([]string{"aaacert-invalid", "aaacert-invalid"})),
+				ExpectError: regexp.MustCompile(`duplication is not supported in list`),
+			},
+			{
+				Config:      CreateAccVMMControllerUpdatedAttr(vmmDomPName, rName, ip, rootContName, "n1kv_stats_mode", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccVMMControllerUpdatedAttr(vmmDomPName, rName, ip, rootContName, "port", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccVMMControllerUpdatedAttr(vmmDomPName, rName, ip, rootContName, "scope", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccVMMControllerUpdatedAttr(vmmDomPName, rName, ip, rootContName, "seq_num", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccVMMControllerUpdatedAttr(vmmDomPName, rName, ip, rootContName, "stats_mode", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccVMMControllerUpdatedAttr(vmmDomPName, rName, ip, rootContName, "vxlan_depl_pref", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccVMMControllerUpdatedAttr(vmmDomPName, rName, ip, rootContName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccVMMControllerConfig(vmmDomPName, rName, ip, rootContName),
+			},
+		},
+	})
+}
+
+func TestAccAciVMMController_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	rootContName := makeTestVariable(acctest.RandString(5))
+	vmmDomPName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVMMControllerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccVMMControllerConfigMultiple(vmmDomPName, rName, rootContName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciVMMControllerExists(name string, vmm_controller *models.VMMController) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("VMM Controller %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No VMM Controller dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		vmm_controllerFound := models.VMMControllerFromContainer(cont)
+		if vmm_controllerFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("VMM Controller %s not found", rs.Primary.ID)
+		}
+		*vmm_controller = *vmm_controllerFound
+		return nil
+	}
+}
+
+func testAccCheckAciVMMControllerDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing vmm_controller destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_vmm_controller" {
+			cont, err := client.Get(rs.Primary.ID)
+			vmm_controller := models.VMMControllerFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("VMM Controller %s Still exists", vmm_controller.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciVMMControllerIdEqual(m1, m2 *models.VMMController) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("vmm_controller DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciVMMControllerIdNotEqual(m1, m2 *models.VMMController) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("vmm_controller DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateVMMControllerWithoutRequired(vmmDomPName, rName, hostOrIp, rootContName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing vmm_controller creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "%v"
+	}
+	
+	`
+	switch attrName {
+	case "vmm_domain_dn":
+		rBlock += `
+	resource "aci_vmm_controller" "test" {
+	#	vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+		host_or_ip = "%s"
+		root_cont_name = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+	#	name  = "%s"
+		host_or_ip = "%s"
+		root_cont_name = "%s"
+	}
+		`
+	case "host_or_ip":
+		rBlock += `
+	resource "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+	#	host_or_ip = "%s"
+		root_cont_name = "%s"
+	}
+		`
+	case "root_cont_name":
+		rBlock += `
+	resource "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+		host_or_ip = "%s"
+	#	root_cont_name = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, vmmDomPName, providerProfileDn, rName, hostOrIp, rootContName)
+}
+
+func CreateAccVMMControllerConfigWithRequiredParams(vmmDomPName, rName, ip, rootContName string) string {
+	fmt.Println("=== STEP  testing vmm_controller creation with updated naming arguments")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "%v"
+	}
+	
+	resource "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+		host_or_ip = "%s"
+		root_cont_name = "%s"
+	}
+	`, vmmDomPName, providerProfileDn, rName, ip, rootContName)
+	return resource
+}
+func CreateAccVMMControllerConfigUpdatedRequiredArguments(vmmDomPName, rName, ip, rootContName string) string {
+	fmt.Println("=== STEP  testing vmm_controller creation with invalid argument")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "%v"
+	}
+	
+	resource "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+		host_or_ip = "%s"
+		root_cont_name = "%s"
+	}
+	`, providerProfileDn, vmmDomPName, rName, ip, rootContName)
+	return resource
+}
+
+func CreateAccVMMControllerConfig(vmmDomPName, rName, ip, rootContName string) string {
+	fmt.Println("=== STEP  testing vmm_controller creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "%v"
+	}
+	
+	resource "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+		host_or_ip = "%s"
+		root_cont_name = "%s"
+	}
+	`, vmmDomPName, providerProfileDn, rName, ip, rootContName)
+	return resource
+}
+
+func CreateAccVMMControllerConfigUpdatedName(vmmDomPName, rName, ip, rootContName string) string {
+	fmt.Println("=== STEP  testing vmm_controller creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "%v"
+	}
+	
+	resource "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+		host_or_ip = "%s"
+		root_cont_name = "%s"
+	}
+	`, vmmDomPName, providerProfileDn, rName, ip, rootContName)
+	return resource
+}
+func CreateAccVMMControllerConfigMultiple(vmmDomPName, rName, rootContName string) string {
+	fmt.Println("=== STEP  testing multiple vmm_controller creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "%v"
+	}
+	
+	resource "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		host_or_ip = "10.4.0.${count.index}"
+		root_cont_name = "%s"
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, vmmDomPName, providerProfileDn, rootContName, rName)
+	return resource
+}
+
+func CreateAccVMMControllerWithInValidParentDn(vmmDomPName, rName, ip, rootContName string) string {
+	fmt.Println("=== STEP  Negative Case: testing vmm_controller creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_tenant.test.id
+		name  = "%s"	
+		host_or_ip = "%s"
+		root_cont_name = "%s"
+	}
+	`, vmmDomPName, rName, ip, rootContName)
+	return resource
+}
+
+func CreateAccVMMControllerConfigWithOptionalValues(vmmDomPName, rName, ip, rootContName string) string {
+	fmt.Println("=== STEP  Basic: testing vmm_controller creation with optional parameters")
+	resource := fmt.Sprintf(`
+
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "%v"
+	}
+	
+	resource "aci_vmm_controller" "test" {
+		vmm_domain_dn  = "${aci_vmm_domain.test.id}"
+		name  = "%s"
+		host_or_ip = "%s"
+		root_cont_name = "%s"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_vmm_controller"
+		dvs_version = "5.1"
+		inventory_trig_st = "autoTriggered"
+		mode = "cf"
+		msft_config_err_msg = "Error"
+		msft_config_issues = ["aaacert-invalid"]
+		n1kv_stats_mode = "disabled"
+		port = "1"
+		scope = "MicrosoftSCVMM"
+		stats_mode = "enabled"
+		vxlan_depl_pref = "nsx"
+	}
+	`, vmmDomPName, providerProfileDn, rName, ip, rootContName)
+
+	return resource
+}
+
+func CreateAccVMMControllerRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing vmm_controller updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_vmm_controller" "test" {
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_vmm_controller"
+		dvs_version = "5.1"
+		inventory_trig_st = "autoTriggered"
+		mode = "cf"
+		msft_config_err_msg = ""
+		msft_config_issues = ["aaacert-invalid"]
+		n1kv_stats_mode = "disabled"
+		port = "1"
+		scope = "MicrosoftSCVMM"
+		stats_mode = "enabled"
+		vxlan_depl_pref = "nsx"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccVMMControllerUpdatedAttr(vmmDomPName, rName, ip, rootContName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing vmm_controller attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "%v"
+	}
+	
+	resource "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+		host_or_ip = "%s"
+		root_cont_name = "%s"
+		%s = "%s"
+	}
+	`, vmmDomPName, providerProfileDn, rName, ip, rootContName, attribute, value)
+	return resource
+}
+
+func CreateAccVMMControllerUpdatedAttrList(vmmDomPName, rName, ip, rootContName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing vmm_controller attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_vmm_domain" "test" {
+		name 		= "%s"
+		provider_profile_dn = "%v"
+	}
+	
+	resource "aci_vmm_controller" "test" {
+		vmm_domain_dn  = aci_vmm_domain.test.id
+		name  = "%s"
+		host_or_ip = "%s"
+		root_cont_name = "%s"
+		%s = %s
+	}
+	`, vmmDomPName, providerProfileDn, rName, ip, rootContName, attribute, value)
+	return resource
+}


### PR DESCRIPTION
$ go test -v -run TestAccAciVMMController_Basic -timeout=60m
=== RUN   TestAccAciVMMController_Basic
=== STEP  Basic: testing vmm_controller creation without  vmm_domain_dn
=== STEP  Basic: testing vmm_controller creation without  name
=== STEP  Basic: testing vmm_controller creation without  host_or_ip
=== STEP  Basic: testing vmm_controller creation without  root_cont_name
=== STEP  testing vmm_controller creation with required arguments only
=== STEP  Basic: testing vmm_controller creation with optional parameters
=== STEP  testing vmm_controller creation with required arguments only
=== STEP  Basic: testing vmm_controller updation without required parameters
=== STEP  testing vmm_controller creation with updated naming arguments
=== STEP  testing vmm_controller creation with required arguments only
=== STEP  testing vmm_controller creation with updated naming arguments
=== PAUSE TestAccAciVMMController_Basic
=== CONT  TestAccAciVMMController_Basic
=== STEP  testing vmm_controller destroy
--- PASS: TestAccAciVMMController_Basic (256.84s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   259.517s

$ go test -v -run TestAccAciVMMControllerDataSource_Basic -timeout=60m
=== RUN   TestAccAciVMMControllerDataSource_Basic
=== STEP  Basic: testing vmm_controller Data Source without  vmm_domain_dn
=== STEP  Basic: testing vmm_controller Data Source without  name
=== STEP  testing vmm_controller Data Source with required arguments only
=== STEP  testing vmm_controller Data Source with random attribute
=== STEP  testing vmm_controller Data Source with Invalid Parent Dn
=== STEP  testing vmm_controller Data Source with updated resource
=== PAUSE TestAccAciVMMControllerDataSource_Basic
=== CONT  TestAccAciVMMControllerDataSource_Basic
=== STEP  testing vmm_controller destroy
--- PASS: TestAccAciVMMControllerDataSource_Basic (130.13s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   132.220s

$ go test -v -run TestAccAciVMMController_Update -timeout=60m
=== RUN   TestAccAciVMMController_Update
=== STEP  testing vmm_controller creation with required arguments only
=== STEP  testing vmm_controller attribute: mode = unknown
=== STEP  testing vmm_controller attribute: msft_config_issues = ["aaacert-invalid","duplicate-mac-in-inventory","duplicate-rootContName","invalid-object-in-inventory","invalid-rootContName","inventory-failed","missing-hostGroup-in-cloud","missing-rootContName","zero-mac-in-inventory"]
=== STEP  testing vmm_controller creation with required arguments only
=== PAUSE TestAccAciVMMController_Update
=== CONT  TestAccAciVMMController_Update
=== STEP  testing vmm_controller destroy
--- PASS: TestAccAciVMMController_Update (152.27s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   154.036s

$ go test -v -run TestAccAciVMMController_Negative -timeout=60m
=== RUN   TestAccAciVMMController_Negative
=== STEP  testing vmm_controller creation with required arguments only
=== STEP  Negative Case: testing vmm_controller creation with invalid parent Dn
=== STEP  testing vmm_controller creation with required arguments only
=== STEP  testing vmm_controller attribute: annotation = p12vgaeqfjohcf4b7nelgonv8peuk6zfy239c7omtounuo9duzj3fhz83r7a9ek74udd1ycyua3y91alyp92l6buvprquw36hacfoy16kp8el7b9r84wtazt2qzspupok
=== STEP  testing vmm_controller attribute: name_alias = 7dht67gp2zavsix7krrhpgbcyphgdemc10sqwju7ysy1z2un117uv1bpjh8bo1tk
=== STEP  testing vmm_controller attribute: dvs_version = aa6k7
=== STEP  testing vmm_controller attribute: inventory_trig_st = aa6k7
=== STEP  testing vmm_controller attribute: mode = aa6k7
=== STEP  testing vmm_controller attribute: msft_config_issues = ["aa6k7"]
=== STEP  testing vmm_controller attribute: msft_config_issues = ["aaacert-invalid","aaacert-invalid"]
=== STEP  testing vmm_controller attribute: n1kv_stats_mode = aa6k7
=== STEP  testing vmm_controller attribute: port = aa6k7
=== STEP  testing vmm_controller attribute: scope = aa6k7
=== STEP  testing vmm_controller attribute: seq_num = aa6k7
=== STEP  testing vmm_controller attribute: stats_mode = aa6k7
=== STEP  testing vmm_controller attribute: vxlan_depl_pref = aa6k7
=== STEP  testing vmm_controller attribute: naqhk = aa6k7
=== STEP  testing vmm_controller creation with required arguments only
=== PAUSE TestAccAciVMMController_Negative
=== CONT  TestAccAciVMMController_Negative
=== STEP  testing vmm_controller destroy
--- PASS: TestAccAciVMMController_Negative (205.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   206.764s

$ go test -v -run TestAccAciVMMController_MultipleCreateDelete -timeout=60m
=== RUN   TestAccAciVMMController_MultipleCreateDelete
=== STEP  testing multiple vmm_controller creation with required arguments only
=== PAUSE TestAccAciVMMController_MultipleCreateDelete
=== CONT  TestAccAciVMMController_MultipleCreateDelete
=== STEP  testing vmm_controller destroy
--- PASS: TestAccAciVMMController_MultipleCreateDelete (47.90s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   49.242s

$ go test -v -run TestAccAciRanges_Basic -timeout=60m
=== RUN   TestAccAciRanges_Basic
=== STEP  Basic: testing ranges creation without  vlan_pool_dn
=== STEP  Basic: testing ranges creation without  from
=== STEP  Basic: testing ranges creation without  to
=== STEP  testing ranges creation with required arguments only
=== STEP  Basic: testing ranges creation with optional parameters
=== STEP  Basic: testing ranges updation without required parameters
=== STEP  testing ranges creation with updated Required arguments
=== STEP  testing ranges creation with required arguments only
=== STEP  testing ranges creation with updated Required arguments
=== STEP  testing ranges creation with required arguments only
=== STEP  testing ranges creation with updated Required arguments
=== PAUSE TestAccAciRanges_Basic
=== CONT  TestAccAciRanges_Basic
=== STEP  testing ranges destroy
--- PASS: TestAccAciRanges_Basic (294.70s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   296.588s

$ go test -v -run TestAccAciRangesDataSource_Basic -timeout=60m
=== RUN   TestAccAciRangesDataSource_Basic
=== STEP  Basic: testing ranges Data Source without  vlan_pool_dn
=== STEP  Basic: testing ranges Data Source without  from
=== STEP  Basic: testing ranges Data Source without  to
=== STEP  testing ranges Data Source with required arguments only
=== STEP  testing ranges Data Source with random attribute
=== STEP  testing ranges Data Source with required arguments only
=== STEP  testing ranges Data Source with updated resource
=== PAUSE TestAccAciRangesDataSource_Basic
=== CONT  TestAccAciRangesDataSource_Basic
=== STEP  testing ranges destroy
--- PASS: TestAccAciRangesDataSource_Basic (80.82s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   83.091s

$ go test -v -run TestAccAciRanges_Negative -timeout=60m
=== RUN   TestAccAciRanges_Negative
=== STEP  testing ranges creation with required arguments only
=== STEP  testing ranges creation with Invalid Parent Dn
=== STEP  testing ranges creation with required arguments only
=== STEP  testing ranges creation with required arguments only
=== STEP  testing ranges creation with required arguments only
=== STEP  testing ranges attribute: description = e4zl60t03381dlwg49ue61criwc7x81a6hhe6za8yxactesuemixqkypox4vl9txzpvbw0w9ks2ck40s2q4w0ybqxfuqpuapctfn6fyeh402dmhcwxwcwjimtf2zvwayb
=== STEP  testing ranges attribute: description = s87f7y6x021zvdr8ve9u6rgidwq04s8znqe76fdv3xb8chhqsirupi3ldtm3xr97vavqgnmkwpfbpyq60fdjrybusa8jsnj186wlhedd74ns870m723ryoebehgfpe8x4
=== STEP  testing ranges attribute: annotation = wbtriqqui4ivj1d4vxsixewum9sevnofatcld948oocggn2qdrh3jnpnrokworiwhfc2dgdohc8tfmhxkxxfu4mgwrmdwpsd2p8bzgw9s7ji0nnvvhxrocgomdwzojqov
=== STEP  testing ranges attribute: name_alias = aqwmh1wue2902o8xw7nxu1oqldkataseda4clei0jvazahci6csobibtwh3rj8ei
=== STEP  testing ranges attribute: alloc_mode = d3lmh
=== STEP  testing ranges attribute: role = d3lmh
=== STEP  testing ranges attribute: sczgp = d3lmh
=== STEP  testing ranges creation with required arguments only
=== PAUSE TestAccAciRanges_Negative
=== CONT  TestAccAciRanges_Negative
=== STEP  testing ranges destroy
--- PASS: TestAccAciRanges_Negative (212.96s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   214.752s

$ go test -v -run TestAccAciRanges_Update -timeout=60m
=== RUN   TestAccAciRanges_Update
=== STEP  testing ranges creation with required arguments only
=== STEP  testing ranges attribute: alloc_mode = static
=== STEP  testing ranges creation with required arguments only
=== PAUSE TestAccAciRanges_Update
=== CONT  TestAccAciRanges_Update
=== STEP  testing ranges destroy
--- PASS: TestAccAciRanges_Update (112.04s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   113.780s

$ go test -v -run TestAccAciRanges_MultipleCreateDelete -timeout=60m
=== RUN   TestAccAciRanges_MultipleCreateDelete
=== STEP  testing multiple ranges creation with required arguments only
=== PAUSE TestAccAciRanges_MultipleCreateDelete
=== CONT  TestAccAciRanges_MultipleCreateDelete
=== STEP  testing ranges destroy
--- PASS: TestAccAciRanges_MultipleCreateDelete (39.31s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   41.349s