### PR TITLE
Updated Ranges and Vmm Controller

### DIFF
--- a/testacc/data_source_aci_fvnsencapblk_test.go
+++ b/testacc/data_source_aci_fvnsencapblk_test.go
@@ -141,7 +141,7 @@ func CreateRangesDSWithoutRequired(rName, from, to, attrName string) string {
 }
 
 func CreateAccRangesDSWithInvalidName(rName, from, to string) string {
-	fmt.Println("=== STEP  testing ranges Data Source with required arguments only")
+	fmt.Println("=== STEP  testing ranges Data Source with Invalid Name")
 	resource := fmt.Sprintf(`
 
 	resource "aci_vlan_pool" "test" {

--- a/testacc/data_source_aci_vmmusraccp_test.go
+++ b/testacc/data_source_aci_vmmusraccp_test.go
@@ -67,7 +67,7 @@ func CreateAccVMMCredentialConfigDataSource(vmmDomPName, rName string) string {
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 	
 	resource "aci_vmm_credential" "test" {
@@ -80,7 +80,7 @@ func CreateAccVMMCredentialConfigDataSource(vmmDomPName, rName string) string {
 		name  = aci_vmm_credential.test.name
 		depends_on = [ aci_vmm_credential.test ]
 	}
-	`, vmmDomPName, rName)
+	`, vmmDomPName, providerProfileDn, rName)
 	return resource
 }
 
@@ -90,7 +90,7 @@ func CreateVMMCredentialDSWithoutRequired(vmmDomPName, rName, attrName string) s
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}	
 	resource "aci_vmm_credential" "test" {
 		vmm_domain_dn  = aci_vmm_domain.test.id
@@ -115,7 +115,7 @@ func CreateVMMCredentialDSWithoutRequired(vmmDomPName, rName, attrName string) s
 	}
 		`
 	}
-	return fmt.Sprintf(rBlock, vmmDomPName, rName)
+	return fmt.Sprintf(rBlock, vmmDomPName, providerProfileDn, rName)
 }
 
 func CreateAccVMMCredentialDSWithInvalidParentDn(vmmDomPName, rName string) string {
@@ -124,7 +124,7 @@ func CreateAccVMMCredentialDSWithInvalidParentDn(vmmDomPName, rName string) stri
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 	
 	resource "aci_vmm_credential" "test" {
@@ -137,7 +137,7 @@ func CreateAccVMMCredentialDSWithInvalidParentDn(vmmDomPName, rName string) stri
 		name  = "${aci_vmm_credential.test.name}_invalid"
 		depends_on = [ aci_vmm_credential.test ]
 	}
-	`, vmmDomPName, rName)
+	`, vmmDomPName, providerProfileDn, rName)
 	return resource
 }
 
@@ -147,7 +147,7 @@ func CreateAccVMMCredentialDataSourceUpdate(vmmDomPName, rName, key, value strin
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}	
 	resource "aci_vmm_credential" "test" {
 		vmm_domain_dn  = aci_vmm_domain.test.id
@@ -160,7 +160,7 @@ func CreateAccVMMCredentialDataSourceUpdate(vmmDomPName, rName, key, value strin
 		%s = "%s"
 		depends_on = [ aci_vmm_credential.test ]
 	}
-	`, vmmDomPName, rName, key, value)
+	`, vmmDomPName, providerProfileDn, rName, key, value)
 	return resource
 }
 
@@ -170,7 +170,7 @@ func CreateAccVMMCredentialDataSourceUpdatedResource(vmmDomPName, rName, key, va
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 	
 	resource "aci_vmm_credential" "test" {
@@ -184,6 +184,6 @@ func CreateAccVMMCredentialDataSourceUpdatedResource(vmmDomPName, rName, key, va
 		name  = aci_vmm_credential.test.name
 		depends_on = [ aci_vmm_credential.test ]
 	}
-	`, vmmDomPName, rName, key, value)
+	`, vmmDomPName, providerProfileDn, rName, key, value)
 	return resource
 }

--- a/testacc/provider_test.go
+++ b/testacc/provider_test.go
@@ -16,6 +16,7 @@ import (
 var testAccProviders map[string]func() (*schema.Provider, error)
 var testAccProvider *schema.Provider
 var systemInfo *models.System
+var providerProfileDn string = "uni/vmmp-VMware"
 
 func init() {
 	testAccProvider = aci.Provider()

--- a/testacc/resource_aci_fvnsencapblk_test.go
+++ b/testacc/resource_aci_fvnsencapblk_test.go
@@ -131,6 +131,23 @@ func TestAccAciRanges_Update(t *testing.T) {
 				),
 			},
 			{
+				Config: CreateAccRangesConfig(rName, "4095", "4095"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRangesExists(resourceName, &ranges_updated),
+					resource.TestCheckResourceAttr(resourceName, "from", "vlan-4095"),
+					resource.TestCheckResourceAttr(resourceName, "to", "vlan-4095"),
+					testAccCheckAciRangesIdNotEqual(&ranges_default, &ranges_updated),
+				),
+			},
+			{
+				Config: CreateAccRangesConfig(rName, from, "4095"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRangesExists(resourceName, &ranges_updated),
+					resource.TestCheckResourceAttr(resourceName, "to", "vlan-4095"),
+					testAccCheckAciRangesIdNotEqual(&ranges_default, &ranges_updated),
+				),
+			},
+			{
 				Config: CreateAccRangesUpdatedAttr(rName, from, to, "alloc_mode", "static"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciRangesExists(resourceName, &ranges_updated),
@@ -173,12 +190,12 @@ func TestAccAciRanges_Negative(t *testing.T) {
 				ExpectError: regexp.MustCompile(`unknown property value`),
 			},
 			{
-				Config:      CreateAccRangesConfig(rName, to, from),
-				ExpectError: regexp.MustCompile(`Range (.)* is invalid. From value cannot be larger than To value`),
+				Config:      CreateAccRangesConfig(rName, "0", to),
+				ExpectError: regexp.MustCompile(`Invalid encapsulation type. Only VLAN encapsulation type is allowed`),
 			},
 			{
-				Config:      CreateAccRangesUpdatedAttr(rName, from, to, "description", acctest.RandString(129)),
-				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+				Config:      CreateAccRangesConfig(rName, to, from),
+				ExpectError: regexp.MustCompile(`Range (.)* is invalid. From value cannot be larger than To value`),
 			},
 			{
 				Config:      CreateAccRangesUpdatedAttr(rName, from, to, "description", acctest.RandString(129)),

--- a/testacc/resource_aci_vmmctrlrp_test.go
+++ b/testacc/resource_aci_vmmctrlrp_test.go
@@ -19,7 +19,7 @@ func TestAccAciVMMController_Basic(t *testing.T) {
 	rName := makeTestVariable(acctest.RandString(5))
 	rNameUpdated := makeTestVariable(acctest.RandString(5))
 	ip, _ := acctest.RandIpAddress("10.0.0.0/16")
-	ipUpdated, _ := acctest.RandIpAddress("10.0.0.0/16")
+	ipUpdated, _ := acctest.RandIpAddress("10.1.0.0/16")
 	rootContName := makeTestVariable(acctest.RandString(5))
 	rootContNameUpdated := makeTestVariable(acctest.RandString(5))
 	vmmDomPName := makeTestVariable(acctest.RandString(5))
@@ -88,6 +88,7 @@ func TestAccAciVMMController_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "scope", "MicrosoftSCVMM"),
 					resource.TestCheckResourceAttr(resourceName, "stats_mode", "enabled"),
 					resource.TestCheckResourceAttr(resourceName, "vxlan_depl_pref", "nsx"),
+					testAccCheckAciVMMControllerIdNotEqual(&vmm_controller_default, &vmm_controller_updated),
 				),
 			},
 			{
@@ -123,7 +124,7 @@ func TestAccAciVMMController_Basic(t *testing.T) {
 					testAccCheckAciVMMControllerExists(resourceName, &vmm_controller_updated),
 					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("%v/dom-%s", providerProfileDn, vmmDomPName)),
 					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
-					resource.TestCheckResourceAttr(resourceName, "ip", ipUpdated),
+					resource.TestCheckResourceAttr(resourceName, "host_or_ip", ipUpdated),
 					resource.TestCheckResourceAttr(resourceName, "root_cont_name", rootContNameUpdated),
 					testAccCheckAciVMMControllerIdNotEqual(&vmm_controller_default, &vmm_controller_updated),
 				),

--- a/testacc/resource_aci_vmmusraccp_test.go
+++ b/testacc/resource_aci_vmmusraccp_test.go
@@ -36,7 +36,7 @@ func TestAccAciVMMCredential_Basic(t *testing.T) {
 				Config: CreateAccVMMCredentialConfig(vmmDomPName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciVMMCredentialExists(resourceName, &vmm_credential_default),
-					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("uni/vmmp-VMware/dom-%s", vmmDomPName)),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("%v/dom-%s", providerProfileDn, vmmDomPName)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
@@ -49,7 +49,7 @@ func TestAccAciVMMCredential_Basic(t *testing.T) {
 				Config: CreateAccVMMCredentialConfigWithOptionalValues(vmmDomPName, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciVMMCredentialExists(resourceName, &vmm_credential_updated),
-					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("uni/vmmp-VMware/dom-%s", vmmDomPName)),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("%v/dom-%s", providerProfileDn, vmmDomPName)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
 					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
@@ -78,7 +78,7 @@ func TestAccAciVMMCredential_Basic(t *testing.T) {
 				Config: CreateAccVMMCredentialConfigWithRequiredParams(rNameUpdated, rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciVMMCredentialExists(resourceName, &vmm_credential_updated),
-					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("uni/vmmp-VMware/dom-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("%v/dom-%s", providerProfileDn, rNameUpdated)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					testAccCheckAciVMMCredentialIdNotEqual(&vmm_credential_default, &vmm_credential_updated),
 				),
@@ -90,7 +90,7 @@ func TestAccAciVMMCredential_Basic(t *testing.T) {
 				Config: CreateAccVMMCredentialConfigWithRequiredParams(rName, rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciVMMCredentialExists(resourceName, &vmm_credential_updated),
-					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("uni/vmmp-VMware/dom-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "vmm_domain_dn", fmt.Sprintf("%v/dom-%s", providerProfileDn, rName)),
 					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
 					testAccCheckAciVMMCredentialIdNotEqual(&vmm_credential_default, &vmm_credential_updated),
 				),
@@ -146,7 +146,6 @@ func TestAccAciVMMCredential_Negative(t *testing.T) {
 
 func TestAccAciVMMCredential_MultipleCreateDelete(t *testing.T) {
 	rName := makeTestVariable(acctest.RandString(5))
-	// vmmProvPName := makeTestVariable(acctest.RandString(5))
 	vmmDomPName := makeTestVariable(acctest.RandString(5))
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -229,7 +228,7 @@ func CreateVMMCredentialWithoutRequired(vmmDomPName, rName, attrName string) str
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 	
 	`
@@ -249,7 +248,7 @@ func CreateVMMCredentialWithoutRequired(vmmDomPName, rName, attrName string) str
 	}
 		`
 	}
-	return fmt.Sprintf(rBlock, vmmDomPName, rName)
+	return fmt.Sprintf(rBlock, vmmDomPName, providerProfileDn, rName)
 }
 
 func CreateAccVMMCredentialConfigWithRequiredParams(vmmDomPName, rName string) string {
@@ -258,14 +257,14 @@ func CreateAccVMMCredentialConfigWithRequiredParams(vmmDomPName, rName string) s
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 
 	resource "aci_vmm_credential" "test" {
 		vmm_domain_dn  = aci_vmm_domain.test.id
 		name  = "%s"
 	}
-	`, vmmDomPName, rName)
+	`, vmmDomPName, providerProfileDn, rName)
 	return resource
 }
 func CreateAccVMMCredentialConfigUpdatedName(vmmDomPName, rName string) string {
@@ -274,13 +273,13 @@ func CreateAccVMMCredentialConfigUpdatedName(vmmDomPName, rName string) string {
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}	
 	resource "aci_vmm_credential" "test" {
 		vmm_domain_dn  = aci_vmm_domain.test.id
 		name  = "%s"
 	}
-	`, vmmDomPName, rName)
+	`, vmmDomPName, providerProfileDn, rName)
 	return resource
 }
 
@@ -290,14 +289,14 @@ func CreateAccVMMCredentialConfig(vmmDomPName, rName string) string {
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 	
 	resource "aci_vmm_credential" "test" {
 		vmm_domain_dn  = aci_vmm_domain.test.id
 		name  = "%s"
 	}
-	`, vmmDomPName, rName)
+	`, vmmDomPName, providerProfileDn, rName)
 	return resource
 }
 
@@ -307,7 +306,7 @@ func CreateAccVMMCredentialConfigMultiple(vmmDomPName, rName string) string {
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 	
 	resource "aci_vmm_credential" "test" {
@@ -315,7 +314,7 @@ func CreateAccVMMCredentialConfigMultiple(vmmDomPName, rName string) string {
 		name  = "%s_${count.index}"
 		count = 5
 	}
-	`, vmmDomPName, rName)
+	`, vmmDomPName, providerProfileDn, rName)
 	return resource
 }
 
@@ -339,7 +338,7 @@ func CreateAccVMMCredentialConfigWithOptionalValues(vmmDomPName, rName string) s
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 	
 	resource "aci_vmm_credential" "test" {
@@ -352,7 +351,7 @@ func CreateAccVMMCredentialConfigWithOptionalValues(vmmDomPName, rName string) s
 		usr = "ABCD"
 		
 	}
-	`, vmmDomPName, rName)
+	`, vmmDomPName, providerProfileDn, rName)
 
 	return resource
 }
@@ -378,7 +377,7 @@ func CreateAccVMMCredentialUpdatedAttr(vmmDomPName, rName, attribute, value stri
 	
 	resource "aci_vmm_domain" "test" {
 		name 		= "%s"
-		provider_profile_dn = "uni/vmmp-VMware"
+		provider_profile_dn = "%v"
 	}
 	
 	resource "aci_vmm_credential" "test" {
@@ -386,6 +385,6 @@ func CreateAccVMMCredentialUpdatedAttr(vmmDomPName, rName, attribute, value stri
 		name  = "%s"
 		%s = "%s"
 	}
-	`, vmmDomPName, rName, attribute, value)
+	`, vmmDomPName, providerProfileDn, rName, attribute, value)
 	return resource
 }

--- a/testacc/resource_aci_vmmvswitchpolicycont_test.go
+++ b/testacc/resource_aci_vmmvswitchpolicycont_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-var providerProfileDn string = "uni/vmmp-VMware"
-
 func TestAccAciVSwitchPolicy_Basic(t *testing.T) {
 	var vswitch_policy_default models.VSwitchPolicyGroup
 	var vswitch_policy_updated models.VSwitchPolicyGroup

--- a/website/docs/r/ranges.html.markdown
+++ b/website/docs/r/ranges.html.markdown
@@ -43,8 +43,8 @@ resource "aci_ranges" "range_1" {
 ## Argument Reference ##
 
 * `vlan_pool_dn` - (Required) Distinguished name of parent VLAN Pool object (from aci_vlan_pool resource/data source).
-* `from` - (Required) From of Object VLAN Pool ranges. Allowed value min: vlan-1, max: vlan-4094.
-* `to` - (Required) To of Object VLAN Pool ranges. Allowed value min: vlan-1, max: vlan-4094.
+* `from` - (Required) From of Object VLAN Pool ranges. Allowed value min: vlan-1, max: vlan-4095.
+* `to` - (Required) To of Object VLAN Pool ranges. Allowed value min: vlan-1, max: vlan-4095.
 * `alloc_mode` - (Optional) Alloc mode for object VLAN Pool ranges.  Allowed values: "dynamic", "static", "inherit". Default is "inherit".
 * `annotation` - (Optional) Annotation for object VLAN Pool ranges.
 * `name_alias` - (Optional) Name alias for object VLAN Pool ranges.


### PR DESCRIPTION
$ go test -v -run TestAccAciRanges -timeout=60m
=== RUN   TestAccAciRangesDataSource_Basic
=== STEP  Basic: testing ranges Data Source without  vlan_pool_dn
=== STEP  Basic: testing ranges Data Source without  from
=== STEP  Basic: testing ranges Data Source without  to
=== STEP  testing ranges Data Source with required arguments only
=== STEP  testing ranges Data Source with random attribute
=== STEP  testing ranges Data Source with Invalid Name
=== STEP  testing ranges Data Source with updated resource
=== PAUSE TestAccAciRangesDataSource_Basic
=== RUN   TestAccAciRanges_Basic
=== STEP  Basic: testing ranges creation without  vlan_pool_dn
=== STEP  Basic: testing ranges creation without  from
=== STEP  Basic: testing ranges creation without  to
=== STEP  testing ranges creation with required arguments only
=== STEP  Basic: testing ranges creation with optional parameters
=== STEP  Basic: testing ranges updation without required parameters
=== STEP  testing ranges creation with updated Required arguments
=== STEP  testing ranges creation with required arguments only
=== STEP  testing ranges creation with updated Required arguments
=== STEP  testing ranges creation with required arguments only
=== STEP  testing ranges creation with updated Required arguments
=== PAUSE TestAccAciRanges_Basic
=== RUN   TestAccAciRanges_Update
=== STEP  testing ranges creation with required arguments only
=== STEP  testing ranges creation with required arguments only
=== STEP  testing ranges creation with required arguments only
=== STEP  testing ranges attribute: alloc_mode = static
=== STEP  testing ranges creation with required arguments only
=== PAUSE TestAccAciRanges_Update
=== RUN   TestAccAciRanges_Negative
=== STEP  testing ranges creation with required arguments only
=== STEP  testing ranges creation with Invalid Parent Dn
=== STEP  testing ranges creation with required arguments only
=== STEP  testing ranges creation with required arguments only
=== STEP  testing ranges creation with required arguments only
=== STEP  testing ranges creation with required arguments only
=== STEP  testing ranges attribute: description = 9qqqv9viuir1c7310anmlk9tyy07vz7jhikc6o4ecvr2z23janb74m861h70b0b9776l7zp2yd13lpajlh7pbc3fuiu71r02oqbufm6nty6ot200wj90pmxuy8633fxlq
=== STEP  testing ranges attribute: annotation = 23ktjxbplsgu1x2ux8fmvqo1e7dj60gbz8mmjbxrr3x82uzv8igiloputx3hzmaamiwtt126f97vkmm4acbfzwr2wupyugi0wk11bq7ywek4m3harwyxu1ntpppn8fkyz
=== STEP  testing ranges attribute: name_alias = tr1dfkgxbvrqikptpngaphc4ib9jbirulvyfs29qnql368901j4chhdhs3nj42va
=== STEP  testing ranges attribute: alloc_mode = yrevb
=== STEP  testing ranges attribute: role = yrevb
=== STEP  testing ranges attribute: wzqre = yrevb
=== STEP  testing ranges creation with required arguments only
=== PAUSE TestAccAciRanges_Negative
=== RUN   TestAccAciRanges_MultipleCreateDelete
=== STEP  testing multiple ranges creation with required arguments only
=== PAUSE TestAccAciRanges_MultipleCreateDelete
=== CONT  TestAccAciRangesDataSource_Basic
=== CONT  TestAccAciRanges_MultipleCreateDelete
=== CONT  TestAccAciRanges_Negative
=== CONT  TestAccAciRanges_Update
=== CONT  TestAccAciRanges_Basic
=== STEP  testing ranges destroy
--- PASS: TestAccAciRanges_MultipleCreateDelete (67.21s)
=== STEP  testing ranges destroy
--- PASS: TestAccAciRangesDataSource_Basic (170.15s)
=== STEP  testing ranges destroy
--- PASS: TestAccAciRanges_Update (270.73s)
=== STEP  testing ranges destroy
--- PASS: TestAccAciRanges_Negative (293.99s)
=== STEP  testing ranges destroy
--- PASS: TestAccAciRanges_Basic (366.56s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   369.009s


$ go test -v -run TestAccAciVMMCredential -timeout=60m
=== RUN   TestAccAciVMMCredentialDataSource_Basic
=== STEP  Basic: testing vmm_credential Data Source without  vmm_domain_dn
=== STEP  Basic: testing vmm_credential Data Source without  name
=== STEP  testing vmm_credential Data Source with required arguments only
=== STEP  testing vmm_credential Data Source with random attribute
=== STEP  testing vmm_credential Data Source with Invalid Parent Dn
=== STEP  testing vmm_credential Data Source with updated resource
=== PAUSE TestAccAciVMMCredentialDataSource_Basic
=== RUN   TestAccAciVMMCredential_Basic
=== STEP  Basic: testing vmm_credential creation without  vmm_domain_dn
=== STEP  Basic: testing vmm_credential creation without  name
=== STEP  testing vmm_credential creation with required arguments only
=== STEP  Basic: testing vmm_credential creation with optional parameters
=== STEP  testing vmm_credential creation with invalid name =  w61z4m89whpzrk64w7ggsv1frzzd3f3h61iq3bc7kp6txlp9ncvdh6t9orpv8lkb7
=== STEP  Basic: testing vmm_credential updation without required parameters
=== STEP  testing vmm_credential creation with required arguments only
=== STEP  testing vmm_credential creation with required arguments only
=== STEP  testing vmm_credential creation with required arguments only
=== PAUSE TestAccAciVMMCredential_Basic
=== RUN   TestAccAciVMMCredential_Negative
=== STEP  testing vmm_credential creation with required arguments only
=== STEP  Negative Case: testing vmm_credential creation with invalid parent Dn
=== STEP  testing vmm_credential attribute: description = zx4smpjilf0v2fmutltep1vl8pixssyeoarwi7yiw0g2rclk1tzhnfnlhdlpzx9jipvxfygrsszxoks23s14b1duu6mg70hb0fhrjy4tcgoj0xmi99cevvdr4ymormljx
=== STEP  testing vmm_credential attribute: annotation = sjsrbqrcn6e4k6ngmwmipo1c8csgatb9ggq1jomrzos3fwjnl1oxa0qaxqk64albe0pexu2ev6epxpivu7gzqbf7g7xpjzlj8qobvbkthriq2ud72gg36wf39bcvemfb2
=== STEP  testing vmm_credential attribute: name_alias = ssc2rgynccqv0jkbty87i6g3es4ehqiqf7xhqtyptyqcwn1ek3n2pgrje38luxh4
=== STEP  testing vmm_credential attribute: usr = yhye793zh88pag0vcn6nnydqb8wotnzzi3ytsztaft7wdr3wazkb4myq2yegv9tnes9s72oqpfd0b49fg2tlvxai9p3nibw3ndjbhzgla9owuiqadvvyzbgh0czkanm3s
=== STEP  testing vmm_credential attribute: dwqma = rbqu4
=== STEP  testing vmm_credential creation with required arguments only
=== PAUSE TestAccAciVMMCredential_Negative
=== RUN   TestAccAciVMMCredential_MultipleCreateDelete
=== STEP  testing multiple vmm_credential creation with required arguments only
=== PAUSE TestAccAciVMMCredential_MultipleCreateDelete
=== CONT  TestAccAciVMMCredentialDataSource_Basic
=== CONT  TestAccAciVMMCredential_Negative
=== CONT  TestAccAciVMMCredential_MultipleCreateDelete
=== CONT  TestAccAciVMMCredential_Basic
=== STEP  testing vmm_credential destroy
--- PASS: TestAccAciVMMCredential_MultipleCreateDelete (53.67s)
=== STEP  testing vmm_credential destroy
--- PASS: TestAccAciVMMCredentialDataSource_Basic (136.79s)
=== STEP  testing vmm_credential destroy
--- PASS: TestAccAciVMMCredential_Negative (177.34s)
=== STEP  testing vmm_credential destroy
--- PASS: TestAccAciVMMCredential_Basic (245.92s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   247.662s


$ go test -v -run TestAccAciVMMController -timeout=60m
=== RUN   TestAccAciVMMControllerDataSource_Basic
=== STEP  Basic: testing vmm_controller Data Source without  vmm_domain_dn
=== STEP  Basic: testing vmm_controller Data Source without  name
=== STEP  testing vmm_controller Data Source with required arguments only
=== STEP  testing vmm_controller Data Source with random attribute
=== STEP  testing vmm_controller Data Source with Invalid Parent Dn
=== STEP  testing vmm_controller Data Source with updated resource
=== PAUSE TestAccAciVMMControllerDataSource_Basic
=== RUN   TestAccAciVMMController_Basic
=== STEP  Basic: testing vmm_controller creation without  vmm_domain_dn
=== STEP  Basic: testing vmm_controller creation without  name
=== STEP  Basic: testing vmm_controller creation without  host_or_ip
=== STEP  Basic: testing vmm_controller creation without  root_cont_name
=== STEP  testing vmm_controller creation with required arguments only
=== STEP  Basic: testing vmm_controller creation with optional parameters
=== STEP  testing vmm_controller creation with required arguments only
=== STEP  Basic: testing vmm_controller updation without required parameters
=== STEP  testing vmm_controller creation with updated naming arguments
=== STEP  testing vmm_controller creation with required arguments only
=== STEP  testing vmm_controller creation with updated naming arguments
=== PAUSE TestAccAciVMMController_Basic
=== RUN   TestAccAciVMMController_Update
=== STEP  testing vmm_controller creation with required arguments only
=== STEP  testing vmm_controller attribute: mode = unknown
=== STEP  testing vmm_controller attribute: msft_config_issues = ["aaacert-invalid","duplicate-mac-in-inventory","duplicate-rootContName","invalid-object-in-inventory","invalid-rootContName","inventory-failed","missing-hostGroup-in-cloud","missing-rootContName","zero-mac-in-inventory"]
=== STEP  testing vmm_controller creation with required arguments only
=== PAUSE TestAccAciVMMController_Update
=== RUN   TestAccAciVMMController_Negative
=== STEP  testing vmm_controller creation with required arguments only
=== STEP  Negative Case: testing vmm_controller creation with invalid parent Dn
=== STEP  testing vmm_controller creation with required arguments only
=== STEP  testing vmm_controller attribute: annotation = m4wigsjrdpz1mgovbsz7gmaa20d0ibtowlgideahfwchjlte4i31vuzo3zc30sdbu4jet48kcdgb2ilytpbdjt2h46h3vnip8hg48926lf43987dh9odmpa4ymwkmg1wu
=== STEP  testing vmm_controller attribute: name_alias = a23ol6i0fbdmug8ppwcybka3fwt00vafyryh384lhceatbva2lj9y7hyz8bwo78i
=== STEP  testing vmm_controller attribute: dvs_version = inkfu
=== STEP  testing vmm_controller attribute: inventory_trig_st = inkfu
=== STEP  testing vmm_controller attribute: mode = inkfu
=== STEP  testing vmm_controller attribute: msft_config_issues = ["inkfu"]
=== STEP  testing vmm_controller attribute: msft_config_issues = ["aaacert-invalid","aaacert-invalid"]
=== STEP  testing vmm_controller attribute: n1kv_stats_mode = inkfu
=== STEP  testing vmm_controller attribute: port = inkfu
=== STEP  testing vmm_controller attribute: scope = inkfu
=== STEP  testing vmm_controller attribute: seq_num = inkfu
=== STEP  testing vmm_controller attribute: stats_mode = inkfu
=== STEP  testing vmm_controller attribute: vxlan_depl_pref = inkfu
=== STEP  testing vmm_controller attribute: krrle = inkfu
=== STEP  testing vmm_controller creation with required arguments only
=== PAUSE TestAccAciVMMController_Negative
=== RUN   TestAccAciVMMController_MultipleCreateDelete
=== STEP  testing multiple vmm_controller creation with required arguments only
=== PAUSE TestAccAciVMMController_MultipleCreateDelete
=== CONT  TestAccAciVMMControllerDataSource_Basic
=== CONT  TestAccAciVMMController_Negative
=== CONT  TestAccAciVMMController_MultipleCreateDelete
=== CONT  TestAccAciVMMController_Update
=== CONT  TestAccAciVMMController_Basic
=== STEP  testing vmm_controller destroy
--- PASS: TestAccAciVMMController_MultipleCreateDelete (71.74s)
=== STEP  testing vmm_controller destroy
--- PASS: TestAccAciVMMControllerDataSource_Basic (150.52s)
=== STEP  testing vmm_controller destroy
--- PASS: TestAccAciVMMController_Update (211.66s)
=== STEP  testing vmm_controller destroy
--- PASS: TestAccAciVMMController_Negative (282.50s)
=== STEP  testing vmm_controller destroy
--- PASS: TestAccAciVMMController_Basic (307.97s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   309.946s
