### PR TITLE
Aci tacacs provider

### DIFF
--- a/testacc/data_source_aci_aaaldapgroupmaprule_test.go
+++ b/testacc/data_source_aci_aaaldapgroupmaprule_test.go
@@ -1,162 +1,161 @@
 package testacc
 
-// import (
-// 	"fmt"
-// 	"regexp"
-// 	"testing"
+import (
+	"fmt"
+	"regexp"
+	"testing"
 
-// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-// )
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
 
+func TestAccAciLDAPGroupMapRuleDataSource_Basic(t *testing.T) {
+	resourceName := "aci_ldap_group_map_rule.test"
+	dataSourceName := "data.aci_ldap_group_map_rule.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
 
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLDAPGroupMapRuleDestroy,
+		Steps: []resource.TestStep{
 
+			{
+				Config:      CreateLDAPGroupMapRuleDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLDAPGroupMapRuleConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "type", resourceName, "type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "groupdn", resourceName, "groupdn"),
+				),
+			},
+			{
+				Config:      CreateAccLDAPGroupMapRuleDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
 
-  
+			{
+				Config:      CreateAccLDAPGroupMapRuleDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccLDAPGroupMapRuleDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
 
-// func TestAccAciLDAPGroupMapRuleDataSource_Basic(t *testing.T) {
-// 	resourceName := "aci_ldap_group_map_rule.test"
-// 	dataSourceName := "data.aci_ldap_group_map_rule.test"
-// 	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
-// 	randomValue := acctest.RandString(10)
-// 	rName := makeTestVariable(acctest.RandString(5))
+func CreateAccLDAPGroupMapRuleConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing ldap_group_map_rule Data Source with required arguments only")
+	resource := fmt.Sprintf(`
 	
-// 	resource.ParallelTest(t, resource.TestCase{
-// 		PreCheck:	  func(){ testAccPreCheck(t) },
-// 		ProviderFactories:    testAccProviders,
-// 		CheckDestroy: testAccCheckAciLDAPGroupMapRuleDestroy,
-// 		Steps: []resource.TestStep{
-			
-// 			{
-// 				Config:      CreateLDAPGroupMapRuleDSWithoutRequired(rName, "name"),
-// 				ExpectError: regexp.MustCompile(`Missing required argument`),
-// 			},
-// 			{
-// 				Config: CreateAccLDAPGroupMapRuleConfigDataSource(rName),
-// 				Check: resource.ComposeTestCheckFunc(
-					
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "groupdn", resourceName, "groupdn"),
-					
-// 				),
-// 			},
-// 			{
-// 				Config:      CreateAccLDAPGroupMapRuleDataSourceUpdate(rName, randomParameter, randomValue),
-// 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
-// 			},
-			
-// 			{
-// 				Config:      CreateAccLDAPGroupMapRuleDSWithInvalidName(rName),
-// 				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
-// 			},
-// 			{
-// 				Config: CreateAccLDAPGroupMapRuleDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
-// 				),
-// 			},
-// 		},
-// 	})
-// }
+	resource "aci_ldap_group_map_rule" "test" {
+		type = "duo"
+		name  = "%s"
+	}
 
+	data "aci_ldap_group_map_rule" "test" {
+		type = aci_ldap_group_map_rule.test.type
+		name  = aci_ldap_group_map_rule.test.name
+		depends_on = [ aci_ldap_group_map_rule.test ]
+	}
+	`, rName)
+	return resource
+}
 
-// func CreateAccLDAPGroupMapRuleConfigDataSource(rName string) string {
-// 	fmt.Println("=== STEP  testing ldap_group_map_rule Data Source with required arguments only")
-// 	resource := fmt.Sprintf(`
+func CreateLDAPGroupMapRuleDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing ldap_group_map_rule Data Source without ", attrName)
+	rBlock := `
 	
-// 	resource "aci_ldap_group_map_rule" "test" {
-	
-// 		name  = "%s"
-// 	}
+	resource "aci_ldap_group_map_rule" "test" {
+		type = "duo"
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_ldap_group_map_rule" "test" {
+		type = aci_ldap_group_map_rule.test.type
+	#	name  = aci_ldap_group_map_rule.test.name
+		depends_on = [ aci_ldap_group_map_rule.test ]
+	}
+		`
+	case "type":
+		rBlock += `
+	data "aci_ldap_group_map_rule" "test" {
+	#	type = aci_ldap_group_map_rule.test.type
+		name  = aci_ldap_group_map_rule.test.name
+		depends_on = [ aci_ldap_group_map_rule.test ]
+	}
+	`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
 
-// 	data "aci_ldap_group_map_rule" "test" {
+func CreateAccLDAPGroupMapRuleDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing ldap_group_map_rule Data Source with invalid name")
+	resource := fmt.Sprintf(`
 	
-// 		name  = aci_ldap_group_map_rule.test.name
-// 		depends_on = [ aci_ldap_group_map_rule.test ]
-// 	}
-// 	`, rName)
-// 	return resource
-// }
+	resource "aci_ldap_group_map_rule" "test" {
+		type = "duo"
+		name  = "%s"
+	}
 
-// func CreateLDAPGroupMapRuleDSWithoutRequired(rName, attrName string) string {
-// 	fmt.Println("=== STEP  Basic: testing ldap_group_map_rule Data Source without ",attrName)
-// 	rBlock := `
-	
-// 	resource "aci_ldap_group_map_rule" "test" {
-	
-// 		name  = "%s"
-// 	}
-// 	`
-// 	switch attrName {
-// 	case "name":
-// 		rBlock += `
-// 	data "aci_ldap_group_map_rule" "test" {
-	
-// 	#	name  = aci_ldap_group_map_rule.test.name
-// 		depends_on = [ aci_ldap_group_map_rule.test ]
-// 	}
-// 		`
-// 	}
-// 	return fmt.Sprintf(rBlock,rName)
-// }
+	data "aci_ldap_group_map_rule" "test" {
+		type = aci_ldap_group_map_rule.test.type
+		name  = "${aci_ldap_group_map_rule.test.name}_invalid"
+		depends_on = [ aci_ldap_group_map_rule.test ]
+	}
+	`, rName)
+	return resource
+}
 
+func CreateAccLDAPGroupMapRuleDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing ldap_group_map_rule Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map_rule" "test" {
+		type = "duo"
+		name  = "%s"
+	}
 
-// func CreateAccLDAPGroupMapRuleDSWithInvalidName(rName string) string {
-// 	fmt.Println("=== STEP  testing ldap_group_map_rule Data Source with required arguments only")
-// 	resource := fmt.Sprintf(`
-	
-// 	resource "aci_ldap_group_map_rule" "test" {
-	
-// 		name  = "%s"
-// 	}
+	data "aci_ldap_group_map_rule" "test" {
+		type = aci_ldap_group_map_rule.test.type
+		name  = aci_ldap_group_map_rule.test.name
+		%s = "%s"
+		depends_on = [ aci_ldap_group_map_rule.test ]
+	}
+	`, rName, key, value)
+	return resource
+}
 
-// 	data "aci_ldap_group_map_rule" "test" {
+func CreateAccLDAPGroupMapRuleDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing ldap_group_map_rule Data Source with updated resource")
+	resource := fmt.Sprintf(`
 	
-// 		name  = "${aci_ldap_group_map_rule.test.name}_invalid"
-// 		name  = aci_ldap_group_map_rule.test.name
-// 		depends_on = [ aci_ldap_group_map_rule.test ]
-// 	}
-// 	`, rName)
-// 	return resource
-// }
+	resource "aci_ldap_group_map_rule" "test" {
+		type = "duo"
+		name  = "%s"
+		%s = "%s"
+	}
 
-// func CreateAccLDAPGroupMapRuleDataSourceUpdate(rName, key, value string) string {
-// 	fmt.Println("=== STEP  testing ldap_group_map_rule Data Source with random attribute")
-// 	resource := fmt.Sprintf(`
-	
-// 	resource "aci_ldap_group_map_rule" "test" {
-	
-// 		name  = "%s"
-// 	}
-
-// 	data "aci_ldap_group_map_rule" "test" {
-	
-// 		name  = aci_ldap_group_map_rule.test.name
-// 		%s = "%s"
-// 		depends_on = [ aci_ldap_group_map_rule.test ]
-// 	}
-// 	`, rName,key,value)
-// 	return resource
-// }
-
-// func CreateAccLDAPGroupMapRuleDataSourceUpdatedResource(rName, key, value string) string {
-// 	fmt.Println("=== STEP  testing ldap_group_map_rule Data Source with updated resource")
-// 	resource := fmt.Sprintf(`
-	
-// 	resource "aci_ldap_group_map_rule" "test" {
-	
-// 		name  = "%s"
-// 		%s = "%s"
-// 	}
-
-// 	data "aci_ldap_group_map_rule" "test" {
-	
-// 		name  = aci_ldap_group_map_rule.test.name
-// 		depends_on = [ aci_ldap_group_map_rule.test ]
-// 	}
-// 	`, rName,key,value)
-// 	return resource
-// }
+	data "aci_ldap_group_map_rule" "test" {
+		type = aci_ldap_group_map_rule.test.type
+		name  = aci_ldap_group_map_rule.test.name
+		depends_on = [ aci_ldap_group_map_rule.test ]
+	}
+	`, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_aaaldapgroupmaprule_test.go
+++ b/testacc/data_source_aci_aaaldapgroupmaprule_test.go
@@ -1,0 +1,162 @@
+package testacc
+
+// import (
+// 	"fmt"
+// 	"regexp"
+// 	"testing"
+
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// )
+
+
+
+
+  
+
+// func TestAccAciLDAPGroupMapRuleDataSource_Basic(t *testing.T) {
+// 	resourceName := "aci_ldap_group_map_rule.test"
+// 	dataSourceName := "data.aci_ldap_group_map_rule.test"
+// 	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+// 	randomValue := acctest.RandString(10)
+// 	rName := makeTestVariable(acctest.RandString(5))
+	
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		PreCheck:	  func(){ testAccPreCheck(t) },
+// 		ProviderFactories:    testAccProviders,
+// 		CheckDestroy: testAccCheckAciLDAPGroupMapRuleDestroy,
+// 		Steps: []resource.TestStep{
+			
+// 			{
+// 				Config:      CreateLDAPGroupMapRuleDSWithoutRequired(rName, "name"),
+// 				ExpectError: regexp.MustCompile(`Missing required argument`),
+// 			},
+// 			{
+// 				Config: CreateAccLDAPGroupMapRuleConfigDataSource(rName),
+// 				Check: resource.ComposeTestCheckFunc(
+					
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "groupdn", resourceName, "groupdn"),
+					
+// 				),
+// 			},
+// 			{
+// 				Config:      CreateAccLDAPGroupMapRuleDataSourceUpdate(rName, randomParameter, randomValue),
+// 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+// 			},
+			
+// 			{
+// 				Config:      CreateAccLDAPGroupMapRuleDSWithInvalidName(rName),
+// 				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+// 			},
+// 			{
+// 				Config: CreateAccLDAPGroupMapRuleDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
+
+
+// func CreateAccLDAPGroupMapRuleConfigDataSource(rName string) string {
+// 	fmt.Println("=== STEP  testing ldap_group_map_rule Data Source with required arguments only")
+// 	resource := fmt.Sprintf(`
+	
+// 	resource "aci_ldap_group_map_rule" "test" {
+	
+// 		name  = "%s"
+// 	}
+
+// 	data "aci_ldap_group_map_rule" "test" {
+	
+// 		name  = aci_ldap_group_map_rule.test.name
+// 		depends_on = [ aci_ldap_group_map_rule.test ]
+// 	}
+// 	`, rName)
+// 	return resource
+// }
+
+// func CreateLDAPGroupMapRuleDSWithoutRequired(rName, attrName string) string {
+// 	fmt.Println("=== STEP  Basic: testing ldap_group_map_rule Data Source without ",attrName)
+// 	rBlock := `
+	
+// 	resource "aci_ldap_group_map_rule" "test" {
+	
+// 		name  = "%s"
+// 	}
+// 	`
+// 	switch attrName {
+// 	case "name":
+// 		rBlock += `
+// 	data "aci_ldap_group_map_rule" "test" {
+	
+// 	#	name  = aci_ldap_group_map_rule.test.name
+// 		depends_on = [ aci_ldap_group_map_rule.test ]
+// 	}
+// 		`
+// 	}
+// 	return fmt.Sprintf(rBlock,rName)
+// }
+
+
+// func CreateAccLDAPGroupMapRuleDSWithInvalidName(rName string) string {
+// 	fmt.Println("=== STEP  testing ldap_group_map_rule Data Source with required arguments only")
+// 	resource := fmt.Sprintf(`
+	
+// 	resource "aci_ldap_group_map_rule" "test" {
+	
+// 		name  = "%s"
+// 	}
+
+// 	data "aci_ldap_group_map_rule" "test" {
+	
+// 		name  = "${aci_ldap_group_map_rule.test.name}_invalid"
+// 		name  = aci_ldap_group_map_rule.test.name
+// 		depends_on = [ aci_ldap_group_map_rule.test ]
+// 	}
+// 	`, rName)
+// 	return resource
+// }
+
+// func CreateAccLDAPGroupMapRuleDataSourceUpdate(rName, key, value string) string {
+// 	fmt.Println("=== STEP  testing ldap_group_map_rule Data Source with random attribute")
+// 	resource := fmt.Sprintf(`
+	
+// 	resource "aci_ldap_group_map_rule" "test" {
+	
+// 		name  = "%s"
+// 	}
+
+// 	data "aci_ldap_group_map_rule" "test" {
+	
+// 		name  = aci_ldap_group_map_rule.test.name
+// 		%s = "%s"
+// 		depends_on = [ aci_ldap_group_map_rule.test ]
+// 	}
+// 	`, rName,key,value)
+// 	return resource
+// }
+
+// func CreateAccLDAPGroupMapRuleDataSourceUpdatedResource(rName, key, value string) string {
+// 	fmt.Println("=== STEP  testing ldap_group_map_rule Data Source with updated resource")
+// 	resource := fmt.Sprintf(`
+	
+// 	resource "aci_ldap_group_map_rule" "test" {
+	
+// 		name  = "%s"
+// 		%s = "%s"
+// 	}
+
+// 	data "aci_ldap_group_map_rule" "test" {
+	
+// 		name  = aci_ldap_group_map_rule.test.name
+// 		depends_on = [ aci_ldap_group_map_rule.test ]
+// 	}
+// 	`, rName,key,value)
+// 	return resource
+// }

--- a/testacc/data_source_aci_aaaldapgroupmapruleref_test.go
+++ b/testacc/data_source_aci_aaaldapgroupmapruleref_test.go
@@ -1,0 +1,197 @@
+package testacc
+
+// import (
+// 	"fmt"
+// 	"regexp"
+// 	"testing"
+
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// )
+
+
+
+
+  
+
+// func TestAccAciLDAPGroupMaprulerefDataSource_Basic(t *testing.T) {
+// 	resourceName := "aci_ldap_group_mapruleref.test"
+// 	dataSourceName := "data.aci_ldap_group_mapruleref.test"
+// 	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+// 	randomValue := acctest.RandString(10)
+// 	rName := makeTestVariable(acctest.RandString(5))
+	
+// 	aaaLdapGroupMapName := makeTestVariable(acctest.RandString(5))
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		PreCheck:	  func(){ testAccPreCheck(t) },
+// 		ProviderFactories:    testAccProviders,
+// 		CheckDestroy: testAccCheckAciLDAPGroupMaprulerefDestroy,
+// 		Steps: []resource.TestStep{
+// 			{
+// 				Config:      CreateLDAPGroupMaprulerefDSWithoutRequired(aaaLdapGroupMapName, rName,"ldap_group_map_dn"),
+// 				ExpectError: regexp.MustCompile(`Missing required argument`),
+// 			},
+// 			{
+// 				Config:      CreateLDAPGroupMaprulerefDSWithoutRequired(aaaLdapGroupMapName, rName, "name"),
+// 				ExpectError: regexp.MustCompile(`Missing required argument`),
+// 			},
+// 			{
+// 				Config: CreateAccLDAPGroupMaprulerefConfigDataSource(aaaLdapGroupMapName, rName),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "ldap_group_map_dn", resourceName, "ldap_group_map_dn",),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					
+// 				),
+// 			},
+// 			{
+// 				Config:      CreateAccLDAPGroupMaprulerefDataSourceUpdate(aaaLdapGroupMapName, rName, randomParameter, randomValue),
+// 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+// 			},
+			
+// 			{
+// 				Config:      CreateAccLDAPGroupMaprulerefDSWithInvalidParentDn(aaaLdapGroupMapName, rName),
+// 				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+// 			},
+			
+// 			{
+// 				Config: CreateAccLDAPGroupMaprulerefDataSourceUpdatedResource(aaaLdapGroupMapName, rName, "annotation", "orchestrator:terraform-testacc"),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
+
+
+// func CreateAccLDAPGroupMaprulerefConfigDataSource(aaaLdapGroupMapName, rName string) string {
+// 	fmt.Println("=== STEP  testing ldap_group_mapruleref Data Source with required arguments only")
+// 	resource := fmt.Sprintf(`
+	
+// 	resource "aci_ldap_group_map" "test" {
+// 		name 		= "%s"
+	
+// 	}
+	
+// 	resource "aci_ldap_group_mapruleref" "test" {
+// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
+// 		name  = "%s"
+// 	}
+
+// 	data "aci_ldap_group_mapruleref" "test" {
+// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
+// 		name  = aci_ldap_group_mapruleref.test.name
+// 		depends_on = [ aci_ldap_group_mapruleref.test ]
+// 	}
+// 	`, aaaLdapGroupMapName, rName)
+// 	return resource
+// }
+
+// func CreateLDAPGroupMaprulerefDSWithoutRequired(aaaLdapGroupMapName, rName, attrName string) string {
+// 	fmt.Println("=== STEP  Basic: testing ldap_group_mapruleref Data Source without ",attrName)
+// 	rBlock := `
+	
+// 	resource "aci_ldap_group_map" "test" {
+// 		name 		= "%s"
+	
+// 	}
+	
+// 	resource "aci_ldap_group_mapruleref" "test" {
+// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
+// 		name  = "%s"
+// 	}
+// 	`
+// 	switch attrName {
+// 	case "ldap_group_map_dn":
+// 		rBlock += `
+// 	data "aci_ldap_group_mapruleref" "test" {
+// 	#	ldap_group_map_dn  = aci_ldap_group_map.test.id
+// 		name  = aci_ldap_group_mapruleref.test.name
+// 		depends_on = [ aci_ldap_group_mapruleref.test ]
+// 	}
+// 		`
+// 	case "name":
+// 		rBlock += `
+// 	data "aci_ldap_group_mapruleref" "test" {
+// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
+// 	#	name  = aci_ldap_group_mapruleref.test.name
+// 		depends_on = [ aci_ldap_group_mapruleref.test ]
+// 	}
+// 		`
+// 	}
+// 	return fmt.Sprintf(rBlock,aaaLdapGroupMapName, rName)
+// }
+
+// func CreateAccLDAPGroupMaprulerefDSWithInvalidParentDn(aaaLdapGroupMapName, rName string) string {
+// 	fmt.Println("=== STEP  testing ldap_group_mapruleref Data Source with Invalid Parent Dn")
+// 	resource := fmt.Sprintf(`
+	
+// 	resource "aci_ldap_group_map" "test" {
+// 		name 		= "%s"
+	
+// 	}
+	
+// 	resource "aci_ldap_group_mapruleref" "test" {
+// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
+// 		name  = "%s"
+// 	}
+
+// 	data "aci_ldap_group_mapruleref" "test" {
+// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
+// 		name  = "${aci_ldap_group_mapruleref.test.name}_invalid"
+// 		depends_on = [ aci_ldap_group_mapruleref.test ]
+// 	}
+// 	`, aaaLdapGroupMapName, rName)
+// 	return resource
+// }
+
+// func CreateAccLDAPGroupMaprulerefDataSourceUpdate(aaaLdapGroupMapName, rName, key, value string) string {
+// 	fmt.Println("=== STEP  testing ldap_group_mapruleref Data Source with random attribute")
+// 	resource := fmt.Sprintf(`
+	
+// 	resource "aci_ldap_group_map" "test" {
+// 		name 		= "%s"
+	
+// 	}
+	
+// 	resource "aci_ldap_group_mapruleref" "test" {
+// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
+// 		name  = "%s"
+// 	}
+
+// 	data "aci_ldap_group_mapruleref" "test" {
+// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
+// 		name  = aci_ldap_group_mapruleref.test.name
+// 		%s = "%s"
+// 		depends_on = [ aci_ldap_group_mapruleref.test ]
+// 	}
+// 	`, aaaLdapGroupMapName, rName,key,value)
+// 	return resource
+// }
+
+// func CreateAccLDAPGroupMaprulerefDataSourceUpdatedResource(aaaLdapGroupMapName, rName, key, value string) string {
+// 	fmt.Println("=== STEP  testing ldap_group_mapruleref Data Source with updated resource")
+// 	resource := fmt.Sprintf(`
+	
+// 	resource "aci_ldap_group_map" "test" {
+// 		name 		= "%s"
+	
+// 	}
+	
+// 	resource "aci_ldap_group_mapruleref" "test" {
+// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
+// 		name  = "%s"
+// 		%s = "%s"
+// 	}
+
+// 	data "aci_ldap_group_mapruleref" "test" {
+// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
+// 		name  = aci_ldap_group_mapruleref.test.name
+// 		depends_on = [ aci_ldap_group_mapruleref.test ]
+// 	}
+// 	`, aaaLdapGroupMapName, rName,key,value)
+// 	return resource
+// }

--- a/testacc/data_source_aci_aaaldapgroupmapruleref_test.go
+++ b/testacc/data_source_aci_aaaldapgroupmapruleref_test.go
@@ -1,197 +1,188 @@
 package testacc
 
-// import (
-// 	"fmt"
-// 	"regexp"
-// 	"testing"
+import (
+	"fmt"
+	"regexp"
+	"testing"
 
-// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-// )
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
 
+func TestAccAciLDAPGroupMaprulerefDataSource_Basic(t *testing.T) {
+	resourceName := "aci_ldap_group_map_rule_to_group_map.test"
+	dataSourceName := "data.aci_ldap_group_map_rule_to_group_map.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLDAPGroupMaprulerefDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateLDAPGroupMaprulerefDSWithoutRequired(rName, rName, "ldap_group_map_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateLDAPGroupMaprulerefDSWithoutRequired(rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLDAPGroupMaprulerefConfigDataSource(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "ldap_group_map_dn", resourceName, "ldap_group_map_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+				),
+			},
+			{
+				Config:      CreateAccLDAPGroupMaprulerefDataSourceUpdate(rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
 
+			{
+				Config:      CreateAccLDAPGroupMaprulerefDSWithInvalidName(rName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
 
+			{
+				Config: CreateAccLDAPGroupMaprulerefDataSourceUpdatedResource(rName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
 
-  
+func CreateAccLDAPGroupMaprulerefConfigDataSource(aaaLdapGroupMapName, rName string) string {
+	fmt.Println("=== STEP  testing ldap_group_map_rule_to_group_map Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+		name 		= "%s"
+		type = "duo"
+	}
+	
+	resource "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_ldap_group_map.test.id
+		name  = "%s"
+	}
 
-// func TestAccAciLDAPGroupMaprulerefDataSource_Basic(t *testing.T) {
-// 	resourceName := "aci_ldap_group_mapruleref.test"
-// 	dataSourceName := "data.aci_ldap_group_mapruleref.test"
-// 	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
-// 	randomValue := acctest.RandString(10)
-// 	rName := makeTestVariable(acctest.RandString(5))
-	
-// 	aaaLdapGroupMapName := makeTestVariable(acctest.RandString(5))
-// 	resource.ParallelTest(t, resource.TestCase{
-// 		PreCheck:	  func(){ testAccPreCheck(t) },
-// 		ProviderFactories:    testAccProviders,
-// 		CheckDestroy: testAccCheckAciLDAPGroupMaprulerefDestroy,
-// 		Steps: []resource.TestStep{
-// 			{
-// 				Config:      CreateLDAPGroupMaprulerefDSWithoutRequired(aaaLdapGroupMapName, rName,"ldap_group_map_dn"),
-// 				ExpectError: regexp.MustCompile(`Missing required argument`),
-// 			},
-// 			{
-// 				Config:      CreateLDAPGroupMaprulerefDSWithoutRequired(aaaLdapGroupMapName, rName, "name"),
-// 				ExpectError: regexp.MustCompile(`Missing required argument`),
-// 			},
-// 			{
-// 				Config: CreateAccLDAPGroupMaprulerefConfigDataSource(aaaLdapGroupMapName, rName),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "ldap_group_map_dn", resourceName, "ldap_group_map_dn",),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
-					
-// 				),
-// 			},
-// 			{
-// 				Config:      CreateAccLDAPGroupMaprulerefDataSourceUpdate(aaaLdapGroupMapName, rName, randomParameter, randomValue),
-// 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
-// 			},
-			
-// 			{
-// 				Config:      CreateAccLDAPGroupMaprulerefDSWithInvalidParentDn(aaaLdapGroupMapName, rName),
-// 				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
-// 			},
-			
-// 			{
-// 				Config: CreateAccLDAPGroupMaprulerefDataSourceUpdatedResource(aaaLdapGroupMapName, rName, "annotation", "orchestrator:terraform-testacc"),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
-// 				),
-// 			},
-// 		},
-// 	})
-// }
+	data "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_ldap_group_map.test.id
+		name  = aci_ldap_group_map_rule_to_group_map.test.name
+		depends_on = [ aci_ldap_group_map_rule_to_group_map.test ]
+	}
+	`, aaaLdapGroupMapName, rName)
+	return resource
+}
 
+func CreateLDAPGroupMaprulerefDSWithoutRequired(aaaLdapGroupMapName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing ldap_group_map_rule_to_group_map Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_ldap_group_map" "test" {
+		name 		= "%s"
+		type = "duo"
+	}
+	
+	resource "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_ldap_group_map.test.id
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "ldap_group_map_dn":
+		rBlock += `
+	data "aci_ldap_group_map_rule_to_group_map" "test" {
+	#	ldap_group_map_dn  = aci_ldap_group_map.test.id
+		name  = aci_ldap_group_map_rule_to_group_map.test.name
+		depends_on = [ aci_ldap_group_map_rule_to_group_map.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_ldap_group_map.test.id
+	#	name  = aci_ldap_group_map_rule_to_group_map.test.name
+		depends_on = [ aci_ldap_group_map_rule_to_group_map.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, aaaLdapGroupMapName, rName)
+}
 
-// func CreateAccLDAPGroupMaprulerefConfigDataSource(aaaLdapGroupMapName, rName string) string {
-// 	fmt.Println("=== STEP  testing ldap_group_mapruleref Data Source with required arguments only")
-// 	resource := fmt.Sprintf(`
+func CreateAccLDAPGroupMaprulerefDSWithInvalidName(aaaLdapGroupMapName, rName string) string {
+	fmt.Println("=== STEP  testing ldap_group_map_rule_to_group_map Data Source with invalid name")
+	resource := fmt.Sprintf(`
 	
-// 	resource "aci_ldap_group_map" "test" {
-// 		name 		= "%s"
+	resource "aci_ldap_group_map" "test" {
+		name 		= "%s"
+		type = "duo"
+	}
 	
-// 	}
-	
-// 	resource "aci_ldap_group_mapruleref" "test" {
-// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
-// 		name  = "%s"
-// 	}
+	resource "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_ldap_group_map.test.id
+		name  = "%s"
+	}
 
-// 	data "aci_ldap_group_mapruleref" "test" {
-// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
-// 		name  = aci_ldap_group_mapruleref.test.name
-// 		depends_on = [ aci_ldap_group_mapruleref.test ]
-// 	}
-// 	`, aaaLdapGroupMapName, rName)
-// 	return resource
-// }
+	data "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_ldap_group_map.test.id
+		name  = "${aci_ldap_group_map_rule_to_group_map.test.name}_invalid"
+		depends_on = [ aci_ldap_group_map_rule_to_group_map.test ]
+	}
+	`, aaaLdapGroupMapName, rName)
+	return resource
+}
 
-// func CreateLDAPGroupMaprulerefDSWithoutRequired(aaaLdapGroupMapName, rName, attrName string) string {
-// 	fmt.Println("=== STEP  Basic: testing ldap_group_mapruleref Data Source without ",attrName)
-// 	rBlock := `
+func CreateAccLDAPGroupMaprulerefDataSourceUpdate(aaaLdapGroupMapName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing ldap_group_map_rule_to_group_map Data Source with random attribute")
+	resource := fmt.Sprintf(`
 	
-// 	resource "aci_ldap_group_map" "test" {
-// 		name 		= "%s"
+	resource "aci_ldap_group_map" "test" {
+		name 		= "%s"
+		type = "duo"
+	}
 	
-// 	}
-	
-// 	resource "aci_ldap_group_mapruleref" "test" {
-// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
-// 		name  = "%s"
-// 	}
-// 	`
-// 	switch attrName {
-// 	case "ldap_group_map_dn":
-// 		rBlock += `
-// 	data "aci_ldap_group_mapruleref" "test" {
-// 	#	ldap_group_map_dn  = aci_ldap_group_map.test.id
-// 		name  = aci_ldap_group_mapruleref.test.name
-// 		depends_on = [ aci_ldap_group_mapruleref.test ]
-// 	}
-// 		`
-// 	case "name":
-// 		rBlock += `
-// 	data "aci_ldap_group_mapruleref" "test" {
-// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
-// 	#	name  = aci_ldap_group_mapruleref.test.name
-// 		depends_on = [ aci_ldap_group_mapruleref.test ]
-// 	}
-// 		`
-// 	}
-// 	return fmt.Sprintf(rBlock,aaaLdapGroupMapName, rName)
-// }
+	resource "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_ldap_group_map.test.id
+		name  = "%s"
+	}
 
-// func CreateAccLDAPGroupMaprulerefDSWithInvalidParentDn(aaaLdapGroupMapName, rName string) string {
-// 	fmt.Println("=== STEP  testing ldap_group_mapruleref Data Source with Invalid Parent Dn")
-// 	resource := fmt.Sprintf(`
-	
-// 	resource "aci_ldap_group_map" "test" {
-// 		name 		= "%s"
-	
-// 	}
-	
-// 	resource "aci_ldap_group_mapruleref" "test" {
-// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
-// 		name  = "%s"
-// 	}
+	data "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_ldap_group_map.test.id
+		name  = aci_ldap_group_map_rule_to_group_map.test.name
+		%s = "%s"
+		depends_on = [ aci_ldap_group_map_rule_to_group_map.test ]
+	}
+	`, aaaLdapGroupMapName, rName, key, value)
+	return resource
+}
 
-// 	data "aci_ldap_group_mapruleref" "test" {
-// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
-// 		name  = "${aci_ldap_group_mapruleref.test.name}_invalid"
-// 		depends_on = [ aci_ldap_group_mapruleref.test ]
-// 	}
-// 	`, aaaLdapGroupMapName, rName)
-// 	return resource
-// }
+func CreateAccLDAPGroupMaprulerefDataSourceUpdatedResource(aaaLdapGroupMapName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing ldap_group_map_rule_to_group_map Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+		name 		= "%s"
+		type = "duo"
+	}
+	
+	resource "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_ldap_group_map.test.id
+		name  = "%s"
+		%s = "%s"
+	}
 
-// func CreateAccLDAPGroupMaprulerefDataSourceUpdate(aaaLdapGroupMapName, rName, key, value string) string {
-// 	fmt.Println("=== STEP  testing ldap_group_mapruleref Data Source with random attribute")
-// 	resource := fmt.Sprintf(`
-	
-// 	resource "aci_ldap_group_map" "test" {
-// 		name 		= "%s"
-	
-// 	}
-	
-// 	resource "aci_ldap_group_mapruleref" "test" {
-// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
-// 		name  = "%s"
-// 	}
-
-// 	data "aci_ldap_group_mapruleref" "test" {
-// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
-// 		name  = aci_ldap_group_mapruleref.test.name
-// 		%s = "%s"
-// 		depends_on = [ aci_ldap_group_mapruleref.test ]
-// 	}
-// 	`, aaaLdapGroupMapName, rName,key,value)
-// 	return resource
-// }
-
-// func CreateAccLDAPGroupMaprulerefDataSourceUpdatedResource(aaaLdapGroupMapName, rName, key, value string) string {
-// 	fmt.Println("=== STEP  testing ldap_group_mapruleref Data Source with updated resource")
-// 	resource := fmt.Sprintf(`
-	
-// 	resource "aci_ldap_group_map" "test" {
-// 		name 		= "%s"
-	
-// 	}
-	
-// 	resource "aci_ldap_group_mapruleref" "test" {
-// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
-// 		name  = "%s"
-// 		%s = "%s"
-// 	}
-
-// 	data "aci_ldap_group_mapruleref" "test" {
-// 		ldap_group_map_dn  = aci_ldap_group_map.test.id
-// 		name  = aci_ldap_group_mapruleref.test.name
-// 		depends_on = [ aci_ldap_group_mapruleref.test ]
-// 	}
-// 	`, aaaLdapGroupMapName, rName,key,value)
-// 	return resource
-// }
+	data "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_ldap_group_map.test.id
+		name  = aci_ldap_group_map_rule_to_group_map.test.name
+		depends_on = [ aci_ldap_group_map_rule_to_group_map.test ]
+	}
+	`, aaaLdapGroupMapName, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_aaatacacsplusprovider_test.go
+++ b/testacc/data_source_aci_aaatacacsplusprovider_test.go
@@ -1,0 +1,169 @@
+package testacc
+
+// import (
+// 	"fmt"
+// 	"regexp"
+// 	"testing"
+
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// )
+
+
+
+
+  
+
+// func TestAccAciTACACSProviderDataSource_Basic(t *testing.T) {
+// 	resourceName := "aci_tacacs_provider.test"
+// 	dataSourceName := "data.aci_tacacs_provider.test"
+// 	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+// 	randomValue := acctest.RandString(10)
+// 	rName := makeTestVariable(acctest.RandString(5))
+	
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		PreCheck:	  func(){ testAccPreCheck(t) },
+// 		ProviderFactories:    testAccProviders,
+// 		CheckDestroy: testAccCheckAciTACACSProviderDestroy,
+// 		Steps: []resource.TestStep{
+			
+// 			{
+// 				Config:      CreateTACACSProviderDSWithoutRequired(rName, "name"),
+// 				ExpectError: regexp.MustCompile(`Missing required argument`),
+// 			},
+// 			{
+// 				Config: CreateAccTACACSProviderConfigDataSource(rName),
+// 				Check: resource.ComposeTestCheckFunc(
+					
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "auth_protocol", resourceName, "auth_protocol"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "key", resourceName, "key"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "monitor_server", resourceName, "monitor_server"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "monitoring_password", resourceName, "monitoring_password"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "monitoring_user", resourceName, "monitoring_user"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "port", resourceName, "port"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "retries", resourceName, "retries"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "timeout", resourceName, "timeout"),
+					
+// 				),
+// 			},
+// 			{
+// 				Config:      CreateAccTACACSProviderDataSourceUpdate(rName, randomParameter, randomValue),
+// 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+// 			},
+			
+// 			{
+// 				Config:      CreateAccTACACSProviderDSWithInvalidName(rName),
+// 				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+// 			},
+// 			{
+// 				Config: CreateAccTACACSProviderDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
+
+
+// func CreateAccTACACSProviderConfigDataSource(rName string) string {
+// 	fmt.Println("=== STEP  testing tacacs_provider Data Source with required arguments only")
+// 	resource := fmt.Sprintf(`
+	
+// 	resource "aci_tacacs_provider" "test" {
+	
+// 		name  = "%s"
+// 	}
+
+// 	data "aci_tacacs_provider" "test" {
+	
+// 		name  = aci_tacacs_provider.test.name
+// 		depends_on = [ aci_tacacs_provider.test ]
+// 	}
+// 	`, rName)
+// 	return resource
+// }
+
+// func CreateTACACSProviderDSWithoutRequired(rName, attrName string) string {
+// 	fmt.Println("=== STEP  Basic: testing tacacs_provider Data Source without ",attrName)
+// 	rBlock := `
+	
+// 	resource "aci_tacacs_provider" "test" {
+	
+// 		name  = "%s"
+// 	}
+// 	`
+// 	switch attrName {
+// 	case "name":
+// 		rBlock += `
+// 	data "aci_tacacs_provider" "test" {
+	
+// 	#	name  = aci_tacacs_provider.test.name
+// 		depends_on = [ aci_tacacs_provider.test ]
+// 	}
+// 		`
+// 	}
+// 	return fmt.Sprintf(rBlock,rName)
+// }
+
+
+// func CreateAccTACACSProviderDSWithInvalidName(rName string) string {
+// 	fmt.Println("=== STEP  testing tacacs_provider Data Source with required arguments only")
+// 	resource := fmt.Sprintf(`
+	
+// 	resource "aci_tacacs_provider" "test" {
+	
+// 		name  = "%s"
+// 	}
+
+// 	data "aci_tacacs_provider" "test" {
+	
+// 		name  = "${aci_tacacs_provider.test.name}_invalid"
+// 		name  = aci_tacacs_provider.test.name
+// 		depends_on = [ aci_tacacs_provider.test ]
+// 	}
+// 	`, rName)
+// 	return resource
+// }
+
+// func CreateAccTACACSProviderDataSourceUpdate(rName, key, value string) string {
+// 	fmt.Println("=== STEP  testing tacacs_provider Data Source with random attribute")
+// 	resource := fmt.Sprintf(`
+	
+// 	resource "aci_tacacs_provider" "test" {
+	
+// 		name  = "%s"
+// 	}
+
+// 	data "aci_tacacs_provider" "test" {
+	
+// 		name  = aci_tacacs_provider.test.name
+// 		%s = "%s"
+// 		depends_on = [ aci_tacacs_provider.test ]
+// 	}
+// 	`, rName,key,value)
+// 	return resource
+// }
+
+// func CreateAccTACACSProviderDataSourceUpdatedResource(rName, key, value string) string {
+// 	fmt.Println("=== STEP  testing tacacs_provider Data Source with updated resource")
+// 	resource := fmt.Sprintf(`
+	
+// 	resource "aci_tacacs_provider" "test" {
+	
+// 		name  = "%s"
+// 		%s = "%s"
+// 	}
+
+// 	data "aci_tacacs_provider" "test" {
+	
+// 		name  = aci_tacacs_provider.test.name
+// 		depends_on = [ aci_tacacs_provider.test ]
+// 	}
+// 	`, rName,key,value)
+// 	return resource
+// }

--- a/testacc/data_source_aci_aaatacacsplusprovider_test.go
+++ b/testacc/data_source_aci_aaatacacsplusprovider_test.go
@@ -1,169 +1,161 @@
 package testacc
 
-// import (
-// 	"fmt"
-// 	"regexp"
-// 	"testing"
+import (
+	"fmt"
+	"regexp"
+	"testing"
 
-// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-// )
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
 
-
-
-
-  
-
-// func TestAccAciTACACSProviderDataSource_Basic(t *testing.T) {
-// 	resourceName := "aci_tacacs_provider.test"
-// 	dataSourceName := "data.aci_tacacs_provider.test"
-// 	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
-// 	randomValue := acctest.RandString(10)
-// 	rName := makeTestVariable(acctest.RandString(5))
+func TestAccAciTACACSProviderDataSource_Basic(t *testing.T) {
+	resourceName := "aci_tacacs_provider.test"
+	dataSourceName := "data.aci_tacacs_provider.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
 	
-// 	resource.ParallelTest(t, resource.TestCase{
-// 		PreCheck:	  func(){ testAccPreCheck(t) },
-// 		ProviderFactories:    testAccProviders,
-// 		CheckDestroy: testAccCheckAciTACACSProviderDestroy,
-// 		Steps: []resource.TestStep{
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciTACACSProviderDestroy,
+		Steps: []resource.TestStep{
 			
-// 			{
-// 				Config:      CreateTACACSProviderDSWithoutRequired(rName, "name"),
-// 				ExpectError: regexp.MustCompile(`Missing required argument`),
-// 			},
-// 			{
-// 				Config: CreateAccTACACSProviderConfigDataSource(rName),
-// 				Check: resource.ComposeTestCheckFunc(
+			{
+				Config:      CreateTACACSProviderDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccTACACSProviderConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
 					
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "auth_protocol", resourceName, "auth_protocol"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "key", resourceName, "key"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "monitor_server", resourceName, "monitor_server"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "monitoring_password", resourceName, "monitoring_password"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "monitoring_user", resourceName, "monitoring_user"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "port", resourceName, "port"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "retries", resourceName, "retries"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "timeout", resourceName, "timeout"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "auth_protocol", resourceName, "auth_protocol"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "monitor_server", resourceName, "monitor_server"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "monitoring_user", resourceName, "monitoring_user"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "port", resourceName, "port"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "retries", resourceName, "retries"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "timeout", resourceName, "timeout"),
 					
-// 				),
-// 			},
-// 			{
-// 				Config:      CreateAccTACACSProviderDataSourceUpdate(rName, randomParameter, randomValue),
-// 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
-// 			},
+				),
+			},
+			{
+				Config:      CreateAccTACACSProviderDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
 			
-// 			{
-// 				Config:      CreateAccTACACSProviderDSWithInvalidName(rName),
-// 				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
-// 			},
-// 			{
-// 				Config: CreateAccTACACSProviderDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
-// 				),
-// 			},
-// 		},
-// 	})
-// }
+			{
+				Config:      CreateAccTACACSProviderDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccTACACSProviderDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
 
 
-// func CreateAccTACACSProviderConfigDataSource(rName string) string {
-// 	fmt.Println("=== STEP  testing tacacs_provider Data Source with required arguments only")
-// 	resource := fmt.Sprintf(`
+func CreateAccTACACSProviderConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing tacacs_provider Data Source with required arguments only")
+	resource := fmt.Sprintf(`
 	
-// 	resource "aci_tacacs_provider" "test" {
+	resource "aci_tacacs_provider" "test" {
 	
-// 		name  = "%s"
-// 	}
+		name  = "%s"
+	}
 
-// 	data "aci_tacacs_provider" "test" {
+	data "aci_tacacs_provider" "test" {
 	
-// 		name  = aci_tacacs_provider.test.name
-// 		depends_on = [ aci_tacacs_provider.test ]
-// 	}
-// 	`, rName)
-// 	return resource
-// }
+		name  = aci_tacacs_provider.test.name
+		depends_on = [ aci_tacacs_provider.test ]
+	}
+	`, rName)
+	return resource
+}
 
-// func CreateTACACSProviderDSWithoutRequired(rName, attrName string) string {
-// 	fmt.Println("=== STEP  Basic: testing tacacs_provider Data Source without ",attrName)
-// 	rBlock := `
+func CreateTACACSProviderDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing tacacs_provider Data Source without ",attrName)
+	rBlock := `
 	
-// 	resource "aci_tacacs_provider" "test" {
+	resource "aci_tacacs_provider" "test" {
 	
-// 		name  = "%s"
-// 	}
-// 	`
-// 	switch attrName {
-// 	case "name":
-// 		rBlock += `
-// 	data "aci_tacacs_provider" "test" {
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_tacacs_provider" "test" {
 	
-// 	#	name  = aci_tacacs_provider.test.name
-// 		depends_on = [ aci_tacacs_provider.test ]
-// 	}
-// 		`
-// 	}
-// 	return fmt.Sprintf(rBlock,rName)
-// }
+	#	name  = aci_tacacs_provider.test.name
+		depends_on = [ aci_tacacs_provider.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock,rName)
+}
 
 
-// func CreateAccTACACSProviderDSWithInvalidName(rName string) string {
-// 	fmt.Println("=== STEP  testing tacacs_provider Data Source with required arguments only")
-// 	resource := fmt.Sprintf(`
+func CreateAccTACACSProviderDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing tacacs_provider Data Source with invalid name")
+	resource := fmt.Sprintf(`
 	
-// 	resource "aci_tacacs_provider" "test" {
+	resource "aci_tacacs_provider" "test" {
 	
-// 		name  = "%s"
-// 	}
+		name  = "%s"
+	}
 
-// 	data "aci_tacacs_provider" "test" {
+	data "aci_tacacs_provider" "test" {
 	
-// 		name  = "${aci_tacacs_provider.test.name}_invalid"
-// 		name  = aci_tacacs_provider.test.name
-// 		depends_on = [ aci_tacacs_provider.test ]
-// 	}
-// 	`, rName)
-// 	return resource
-// }
+		name  = "${aci_tacacs_provider.test.name}_invalid"
+		depends_on = [ aci_tacacs_provider.test ]
+	}
+	`, rName)
+	return resource
+}
 
-// func CreateAccTACACSProviderDataSourceUpdate(rName, key, value string) string {
-// 	fmt.Println("=== STEP  testing tacacs_provider Data Source with random attribute")
-// 	resource := fmt.Sprintf(`
+func CreateAccTACACSProviderDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing tacacs_provider Data Source with random attribute")
+	resource := fmt.Sprintf(`
 	
-// 	resource "aci_tacacs_provider" "test" {
+	resource "aci_tacacs_provider" "test" {
 	
-// 		name  = "%s"
-// 	}
+		name  = "%s"
+	}
 
-// 	data "aci_tacacs_provider" "test" {
+	data "aci_tacacs_provider" "test" {
 	
-// 		name  = aci_tacacs_provider.test.name
-// 		%s = "%s"
-// 		depends_on = [ aci_tacacs_provider.test ]
-// 	}
-// 	`, rName,key,value)
-// 	return resource
-// }
+		name  = aci_tacacs_provider.test.name
+		%s = "%s"
+		depends_on = [ aci_tacacs_provider.test ]
+	}
+	`, rName,key,value)
+	return resource
+}
 
-// func CreateAccTACACSProviderDataSourceUpdatedResource(rName, key, value string) string {
-// 	fmt.Println("=== STEP  testing tacacs_provider Data Source with updated resource")
-// 	resource := fmt.Sprintf(`
+func CreateAccTACACSProviderDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing tacacs_provider Data Source with updated resource")
+	resource := fmt.Sprintf(`
 	
-// 	resource "aci_tacacs_provider" "test" {
+	resource "aci_tacacs_provider" "test" {
 	
-// 		name  = "%s"
-// 		%s = "%s"
-// 	}
+		name  = "%s"
+		%s = "%s"
+	}
 
-// 	data "aci_tacacs_provider" "test" {
+	data "aci_tacacs_provider" "test" {
 	
-// 		name  = aci_tacacs_provider.test.name
-// 		depends_on = [ aci_tacacs_provider.test ]
-// 	}
-// 	`, rName,key,value)
-// 	return resource
-// }
+		name  = aci_tacacs_provider.test.name
+		depends_on = [ aci_tacacs_provider.test ]
+	}
+	`, rName,key,value)
+	return resource
+}

--- a/testacc/data_source_aci_aaatacacsplusprovidergroup_test.go
+++ b/testacc/data_source_aci_aaatacacsplusprovidergroup_test.go
@@ -1,0 +1,161 @@
+package testacc
+
+// import (
+// 	"fmt"
+// 	"regexp"
+// 	"testing"
+
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+// )
+
+
+
+
+  
+
+// func TestAccAciTACACSPlusProviderGroupDataSource_Basic(t *testing.T) {
+// 	resourceName := "aci_tacacs_plus_provider_group.test"
+// 	dataSourceName := "data.aci_tacacs_plus_provider_group.test"
+// 	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+// 	randomValue := acctest.RandString(10)
+// 	rName := makeTestVariable(acctest.RandString(5))
+	
+// 	resource.ParallelTest(t, resource.TestCase{
+// 		PreCheck:	  func(){ testAccPreCheck(t) },
+// 		ProviderFactories:    testAccProviders,
+// 		CheckDestroy: testAccCheckAciTACACSPlusProviderGroupDestroy,
+// 		Steps: []resource.TestStep{
+			
+// 			{
+// 				Config:      CreateTACACSPlusProviderGroupDSWithoutRequired(rName, "name"),
+// 				ExpectError: regexp.MustCompile(`Missing required argument`),
+// 			},
+// 			{
+// 				Config: CreateAccTACACSPlusProviderGroupConfigDataSource(rName),
+// 				Check: resource.ComposeTestCheckFunc(
+					
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					
+// 				),
+// 			},
+// 			{
+// 				Config:      CreateAccTACACSPlusProviderGroupDataSourceUpdate(rName, randomParameter, randomValue),
+// 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+// 			},
+			
+// 			{
+// 				Config:      CreateAccTACACSPlusProviderGroupDSWithInvalidName(rName),
+// 				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+// 			},
+// 			{
+// 				Config: CreateAccTACACSPlusProviderGroupDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+// 				Check: resource.ComposeTestCheckFunc(
+// 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+// 				),
+// 			},
+// 		},
+// 	})
+// }
+
+
+// func CreateAccTACACSPlusProviderGroupConfigDataSource(rName string) string {
+// 	fmt.Println("=== STEP  testing tacacs_plus_provider_group Data Source with required arguments only")
+// 	resource := fmt.Sprintf(`
+	
+// 	resource "aci_tacacs_plus_provider_group" "test" {
+	
+// 		name  = "%s"
+// 	}
+
+// 	data "aci_tacacs_plus_provider_group" "test" {
+	
+// 		name  = aci_tacacs_plus_provider_group.test.name
+// 		depends_on = [ aci_tacacs_plus_provider_group.test ]
+// 	}
+// 	`, rName)
+// 	return resource
+// }
+
+// func CreateTACACSPlusProviderGroupDSWithoutRequired(rName, attrName string) string {
+// 	fmt.Println("=== STEP  Basic: testing tacacs_plus_provider_group Data Source without ",attrName)
+// 	rBlock := `
+	
+// 	resource "aci_tacacs_plus_provider_group" "test" {
+	
+// 		name  = "%s"
+// 	}
+// 	`
+// 	switch attrName {
+// 	case "name":
+// 		rBlock += `
+// 	data "aci_tacacs_plus_provider_group" "test" {
+	
+// 	#	name  = aci_tacacs_plus_provider_group.test.name
+// 		depends_on = [ aci_tacacs_plus_provider_group.test ]
+// 	}
+// 		`
+// 	}
+// 	return fmt.Sprintf(rBlock,rName)
+// }
+
+
+// func CreateAccTACACSPlusProviderGroupDSWithInvalidName(rName string) string {
+// 	fmt.Println("=== STEP  testing tacacs_plus_provider_group Data Source with required arguments only")
+// 	resource := fmt.Sprintf(`
+	
+// 	resource "aci_tacacs_plus_provider_group" "test" {
+	
+// 		name  = "%s"
+// 	}
+
+// 	data "aci_tacacs_plus_provider_group" "test" {
+	
+// 		name  = "${aci_tacacs_plus_provider_group.test.name}_invalid"
+// 		name  = aci_tacacs_plus_provider_group.test.name
+// 		depends_on = [ aci_tacacs_plus_provider_group.test ]
+// 	}
+// 	`, rName)
+// 	return resource
+// }
+
+// func CreateAccTACACSPlusProviderGroupDataSourceUpdate(rName, key, value string) string {
+// 	fmt.Println("=== STEP  testing tacacs_plus_provider_group Data Source with random attribute")
+// 	resource := fmt.Sprintf(`
+	
+// 	resource "aci_tacacs_plus_provider_group" "test" {
+	
+// 		name  = "%s"
+// 	}
+
+// 	data "aci_tacacs_plus_provider_group" "test" {
+	
+// 		name  = aci_tacacs_plus_provider_group.test.name
+// 		%s = "%s"
+// 		depends_on = [ aci_tacacs_plus_provider_group.test ]
+// 	}
+// 	`, rName,key,value)
+// 	return resource
+// }
+
+// func CreateAccTACACSPlusProviderGroupDataSourceUpdatedResource(rName, key, value string) string {
+// 	fmt.Println("=== STEP  testing tacacs_plus_provider_group Data Source with updated resource")
+// 	resource := fmt.Sprintf(`
+	
+// 	resource "aci_tacacs_plus_provider_group" "test" {
+	
+// 		name  = "%s"
+// 		%s = "%s"
+// 	}
+
+// 	data "aci_tacacs_plus_provider_group" "test" {
+	
+// 		name  = aci_tacacs_plus_provider_group.test.name
+// 		depends_on = [ aci_tacacs_plus_provider_group.test ]
+// 	}
+// 	`, rName,key,value)
+// 	return resource
+// }

--- a/testacc/data_source_aci_aaatacacsplusprovidergroup_test.go
+++ b/testacc/data_source_aci_aaatacacsplusprovidergroup_test.go
@@ -1,161 +1,155 @@
 package testacc
 
-// import (
-// 	"fmt"
-// 	"regexp"
-// 	"testing"
+import (
+	"fmt"
+	"regexp"
+	"testing"
 
-// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-// 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-// )
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
 
-
-
-
-  
-
-// func TestAccAciTACACSPlusProviderGroupDataSource_Basic(t *testing.T) {
-// 	resourceName := "aci_tacacs_plus_provider_group.test"
-// 	dataSourceName := "data.aci_tacacs_plus_provider_group.test"
-// 	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
-// 	randomValue := acctest.RandString(10)
-// 	rName := makeTestVariable(acctest.RandString(5))
+func TestAccAciTACACSPlusProviderGroupDataSource_Basic(t *testing.T) {
+	resourceName := "aci_tacacs_provider_group.test"
+	dataSourceName := "data.aci_tacacs_provider_group.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
 	
-// 	resource.ParallelTest(t, resource.TestCase{
-// 		PreCheck:	  func(){ testAccPreCheck(t) },
-// 		ProviderFactories:    testAccProviders,
-// 		CheckDestroy: testAccCheckAciTACACSPlusProviderGroupDestroy,
-// 		Steps: []resource.TestStep{
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciTACACSPlusProviderGroupDestroy,
+		Steps: []resource.TestStep{
 			
-// 			{
-// 				Config:      CreateTACACSPlusProviderGroupDSWithoutRequired(rName, "name"),
-// 				ExpectError: regexp.MustCompile(`Missing required argument`),
-// 			},
-// 			{
-// 				Config: CreateAccTACACSPlusProviderGroupConfigDataSource(rName),
-// 				Check: resource.ComposeTestCheckFunc(
+			{
+				Config:      CreateTACACSPlusProviderGroupDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccTACACSPlusProviderGroupConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
 					
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
 					
-// 				),
-// 			},
-// 			{
-// 				Config:      CreateAccTACACSPlusProviderGroupDataSourceUpdate(rName, randomParameter, randomValue),
-// 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
-// 			},
+				),
+			},
+			{
+				Config:      CreateAccTACACSPlusProviderGroupDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
 			
-// 			{
-// 				Config:      CreateAccTACACSPlusProviderGroupDSWithInvalidName(rName),
-// 				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
-// 			},
-// 			{
-// 				Config: CreateAccTACACSPlusProviderGroupDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
-// 				Check: resource.ComposeTestCheckFunc(
-// 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
-// 				),
-// 			},
-// 		},
-// 	})
-// }
+			{
+				Config:      CreateAccTACACSPlusProviderGroupDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccTACACSPlusProviderGroupDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
 
 
-// func CreateAccTACACSPlusProviderGroupConfigDataSource(rName string) string {
-// 	fmt.Println("=== STEP  testing tacacs_plus_provider_group Data Source with required arguments only")
-// 	resource := fmt.Sprintf(`
+func CreateAccTACACSPlusProviderGroupConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing tacacs_provider_group Data Source with required arguments only")
+	resource := fmt.Sprintf(`
 	
-// 	resource "aci_tacacs_plus_provider_group" "test" {
+	resource "aci_tacacs_provider_group" "test" {
 	
-// 		name  = "%s"
-// 	}
+		name  = "%s"
+	}
 
-// 	data "aci_tacacs_plus_provider_group" "test" {
+	data "aci_tacacs_provider_group" "test" {
 	
-// 		name  = aci_tacacs_plus_provider_group.test.name
-// 		depends_on = [ aci_tacacs_plus_provider_group.test ]
-// 	}
-// 	`, rName)
-// 	return resource
-// }
+		name  = aci_tacacs_provider_group.test.name
+		depends_on = [ aci_tacacs_provider_group.test ]
+	}
+	`, rName)
+	return resource
+}
 
-// func CreateTACACSPlusProviderGroupDSWithoutRequired(rName, attrName string) string {
-// 	fmt.Println("=== STEP  Basic: testing tacacs_plus_provider_group Data Source without ",attrName)
-// 	rBlock := `
+func CreateTACACSPlusProviderGroupDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing tacacs_provider_group Data Source without ",attrName)
+	rBlock := `
 	
-// 	resource "aci_tacacs_plus_provider_group" "test" {
+	resource "aci_tacacs_provider_group" "test" {
 	
-// 		name  = "%s"
-// 	}
-// 	`
-// 	switch attrName {
-// 	case "name":
-// 		rBlock += `
-// 	data "aci_tacacs_plus_provider_group" "test" {
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_tacacs_provider_group" "test" {
 	
-// 	#	name  = aci_tacacs_plus_provider_group.test.name
-// 		depends_on = [ aci_tacacs_plus_provider_group.test ]
-// 	}
-// 		`
-// 	}
-// 	return fmt.Sprintf(rBlock,rName)
-// }
+	#	name  = aci_tacacs_provider_group.test.name
+		depends_on = [ aci_tacacs_provider_group.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock,rName)
+}
 
 
-// func CreateAccTACACSPlusProviderGroupDSWithInvalidName(rName string) string {
-// 	fmt.Println("=== STEP  testing tacacs_plus_provider_group Data Source with required arguments only")
-// 	resource := fmt.Sprintf(`
+func CreateAccTACACSPlusProviderGroupDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing tacacs_provider_group Data Source with invalid name")
+	resource := fmt.Sprintf(`
 	
-// 	resource "aci_tacacs_plus_provider_group" "test" {
+	resource "aci_tacacs_provider_group" "test" {
 	
-// 		name  = "%s"
-// 	}
+		name  = "%s"
+	}
 
-// 	data "aci_tacacs_plus_provider_group" "test" {
+	data "aci_tacacs_provider_group" "test" {
 	
-// 		name  = "${aci_tacacs_plus_provider_group.test.name}_invalid"
-// 		name  = aci_tacacs_plus_provider_group.test.name
-// 		depends_on = [ aci_tacacs_plus_provider_group.test ]
-// 	}
-// 	`, rName)
-// 	return resource
-// }
+		name  = "${aci_tacacs_provider_group.test.name}_invalid"
+		depends_on = [ aci_tacacs_provider_group.test ]
+	}
+	`, rName)
+	return resource
+}
 
-// func CreateAccTACACSPlusProviderGroupDataSourceUpdate(rName, key, value string) string {
-// 	fmt.Println("=== STEP  testing tacacs_plus_provider_group Data Source with random attribute")
-// 	resource := fmt.Sprintf(`
+func CreateAccTACACSPlusProviderGroupDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing tacacs_provider_group Data Source with random attribute")
+	resource := fmt.Sprintf(`
 	
-// 	resource "aci_tacacs_plus_provider_group" "test" {
+	resource "aci_tacacs_provider_group" "test" {
 	
-// 		name  = "%s"
-// 	}
+		name  = "%s"
+	}
 
-// 	data "aci_tacacs_plus_provider_group" "test" {
+	data "aci_tacacs_provider_group" "test" {
 	
-// 		name  = aci_tacacs_plus_provider_group.test.name
-// 		%s = "%s"
-// 		depends_on = [ aci_tacacs_plus_provider_group.test ]
-// 	}
-// 	`, rName,key,value)
-// 	return resource
-// }
+		name  = aci_tacacs_provider_group.test.name
+		%s = "%s"
+		depends_on = [ aci_tacacs_provider_group.test ]
+	}
+	`, rName,key,value)
+	return resource
+}
 
-// func CreateAccTACACSPlusProviderGroupDataSourceUpdatedResource(rName, key, value string) string {
-// 	fmt.Println("=== STEP  testing tacacs_plus_provider_group Data Source with updated resource")
-// 	resource := fmt.Sprintf(`
+func CreateAccTACACSPlusProviderGroupDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing tacacs_provider_group Data Source with updated resource")
+	resource := fmt.Sprintf(`
 	
-// 	resource "aci_tacacs_plus_provider_group" "test" {
+	resource "aci_tacacs_provider_group" "test" {
 	
-// 		name  = "%s"
-// 		%s = "%s"
-// 	}
+		name  = "%s"
+		%s = "%s"
+	}
 
-// 	data "aci_tacacs_plus_provider_group" "test" {
+	data "aci_tacacs_provider_group" "test" {
 	
-// 		name  = aci_tacacs_plus_provider_group.test.name
-// 		depends_on = [ aci_tacacs_plus_provider_group.test ]
-// 	}
-// 	`, rName,key,value)
-// 	return resource
-// }
+		name  = aci_tacacs_provider_group.test.name
+		depends_on = [ aci_tacacs_provider_group.test ]
+	}
+	`, rName,key,value)
+	return resource
+}

--- a/testacc/resource_aci_aaaldapgroupmaprule_test.go
+++ b/testacc/resource_aci_aaaldapgroupmaprule_test.go
@@ -1,0 +1,341 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciLDAPGroupMapRule_Basic(t *testing.T) {
+	var ldap_group_map_rule_default models.LDAPGroupMapRule
+	var ldap_group_map_rule_updated models.LDAPGroupMapRule
+	resourceName := "aci_ldap_group_map_rule.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLDAPGroupMapRuleDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateLDAPGroupMapRuleWithoutRequired(rName, "duo", "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateLDAPGroupMapRuleWithoutRequired(rName, "duo", "type"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLDAPGroupMapRuleConfig(rName, "duo"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPGroupMapRuleExists(resourceName, &ldap_group_map_rule_default),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "groupdn", ""),
+					resource.TestCheckResourceAttr(resourceName, "type", "duo"),
+				),
+			},
+			{
+				Config: CreateAccLDAPGroupMapRuleConfigWithOptionalValues(rName, "duo"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPGroupMapRuleExists(resourceName, &ldap_group_map_rule_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_ldap_group_map_rule"),
+					resource.TestCheckResourceAttr(resourceName, "groupdn", "groupdn_example"),
+					resource.TestCheckResourceAttr(resourceName, "type", "duo"),
+					testAccCheckAciLDAPGroupMapRuleIdEqual(&ldap_group_map_rule_default, &ldap_group_map_rule_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccLDAPGroupMapRuleConfigWithRequiredParams(rName, rName),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccLDAPGroupMapRuleConfigUpdatedName(acctest.RandString(65), "duo"),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccLDAPGroupMapRuleRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+
+			{
+				Config: CreateAccLDAPGroupMapRuleConfigWithRequiredParams(rNameUpdated, "duo"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPGroupMapRuleExists(resourceName, &ldap_group_map_rule_updated),
+					resource.TestCheckResourceAttr(resourceName, "type", "duo"),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciLDAPGroupMapRuleIdNotEqual(&ldap_group_map_rule_default, &ldap_group_map_rule_updated),
+				),
+			},
+			{
+				Config: CreateAccLDAPGroupMapRuleConfig(rName, "duo"),
+			},
+			{
+				Config: CreateAccLDAPGroupMapRuleConfigWithRequiredParams(rName, "ldap"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPGroupMapRuleExists(resourceName, &ldap_group_map_rule_updated),
+					resource.TestCheckResourceAttr(resourceName, "type", "ldap"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciLDAPGroupMapRuleIdNotEqual(&ldap_group_map_rule_default, &ldap_group_map_rule_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciLDAPGroupMapRule_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLDAPGroupMapRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLDAPGroupMapRuleConfig(rName, "duo"),
+			},
+
+			{
+				Config:      CreateAccLDAPGroupMapRuleUpdatedAttr(rName, "duo", "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLDAPGroupMapRuleUpdatedAttr(rName, "duo", "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLDAPGroupMapRuleUpdatedAttr(rName, "duo", "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLDAPGroupMapRuleUpdatedAttr(rName, "duo", "groupdn", acctest.RandString(128)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLDAPGroupMapRuleUpdatedAttr(rName, "duo", randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccLDAPGroupMapRuleConfig(rName, "duo"),
+			},
+		},
+	})
+}
+
+func TestAccAciLDAPGroupMapRule_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLDAPGroupMapRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLDAPGroupMapRuleConfigMultiple(rName, "duo"),
+			},
+		},
+	})
+}
+
+func testAccCheckAciLDAPGroupMapRuleExists(name string, ldap_group_map_rule *models.LDAPGroupMapRule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("LDAP Group Map Rule %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No LDAP Group Map Rule dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		ldap_group_map_ruleFound := models.LDAPGroupMapRuleFromContainer(cont)
+		if ldap_group_map_ruleFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("LDAP Group Map Rule %s not found", rs.Primary.ID)
+		}
+		*ldap_group_map_rule = *ldap_group_map_ruleFound
+		return nil
+	}
+}
+
+func testAccCheckAciLDAPGroupMapRuleDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing ldap_group_map_rule destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_ldap_group_map_rule" {
+			cont, err := client.Get(rs.Primary.ID)
+			ldap_group_map_rule := models.LDAPGroupMapRuleFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("LDAP Group Map Rule %s Still exists", ldap_group_map_rule.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciLDAPGroupMapRuleIdEqual(m1, m2 *models.LDAPGroupMapRule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("ldap_group_map_rule DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciLDAPGroupMapRuleIdNotEqual(m1, m2 *models.LDAPGroupMapRule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("ldap_group_map_rule DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateLDAPGroupMapRuleWithoutRequired(rName, ruleType, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing ldap_group_map_rule creation without ", attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_ldap_group_map_rule" "test" {
+	#	name  = "%s"
+		type = "%s"
+	}
+		`
+	case "type":
+		rBlock += `
+	resource "aci_ldap_group_map_rule" "test" {
+		name  = "%s"
+	#	type = "%s"
+	}
+	`
+	}
+	return fmt.Sprintf(rBlock, rName, ruleType)
+}
+
+func CreateAccLDAPGroupMapRuleConfigWithRequiredParams(rName, ruleType string) string {
+	fmt.Printf("=== STEP  testing ldap_group_map_rule creation with name %s and type %s\n", rName, ruleType)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map_rule" "test" {
+		name  = "%s"
+		type = "%s"
+	}
+	`, rName, ruleType)
+	return resource
+}
+func CreateAccLDAPGroupMapRuleConfigUpdatedName(rName, ruleType string) string {
+	fmt.Println("=== STEP  testing ldap_group_map_rule creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map_rule" "test" {
+		name  = "%s"
+		type = "%s"
+	}
+	`, rName, ruleType)
+	return resource
+}
+
+func CreateAccLDAPGroupMapRuleConfig(rName, ruleType string) string {
+	fmt.Println("=== STEP  testing ldap_group_map_rule creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map_rule" "test" {
+		name  = "%s"
+		type = "%s"
+	}
+	`, rName, ruleType)
+	return resource
+}
+
+func CreateAccLDAPGroupMapRuleConfigMultiple(rName, ruleType string) string {
+	fmt.Println("=== STEP  testing multiple ldap_group_map_rule creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map_rule" "test" {
+		name  = "%s_${count.index}"
+		type = "%s"
+		count = 5
+	}
+	`, rName, ruleType)
+	return resource
+}
+
+func CreateAccLDAPGroupMapRuleConfigWithOptionalValues(rName, ruleType string) string {
+	fmt.Println("=== STEP  Basic: testing ldap_group_map_rule creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map_rule" "test" {
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_ldap_group_map_rule"
+		groupdn = "groupdn_example"
+		type = "%s"
+	}
+	`, rName, ruleType)
+
+	return resource
+}
+
+func CreateAccLDAPGroupMapRuleRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing ldap_group_map_rule updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_ldap_group_map_rule" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_ldap_group_map_rule"
+		groupdn = "groupdn_example"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccLDAPGroupMapRuleUpdatedAttr(rName, ruleType, attribute, value string) string {
+	fmt.Printf("=== STEP  testing ldap_group_map_rule attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map_rule" "test" {
+		name  = "%s"
+		type = "%s"
+		%s = "%s"
+	}
+	`, rName, ruleType, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_aaaldapgroupmapruleref_test.go
+++ b/testacc/resource_aci_aaaldapgroupmapruleref_test.go
@@ -1,0 +1,396 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciLDAPGroupMapruleref_Basic(t *testing.T) {
+	var ldap_group_map_rule_to_group_map_default models.LDAPGroupMapruleref
+	var ldap_group_map_rule_to_group_map_updated models.LDAPGroupMapruleref
+	resourceName := "aci_ldap_group_map_rule_to_group_map.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLDAPGroupMaprulerefDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateLDAPGroupMaprulerefWithoutRequired(rName, rName, "ldap_group_map_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateLDAPGroupMaprulerefWithoutRequired(rName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLDAPGroupMaprulerefConfig(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPGroupMaprulerefExists(resourceName, &ldap_group_map_rule_to_group_map_default),
+					resource.TestCheckResourceAttr(resourceName, "ldap_group_map_dn", fmt.Sprintf("uni/userext/duoext/ldapgroupmap-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+				),
+			},
+			{
+				Config: CreateAccLDAPGroupMaprulerefConfigWithOptionalValues(rName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPGroupMaprulerefExists(resourceName, &ldap_group_map_rule_to_group_map_updated),
+					resource.TestCheckResourceAttr(resourceName, "ldap_group_map_dn", fmt.Sprintf("uni/userext/duoext/ldapgroupmap-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_ldap_group_map_rule_to_group_map"),
+					testAccCheckAciLDAPGroupMaprulerefIdEqual(&ldap_group_map_rule_to_group_map_default, &ldap_group_map_rule_to_group_map_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccLDAPGroupMaprulerefConfigUpdatedName(rName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccLDAPGroupMaprulerefRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLDAPGroupMaprulerefConfigWithRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPGroupMaprulerefExists(resourceName, &ldap_group_map_rule_to_group_map_updated),
+					resource.TestCheckResourceAttr(resourceName, "ldap_group_map_dn", fmt.Sprintf("uni/userext/duoext/ldapgroupmap-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciLDAPGroupMaprulerefIdNotEqual(&ldap_group_map_rule_to_group_map_default, &ldap_group_map_rule_to_group_map_updated),
+				),
+			},
+			{
+				Config: CreateAccLDAPGroupMaprulerefConfig(rName, rName),
+			},
+			{
+				Config: CreateAccLDAPGroupMaprulerefConfigWithRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPGroupMaprulerefExists(resourceName, &ldap_group_map_rule_to_group_map_updated),
+					resource.TestCheckResourceAttr(resourceName, "ldap_group_map_dn", fmt.Sprintf("uni/userext/duoext/ldapgroupmap-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciLDAPGroupMaprulerefIdNotEqual(&ldap_group_map_rule_to_group_map_default, &ldap_group_map_rule_to_group_map_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciLDAPGroupMapruleref_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLDAPGroupMaprulerefDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLDAPGroupMaprulerefConfig(rName, rName),
+			},
+			{
+				Config:      CreateAccLDAPGroupMaprulerefWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccLDAPGroupMaprulerefUpdatedAttr(rName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLDAPGroupMaprulerefUpdatedAttr(rName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLDAPGroupMaprulerefUpdatedAttr(rName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLDAPGroupMaprulerefUpdatedAttr(rName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccLDAPGroupMaprulerefConfig(rName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciLDAPGroupMapruleref_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	aaaLdapGroupMapName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLDAPGroupMaprulerefDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLDAPGroupMaprulerefConfigMultiple(aaaLdapGroupMapName, rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciLDAPGroupMaprulerefExists(name string, ldap_group_map_rule_to_group_map *models.LDAPGroupMapruleref) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("LDAP Group Mapruleref %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No LDAP Group Mapruleref dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		ldap_group_map_rule_to_group_mapFound := models.LDAPGroupMaprulerefFromContainer(cont)
+		if ldap_group_map_rule_to_group_mapFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("LDAP Group Mapruleref %s not found", rs.Primary.ID)
+		}
+		*ldap_group_map_rule_to_group_map = *ldap_group_map_rule_to_group_mapFound
+		return nil
+	}
+}
+
+func testAccCheckAciLDAPGroupMaprulerefDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing ldap_group_map_rule_to_group_map destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_ldap_group_map_rule_to_group_map" {
+			cont, err := client.Get(rs.Primary.ID)
+			ldap_group_map_rule_to_group_map := models.LDAPGroupMaprulerefFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("LDAP Group Mapruleref %s Still exists", ldap_group_map_rule_to_group_map.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciLDAPGroupMaprulerefIdEqual(m1, m2 *models.LDAPGroupMapruleref) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("ldap_group_map_rule_to_group_map DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciLDAPGroupMaprulerefIdNotEqual(m1, m2 *models.LDAPGroupMapruleref) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("ldap_group_map_rule_to_group_map DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateLDAPGroupMaprulerefWithoutRequired(aaaLdapGroupMapName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing ldap_group_map_rule_to_group_map creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_ldap_group_map" "test" {
+		name 		= "%s"
+		type = "duo"
+	}
+	
+	`
+	switch attrName {
+	case "ldap_group_map_dn":
+		rBlock += `
+	resource "aci_ldap_group_map_rule_to_group_map" "test" {
+	#	ldap_group_map_dn  = aci_ldap_group_map.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_ldap_group_map.test.id
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, aaaLdapGroupMapName, rName)
+}
+
+func CreateAccLDAPGroupMaprulerefConfigWithRequiredParams(aaaLdapGroupMapName, rName string) string {
+	fmt.Println("=== STEP  testing ldap_group_map_rule_to_group_map creation with updated naming arguments")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+		name 		= "%s"
+		type = "duo"
+	}
+	
+	resource "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_ldap_group_map.test.id
+		name  = "%s"
+	}
+	`, aaaLdapGroupMapName, rName)
+	return resource
+}
+func CreateAccLDAPGroupMaprulerefConfigUpdatedName(aaaLdapGroupMapName, rName string) string {
+	fmt.Println("=== STEP  testing ldap_group_map_rule_to_group_map creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+		name 		= "%s"
+		type = "duo"
+	}
+	
+	resource "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_ldap_group_map.test.id
+		name  = "%s"
+	}
+	`, aaaLdapGroupMapName, rName)
+	return resource
+}
+
+func CreateAccLDAPGroupMaprulerefConfig(aaaLdapGroupMapName, rName string) string {
+	fmt.Println("=== STEP  testing ldap_group_map_rule_to_group_map creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+		name 		= "%s"
+		type = "duo"
+	}
+	
+	resource "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_ldap_group_map.test.id
+		name  = "%s"
+	}
+	`, aaaLdapGroupMapName, rName)
+	return resource
+}
+
+func CreateAccLDAPGroupMaprulerefConfigMultiple(aaaLdapGroupMapName, rName string) string {
+	fmt.Println("=== STEP  testing multiple ldap_group_map_rule_to_group_map creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+		name 		= "%s"
+		type = "duo"
+	}
+	
+	resource "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_ldap_group_map.test.id
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, aaaLdapGroupMapName, rName)
+	return resource
+}
+
+func CreateAccLDAPGroupMaprulerefWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing ldap_group_map_rule_to_group_map creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_tenant.test.id
+		name  = "%s"	
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccLDAPGroupMaprulerefConfigWithOptionalValues(aaaLdapGroupMapName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing ldap_group_map_rule_to_group_map creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+		name 		= "%s"
+		type = "duo"
+	}
+	
+	resource "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = "${aci_ldap_group_map.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_ldap_group_map_rule_to_group_map"
+		
+	}
+	`, aaaLdapGroupMapName, rName)
+
+	return resource
+}
+
+func CreateAccLDAPGroupMaprulerefRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing ldap_group_map_rule_to_group_map updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_ldap_group_map_rule_to_group_map" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_ldap_group_map_rule_to_group_map"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccLDAPGroupMaprulerefUpdatedAttr(aaaLdapGroupMapName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing ldap_group_map_rule_to_group_map attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+		name 		= "%s"
+		type = "duo"
+	}
+	
+	resource "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_ldap_group_map.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, aaaLdapGroupMapName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccLDAPGroupMaprulerefUpdatedAttrList(aaaLdapGroupMapName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing ldap_group_map_rule_to_group_map attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_ldap_group_map_rule_to_group_map" "test" {
+		ldap_group_map_dn  = aci_ldap_group_map.test.id
+		name  = "%s"
+		%s = %s
+	}
+	`, aaaLdapGroupMapName, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_aaatacacsplusprovider_test.go
+++ b/testacc/resource_aci_aaatacacsplusprovider_test.go
@@ -18,13 +18,13 @@ func TestAccAciTACACSProvider_Basic(t *testing.T) {
 	resourceName := "aci_tacacs_provider.test"
 	rName := makeTestVariable(acctest.RandString(5))
 	rNameUpdated := makeTestVariable(acctest.RandString(5))
-	
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:	  func(){ testAccPreCheck(t) },
-		ProviderFactories:    testAccProviders,
-		CheckDestroy: testAccCheckAciTACACSProviderDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciTACACSProviderDestroy,
 		Steps: []resource.TestStep{
-			
+
 			{
 				Config:      CreateTACACSProviderWithoutRequired(rName, "name"),
 				ExpectError: regexp.MustCompile(`Missing required argument`),
@@ -33,27 +33,24 @@ func TestAccAciTACACSProvider_Basic(t *testing.T) {
 				Config: CreateAccTACACSProviderConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciTACACSProviderExists(resourceName, &tacacs_provider_default),
-					
-					resource.TestCheckResourceAttr(resourceName, "name",rName),
-					resource.TestCheckResourceAttr(resourceName, "annotation","orchestrator:terraform"),
-					resource.TestCheckResourceAttr(resourceName, "description",""),
-					resource.TestCheckResourceAttr(resourceName, "name_alias",""),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
 					resource.TestCheckResourceAttr(resourceName, "auth_protocol", "pap"),
-					resource.TestCheckResourceAttr(resourceName, "key", ""),
 					resource.TestCheckResourceAttr(resourceName, "monitor_server", "disabled"),
-					resource.TestCheckResourceAttr(resourceName, "monitoring_password", ""),
 					resource.TestCheckResourceAttr(resourceName, "monitoring_user", "default"),
 					resource.TestCheckResourceAttr(resourceName, "port", "49"),
 					resource.TestCheckResourceAttr(resourceName, "retries", "1"),
 					resource.TestCheckResourceAttr(resourceName, "timeout", "5"),
-					
 				),
 			},
 			{
-				Config: CreateAccTACACSProviderConfigWithOptionalValues(rName), 
+				Config: CreateAccTACACSProviderConfigWithOptionalValues(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciTACACSProviderExists(resourceName, &tacacs_provider_updated),	
-					resource.TestCheckResourceAttr(resourceName, "name",rName),
+					testAccCheckAciTACACSProviderExists(resourceName, &tacacs_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
 					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
 					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_tacacs_provider"),
@@ -64,30 +61,31 @@ func TestAccAciTACACSProvider_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "monitoring_user", "monitoring_user_example"),
 					resource.TestCheckResourceAttr(resourceName, "port", "1"),
 					resource.TestCheckResourceAttr(resourceName, "retries", "5"),
-					resource.TestCheckResourceAttr(resourceName, "timeout", "1"),	
+					resource.TestCheckResourceAttr(resourceName, "timeout", "1"),
 					testAccCheckAciTACACSProviderIdEqual(&tacacs_provider_default, &tacacs_provider_updated),
 				),
-			},  
+			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"key", "monitoring_password"},
 			},
 			{
 				Config:      CreateAccTACACSProviderConfigUpdatedName(acctest.RandString(65)),
 				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
 			},
-			
+
 			{
 				Config:      CreateAccTACACSProviderRemovingRequiredField(),
 				ExpectError: regexp.MustCompile(`Missing required argument`),
 			},
-			
+
 			{
 				Config: CreateAccTACACSProviderConfigWithRequiredParams(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciTACACSProviderExists(resourceName, &tacacs_provider_updated),
-					resource.TestCheckResourceAttr(resourceName, "name",rNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
 					testAccCheckAciTACACSProviderIdNotEqual(&tacacs_provider_default, &tacacs_provider_updated),
 				),
 			},
@@ -100,11 +98,11 @@ func TestAccAciTACACSProvider_Update(t *testing.T) {
 	var tacacs_provider_updated models.TACACSProvider
 	resourceName := "aci_tacacs_provider.test"
 	rName := makeTestVariable(acctest.RandString(5))
-	
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:	  func(){ testAccPreCheck(t) },
-		ProviderFactories:    testAccProviders,
-		CheckDestroy: testAccCheckAciTACACSProviderDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciTACACSProviderDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: CreateAccTACACSProviderConfig(rName),
@@ -125,14 +123,6 @@ func TestAccAciTACACSProvider_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciTACACSProviderExists(resourceName, &tacacs_provider_updated),
 					resource.TestCheckResourceAttr(resourceName, "port", "32767"),
-					testAccCheckAciTACACSProviderIdEqual(&tacacs_provider_default, &tacacs_provider_updated),
-				),
-			},
-			{
-				Config: CreateAccTACACSProviderUpdatedAttr(rName, "retries", "5"),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAciTACACSProviderExists(resourceName, &tacacs_provider_updated),
-					resource.TestCheckResourceAttr(resourceName, "retries", "5"),
 					testAccCheckAciTACACSProviderIdEqual(&tacacs_provider_default, &tacacs_provider_updated),
 				),
 			},
@@ -160,7 +150,14 @@ func TestAccAciTACACSProvider_Update(t *testing.T) {
 					testAccCheckAciTACACSProviderIdEqual(&tacacs_provider_default, &tacacs_provider_updated),
 				),
 			},
-			
+			{
+				Config: CreateAccTACACSProviderUpdatedAttr(rName, "auth_protocol", "mschap"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSProviderExists(resourceName, &tacacs_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "auth_protocol", "mschap"),
+					testAccCheckAciTACACSProviderIdEqual(&tacacs_provider_default, &tacacs_provider_updated),
+				),
+			},
 			{
 				Config: CreateAccTACACSProviderConfig(rName),
 			},
@@ -170,19 +167,19 @@ func TestAccAciTACACSProvider_Update(t *testing.T) {
 
 func TestAccAciTACACSProvider_Negative(t *testing.T) {
 	rName := makeTestVariable(acctest.RandString(5))
-	
+
 	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
 	randomValue := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:	  func(){ testAccPreCheck(t) },
-		ProviderFactories:    testAccProviders,
-		CheckDestroy: testAccCheckAciTACACSProviderDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciTACACSProviderDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: CreateAccTACACSProviderConfig(rName),
 			},
-			
+
 			{
 				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "description", acctest.RandString(129)),
 				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
@@ -195,32 +192,22 @@ func TestAccAciTACACSProvider_Negative(t *testing.T) {
 				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
 				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
 			},
-			
+
 			{
 				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "auth_protocol", randomValue),
 				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
 			},
-			
-			{
-				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "key", randomValue),
-				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
-			},
-			
+
 			{
 				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "monitor_server", randomValue),
 				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
 			},
-			
+
 			{
-				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "monitoring_password", randomValue),
-				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "monitoring_user", acctest.RandString(33)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
 			},
-			
-			{
-				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "monitoring_user", randomValue),
-				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
-			},
-			
+
 			{
 				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "port", randomValue),
 				ExpectError: regexp.MustCompile(`unknown property value`),
@@ -233,7 +220,7 @@ func TestAccAciTACACSProvider_Negative(t *testing.T) {
 				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "port", "65536"),
 				ExpectError: regexp.MustCompile(`out of range`),
 			},
-			
+
 			{
 				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "retries", randomValue),
 				ExpectError: regexp.MustCompile(`unknown property value`),
@@ -246,7 +233,7 @@ func TestAccAciTACACSProvider_Negative(t *testing.T) {
 				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "retries", "6"),
 				ExpectError: regexp.MustCompile(`out of range`),
 			},
-			
+
 			{
 				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "timeout", randomValue),
 				ExpectError: regexp.MustCompile(`unknown property value`),
@@ -259,7 +246,7 @@ func TestAccAciTACACSProvider_Negative(t *testing.T) {
 				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "timeout", "61"),
 				ExpectError: regexp.MustCompile(`out of range`),
 			},
-			
+
 			{
 				Config:      CreateAccTACACSProviderUpdatedAttr(rName, randomParameter, randomValue),
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
@@ -273,11 +260,11 @@ func TestAccAciTACACSProvider_Negative(t *testing.T) {
 
 func TestAccAciTACACSProvider_MultipleCreateDelete(t *testing.T) {
 	rName := makeTestVariable(acctest.RandString(5))
-	
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:	  func(){ testAccPreCheck(t) },
-		ProviderFactories:    testAccProviders,
-		CheckDestroy: testAccCheckAciTACACSProviderDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciTACACSProviderDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: CreateAccTACACSProviderConfigMultiple(rName),
@@ -314,17 +301,17 @@ func testAccCheckAciTACACSProviderExists(name string, tacacs_provider *models.TA
 	}
 }
 
-func testAccCheckAciTACACSProviderDestroy(s *terraform.State) error {	
+func testAccCheckAciTACACSProviderDestroy(s *terraform.State) error {
 	fmt.Println("=== STEP  testing tacacs_provider destroy")
 	client := testAccProvider.Meta().(*client.Client)
 	for _, rs := range s.RootModule().Resources {
-		 if rs.Type == "aci_tacacs_provider" {
-			cont,err := client.Get(rs.Primary.ID)
+		if rs.Type == "aci_tacacs_provider" {
+			cont, err := client.Get(rs.Primary.ID)
 			tacacs_provider := models.TACACSProviderFromContainer(cont)
 			if err == nil {
-				return fmt.Errorf("TACACS Provider %s Still exists",tacacs_provider.DistinguishedName)
+				return fmt.Errorf("TACACS Provider %s Still exists", tacacs_provider.DistinguishedName)
 			}
-		}else{
+		} else {
 			continue
 		}
 	}
@@ -350,7 +337,7 @@ func testAccCheckAciTACACSProviderIdNotEqual(m1, m2 *models.TACACSProvider) reso
 }
 
 func CreateTACACSProviderWithoutRequired(rName, attrName string) string {
-	fmt.Println("=== STEP  Basic: testing tacacs_provider creation without ",attrName)
+	fmt.Println("=== STEP  Basic: testing tacacs_provider creation without ", attrName)
 	rBlock := `
 	
 	`
@@ -363,11 +350,11 @@ func CreateTACACSProviderWithoutRequired(rName, attrName string) string {
 	}
 		`
 	}
-	return fmt.Sprintf(rBlock,rName)
+	return fmt.Sprintf(rBlock, rName)
 }
 
 func CreateAccTACACSProviderConfigWithRequiredParams(rName string) string {
-	fmt.Println("=== STEP  testing tacacs_provider creation with updated naming arguments")
+	fmt.Println("=== STEP  testing tacacs_provider creation with name", rName)
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tacacs_provider" "test" {
@@ -378,7 +365,7 @@ func CreateAccTACACSProviderConfigWithRequiredParams(rName string) string {
 	return resource
 }
 func CreateAccTACACSProviderConfigUpdatedName(rName string) string {
-	fmt.Println("=== STEP  testing tacacs_provider creation with invalid name = ",rName)
+	fmt.Println("=== STEP  testing tacacs_provider creation with invalid name = ", rName)
 	resource := fmt.Sprintf(`
 	
 	resource "aci_tacacs_provider" "test" {
@@ -413,8 +400,6 @@ func CreateAccTACACSProviderConfigMultiple(rName string) string {
 	`, rName)
 	return resource
 }
-
-
 
 func CreateAccTACACSProviderConfigWithOptionalValues(rName string) string {
 	fmt.Println("=== STEP  Basic: testing tacacs_provider creation with optional parameters")
@@ -463,7 +448,7 @@ func CreateAccTACACSProviderRemovingRequiredField() string {
 	return resource
 }
 
-func CreateAccTACACSProviderUpdatedAttr(rName,attribute,value string) string {
+func CreateAccTACACSProviderUpdatedAttr(rName, attribute, value string) string {
 	fmt.Printf("=== STEP  testing tacacs_provider attribute: %s = %s \n", attribute, value)
 	resource := fmt.Sprintf(`
 	
@@ -472,11 +457,11 @@ func CreateAccTACACSProviderUpdatedAttr(rName,attribute,value string) string {
 		name  = "%s"
 		%s = "%s"
 	}
-	`, rName,attribute,value)
+	`, rName, attribute, value)
 	return resource
 }
 
-func CreateAccTACACSProviderUpdatedAttrList(rName,attribute,value string) string {
+func CreateAccTACACSProviderUpdatedAttrList(rName, attribute, value string) string {
 	fmt.Printf("=== STEP  testing tacacs_provider attribute: %s = %s \n", attribute, value)
 	resource := fmt.Sprintf(`
 	
@@ -485,6 +470,6 @@ func CreateAccTACACSProviderUpdatedAttrList(rName,attribute,value string) string
 		name  = "%s"
 		%s = %s
 	}
-	`, rName,attribute,value)
+	`, rName, attribute, value)
 	return resource
 }

--- a/testacc/resource_aci_aaatacacsplusprovider_test.go
+++ b/testacc/resource_aci_aaatacacsplusprovider_test.go
@@ -1,0 +1,490 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciTACACSProvider_Basic(t *testing.T) {
+	var tacacs_provider_default models.TACACSProvider
+	var tacacs_provider_updated models.TACACSProvider
+	resourceName := "aci_tacacs_provider.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciTACACSProviderDestroy,
+		Steps: []resource.TestStep{
+			
+			{
+				Config:      CreateTACACSProviderWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccTACACSProviderConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSProviderExists(resourceName, &tacacs_provider_default),
+					
+					resource.TestCheckResourceAttr(resourceName, "name",rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation","orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description",""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias",""),
+					resource.TestCheckResourceAttr(resourceName, "auth_protocol", "pap"),
+					resource.TestCheckResourceAttr(resourceName, "key", ""),
+					resource.TestCheckResourceAttr(resourceName, "monitor_server", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_password", ""),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_user", "default"),
+					resource.TestCheckResourceAttr(resourceName, "port", "49"),
+					resource.TestCheckResourceAttr(resourceName, "retries", "1"),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "5"),
+					
+				),
+			},
+			{
+				Config: CreateAccTACACSProviderConfigWithOptionalValues(rName), 
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSProviderExists(resourceName, &tacacs_provider_updated),	
+					resource.TestCheckResourceAttr(resourceName, "name",rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_tacacs_provider"),
+					resource.TestCheckResourceAttr(resourceName, "auth_protocol", "chap"),
+					resource.TestCheckResourceAttr(resourceName, "key", "example_key"),
+					resource.TestCheckResourceAttr(resourceName, "monitor_server", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_password", "monitoring_password_example"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_user", "monitoring_user_example"),
+					resource.TestCheckResourceAttr(resourceName, "port", "1"),
+					resource.TestCheckResourceAttr(resourceName, "retries", "5"),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "1"),	
+					testAccCheckAciTACACSProviderIdEqual(&tacacs_provider_default, &tacacs_provider_updated),
+				),
+			},  
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccTACACSProviderConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			
+			{
+				Config:      CreateAccTACACSProviderRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			
+			{
+				Config: CreateAccTACACSProviderConfigWithRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSProviderExists(resourceName, &tacacs_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "name",rNameUpdated),
+					testAccCheckAciTACACSProviderIdNotEqual(&tacacs_provider_default, &tacacs_provider_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciTACACSProvider_Update(t *testing.T) {
+	var tacacs_provider_default models.TACACSProvider
+	var tacacs_provider_updated models.TACACSProvider
+	resourceName := "aci_tacacs_provider.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciTACACSProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccTACACSProviderConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSProviderExists(resourceName, &tacacs_provider_default),
+				),
+			},
+			{
+				Config: CreateAccTACACSProviderUpdatedAttr(rName, "port", "65535"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSProviderExists(resourceName, &tacacs_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "port", "65535"),
+					testAccCheckAciTACACSProviderIdEqual(&tacacs_provider_default, &tacacs_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccTACACSProviderUpdatedAttr(rName, "port", "32767"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSProviderExists(resourceName, &tacacs_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "port", "32767"),
+					testAccCheckAciTACACSProviderIdEqual(&tacacs_provider_default, &tacacs_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccTACACSProviderUpdatedAttr(rName, "retries", "5"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSProviderExists(resourceName, &tacacs_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "retries", "5"),
+					testAccCheckAciTACACSProviderIdEqual(&tacacs_provider_default, &tacacs_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccTACACSProviderUpdatedAttr(rName, "retries", "2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSProviderExists(resourceName, &tacacs_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "retries", "2"),
+					testAccCheckAciTACACSProviderIdEqual(&tacacs_provider_default, &tacacs_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccTACACSProviderUpdatedAttr(rName, "timeout", "60"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSProviderExists(resourceName, &tacacs_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "60"),
+					testAccCheckAciTACACSProviderIdEqual(&tacacs_provider_default, &tacacs_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccTACACSProviderUpdatedAttr(rName, "timeout", "30"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSProviderExists(resourceName, &tacacs_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "30"),
+					testAccCheckAciTACACSProviderIdEqual(&tacacs_provider_default, &tacacs_provider_updated),
+				),
+			},
+			
+			{
+				Config: CreateAccTACACSProviderConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciTACACSProvider_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciTACACSProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccTACACSProviderConfig(rName),
+			},
+			
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "auth_protocol", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "key", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "monitor_server", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "monitoring_password", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "monitoring_user", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "port", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "port", "0"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "port", "65536"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "retries", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "retries", "-1"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "retries", "6"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "timeout", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "timeout", "-1"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, "timeout", "61"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			
+			{
+				Config:      CreateAccTACACSProviderUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccTACACSProviderConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciTACACSProvider_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciTACACSProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccTACACSProviderConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciTACACSProviderExists(name string, tacacs_provider *models.TACACSProvider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("TACACS Provider %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No TACACS Provider dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		tacacs_providerFound := models.TACACSProviderFromContainer(cont)
+		if tacacs_providerFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("TACACS Provider %s not found", rs.Primary.ID)
+		}
+		*tacacs_provider = *tacacs_providerFound
+		return nil
+	}
+}
+
+func testAccCheckAciTACACSProviderDestroy(s *terraform.State) error {	
+	fmt.Println("=== STEP  testing tacacs_provider destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		 if rs.Type == "aci_tacacs_provider" {
+			cont,err := client.Get(rs.Primary.ID)
+			tacacs_provider := models.TACACSProviderFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("TACACS Provider %s Still exists",tacacs_provider.DistinguishedName)
+			}
+		}else{
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciTACACSProviderIdEqual(m1, m2 *models.TACACSProvider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("tacacs_provider DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciTACACSProviderIdNotEqual(m1, m2 *models.TACACSProvider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("tacacs_provider DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateTACACSProviderWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing tacacs_provider creation without ",attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_tacacs_provider" "test" {
+	
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock,rName)
+}
+
+func CreateAccTACACSProviderConfigWithRequiredParams(rName string) string {
+	fmt.Println("=== STEP  testing tacacs_provider creation with updated naming arguments")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_provider" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+func CreateAccTACACSProviderConfigUpdatedName(rName string) string {
+	fmt.Println("=== STEP  testing tacacs_provider creation with invalid name = ",rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_provider" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccTACACSProviderConfig(rName string) string {
+	fmt.Println("=== STEP  testing tacacs_provider creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_provider" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccTACACSProviderConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple tacacs_provider creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_provider" "test" {
+	
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+
+
+func CreateAccTACACSProviderConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing tacacs_provider creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_provider" "test" {
+	
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_tacacs_provider"
+		auth_protocol = "chap"
+		key = "example_key"
+		monitor_server = "enabled"
+		monitoring_password = "monitoring_password_example"
+		monitoring_user = "monitoring_user_example"
+		port = "1"
+		retries = "5"
+		timeout = "1"
+		
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccTACACSProviderRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing tacacs_provider updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_tacacs_provider" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_tacacs_provider"
+		auth_protocol = "chap"
+		key = ""
+		monitor_server = "enabled"
+		monitoring_password = ""
+		monitoring_user = ""
+		port = "2"
+		retries = "1"
+		timeout = "1"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccTACACSProviderUpdatedAttr(rName,attribute,value string) string {
+	fmt.Printf("=== STEP  testing tacacs_provider attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_provider" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName,attribute,value)
+	return resource
+}
+
+func CreateAccTACACSProviderUpdatedAttrList(rName,attribute,value string) string {
+	fmt.Printf("=== STEP  testing tacacs_provider attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_provider" "test" {
+	
+		name  = "%s"
+		%s = %s
+	}
+	`, rName,attribute,value)
+	return resource
+}

--- a/testacc/resource_aci_aaatacacsplusprovidergroup_test.go
+++ b/testacc/resource_aci_aaatacacsplusprovidergroup_test.go
@@ -1,0 +1,303 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciTACACSPlusProviderGroup_Basic(t *testing.T) {
+	var tacacs_provider_group_default models.TACACSPlusProviderGroup
+	var tacacs_provider_group_updated models.TACACSPlusProviderGroup
+	resourceName := "aci_tacacs_provider_group.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciTACACSPlusProviderGroupDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateTACACSPlusProviderGroupWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccTACACSPlusProviderGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSPlusProviderGroupExists(resourceName, &tacacs_provider_group_default),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+				),
+			},
+			{
+				Config: CreateAccTACACSPlusProviderGroupConfigWithOptionalValues(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSPlusProviderGroupExists(resourceName, &tacacs_provider_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_tacacs_provider_group"),
+					testAccCheckAciTACACSPlusProviderGroupIdEqual(&tacacs_provider_group_default, &tacacs_provider_group_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccTACACSPlusProviderGroupConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccTACACSPlusProviderGroupRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccTACACSPlusProviderGroupConfigWithRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSPlusProviderGroupExists(resourceName, &tacacs_provider_group_updated),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciTACACSPlusProviderGroupIdNotEqual(&tacacs_provider_group_default, &tacacs_provider_group_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciTACACSPlusProviderGroup_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciTACACSPlusProviderGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccTACACSPlusProviderGroupConfig(rName),
+			},
+
+			{
+				Config:      CreateAccTACACSPlusProviderGroupUpdatedAttr(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccTACACSPlusProviderGroupUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccTACACSPlusProviderGroupUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccTACACSPlusProviderGroupUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccTACACSPlusProviderGroupConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciTACACSPlusProviderGroup_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciTACACSPlusProviderGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccTACACSPlusProviderGroupConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciTACACSPlusProviderGroupExists(name string, tacacs_provider_group *models.TACACSPlusProviderGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("TACACS Plus Provider Group %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No TACACS Plus Provider Group dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		tacacs_provider_groupFound := models.TACACSPlusProviderGroupFromContainer(cont)
+		if tacacs_provider_groupFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("TACACS Plus Provider Group %s not found", rs.Primary.ID)
+		}
+		*tacacs_provider_group = *tacacs_provider_groupFound
+		return nil
+	}
+}
+
+func testAccCheckAciTACACSPlusProviderGroupDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing tacacs_provider_group destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_tacacs_provider_group" {
+			cont, err := client.Get(rs.Primary.ID)
+			tacacs_provider_group := models.TACACSPlusProviderGroupFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("TACACS Plus Provider Group %s Still exists", tacacs_provider_group.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciTACACSPlusProviderGroupIdEqual(m1, m2 *models.TACACSPlusProviderGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("tacacs_provider_group DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciTACACSPlusProviderGroupIdNotEqual(m1, m2 *models.TACACSPlusProviderGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("tacacs_provider_group DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateTACACSPlusProviderGroupWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing tacacs_provider_group creation without ", attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_tacacs_provider_group" "test" {
+	
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccTACACSPlusProviderGroupConfigWithRequiredParams(rName string) string {
+	fmt.Println("=== STEP  testing tacacs_provider_group creation with updated naming arguments")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_provider_group" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+func CreateAccTACACSPlusProviderGroupConfigUpdatedName(rName string) string {
+	fmt.Println("=== STEP  testing tacacs_provider_group creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_provider_group" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccTACACSPlusProviderGroupConfig(rName string) string {
+	fmt.Println("=== STEP  testing tacacs_provider_group creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_provider_group" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccTACACSPlusProviderGroupConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple tacacs_provider_group creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_provider_group" "test" {
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccTACACSPlusProviderGroupConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing tacacs_provider_group creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_provider_group" "test" {
+	
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_tacacs_provider_group"
+		
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccTACACSPlusProviderGroupRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing tacacs_provider_group updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_tacacs_provider_group" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_tacacs_provider_group"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccTACACSPlusProviderGroupUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing tacacs_provider_group attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_provider_group" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName, attribute, value)
+	return resource
+}


### PR DESCRIPTION
$ go test -v -run TestAccAciTACACSPlusProviderGroup -timeout=60m
=== RUN   TestAccAciTACACSPlusProviderGroupDataSource_Basic
=== STEP  Basic: testing tacacs_provider_group Data Source without  name
=== STEP  testing tacacs_provider_group Data Source with required arguments only
=== STEP  testing tacacs_provider_group Data Source with random attribute
=== STEP  testing tacacs_provider_group Data Source with invalid name
=== STEP  testing tacacs_provider_group Data Source with updated resource
=== PAUSE TestAccAciTACACSPlusProviderGroupDataSource_Basic
=== RUN   TestAccAciTACACSPlusProviderGroup_Basic
=== STEP  Basic: testing tacacs_provider_group creation without  name
=== STEP  testing tacacs_provider_group creation with required arguments only
=== STEP  Basic: testing tacacs_provider_group creation with optional parameters
=== STEP  testing tacacs_provider_group creation with invalid name =  nqq1yurxeyu0tg6wp6z0v0pc2v7nxby0s90lfapt21u7q848bnipzwgfqrmzskqab
=== STEP  Basic: testing tacacs_provider_group updation without required parameters
=== STEP  testing tacacs_provider_group creation with updated naming arguments
=== PAUSE TestAccAciTACACSPlusProviderGroup_Basic
=== RUN   TestAccAciTACACSPlusProviderGroup_Negative
=== STEP  testing tacacs_provider_group creation with required arguments only
=== STEP  testing tacacs_provider_group attribute: description = nc38zwh4mtvf2yhqpx1iojtnk1zv7tx8g4w2ndz6katfro6fmwrcslhbcp8jb6k6prqw8e7aj2qvshuylaakd30jp3qxysiznu0tz12vxv60hlhaocuipqvyk9ngehz2d
=== STEP  testing tacacs_provider_group attribute: annotation = bexgzly9yscybmvi6qdpxw118o3jnyd7knjykeltzmkqemhdtiwrfyqz86xid8kslxdcwi03iuy9zs6qnwhxdqo7udkku7ki23vvzjjvk6bl1tiueqygmcit9qga07vdy
=== STEP  testing tacacs_provider_group attribute: name_alias = hggbqinw173u2z8avcd49b0bthd4ntj4ni9xfyf1qdr3nvq4778czbk60yiadfo7
=== STEP  testing tacacs_provider_group attribute: lqxxc = 4jow6
=== STEP  testing tacacs_provider_group creation with required arguments only
=== PAUSE TestAccAciTACACSPlusProviderGroup_Negative
=== RUN   TestAccAciTACACSPlusProviderGroup_MultipleCreateDelete
=== STEP  testing multiple tacacs_provider_group creation with required arguments only
=== PAUSE TestAccAciTACACSPlusProviderGroup_MultipleCreateDelete
=== CONT  TestAccAciTACACSPlusProviderGroupDataSource_Basic
=== CONT  TestAccAciTACACSPlusProviderGroup_Negative
=== CONT  TestAccAciTACACSPlusProviderGroup_Basic
=== CONT  TestAccAciTACACSPlusProviderGroup_MultipleCreateDelete
=== STEP  testing tacacs_provider_group destroy
--- PASS: TestAccAciTACACSPlusProviderGroup_MultipleCreateDelete (15.75s)
=== STEP  testing tacacs_provider_group destroy
--- PASS: TestAccAciTACACSPlusProviderGroupDataSource_Basic (28.80s)
=== STEP  testing tacacs_provider_group destroy
--- PASS: TestAccAciTACACSPlusProviderGroup_Negative (36.68s)
=== STEP  testing tacacs_provider_group destroy
--- PASS: TestAccAciTACACSPlusProviderGroup_Basic (41.34s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   42.917s
$ go test -v -run TestAccAciTACACSProvider -timeout=60m
=== RUN   TestAccAciTACACSProviderDataSource_Basic
=== STEP  Basic: testing tacacs_provider Data Source without  name
=== STEP  testing tacacs_provider Data Source with required arguments only
=== STEP  testing tacacs_provider Data Source with random attribute
=== STEP  testing tacacs_provider Data Source with invalid name
=== STEP  testing tacacs_provider Data Source with updated resource
=== PAUSE TestAccAciTACACSProviderDataSource_Basic
=== RUN   TestAccAciTACACSProvider_Basic
=== STEP  Basic: testing tacacs_provider creation without  name
=== STEP  testing tacacs_provider creation with required arguments only
=== STEP  Basic: testing tacacs_provider creation with optional parameters
=== STEP  testing tacacs_provider creation with invalid name =  xysqvvoa48v8tsnlvof9dkzuilvnbp9y38ja6pkqjdybeh644ww7hs8cosevtyqmu
=== STEP  Basic: testing tacacs_provider updation without required parameters
=== STEP  testing tacacs_provider creation with name acctest_izbkd
=== PAUSE TestAccAciTACACSProvider_Basic
=== RUN   TestAccAciTACACSProvider_Update
=== STEP  testing tacacs_provider creation with required arguments only
=== STEP  testing tacacs_provider attribute: port = 65535
=== STEP  testing tacacs_provider attribute: port = 32767
=== STEP  testing tacacs_provider attribute: retries = 2
=== STEP  testing tacacs_provider attribute: timeout = 60
=== STEP  testing tacacs_provider attribute: timeout = 30
=== STEP  testing tacacs_provider attribute: auth_protocol = mschap
=== STEP  testing tacacs_provider creation with required arguments only
=== PAUSE TestAccAciTACACSProvider_Update
=== RUN   TestAccAciTACACSProvider_Negative
=== STEP  testing tacacs_provider creation with required arguments only
=== STEP  testing tacacs_provider attribute: description = lti3213tivm9hhr4pcbypiyklyzmokujc69quj0ji7qej2z9weia28kwuv49vhszri4px8beyellv1y4tczcr84r1ek2oxek7cv66olbkeyonpgjhdjh3w41iz9q4pyfe
=== STEP  testing tacacs_provider attribute: annotation = c1hcbqy2wyc2x6n0668qtltc0mq2dph0xtgscjqplviaumlx00rxzhyxv9wiz0aa7mjz34ef9inoh86oob9sfrutsy4ul4tc6ik44btesc2yvxzh9ub3ivm24bk0dcdt4
=== STEP  testing tacacs_provider attribute: name_alias = s9piqaimv4ceor6avv0otigl2hvnczj6etko4vm2rls16f1bvjfdpmhk2ohzahd6
=== STEP  testing tacacs_provider attribute: auth_protocol = 7vmt8
=== STEP  testing tacacs_provider attribute: monitor_server = 7vmt8
=== STEP  testing tacacs_provider attribute: monitoring_user = gqkefjl8oaf8mjdcdsvhemdih2alhnkdx
=== STEP  testing tacacs_provider attribute: port = 7vmt8
=== STEP  testing tacacs_provider attribute: port = 0
=== STEP  testing tacacs_provider attribute: port = 65536
=== STEP  testing tacacs_provider attribute: retries = 7vmt8
=== STEP  testing tacacs_provider attribute: retries = -1
=== STEP  testing tacacs_provider attribute: retries = 6
=== STEP  testing tacacs_provider attribute: timeout = 7vmt8
=== STEP  testing tacacs_provider attribute: timeout = -1
=== STEP  testing tacacs_provider attribute: timeout = 61
=== STEP  testing tacacs_provider attribute: jhtis = 7vmt8
=== STEP  testing tacacs_provider creation with required arguments only
=== PAUSE TestAccAciTACACSProvider_Negative
=== RUN   TestAccAciTACACSProvider_MultipleCreateDelete
=== STEP  testing multiple tacacs_provider creation with required arguments only
=== PAUSE TestAccAciTACACSProvider_MultipleCreateDelete
=== CONT  TestAccAciTACACSProviderDataSource_Basic
=== CONT  TestAccAciTACACSProvider_Negative
=== CONT  TestAccAciTACACSProvider_Basic
=== CONT  TestAccAciTACACSProvider_MultipleCreateDelete
=== CONT  TestAccAciTACACSProvider_Update
=== STEP  testing tacacs_provider destroy
--- PASS: TestAccAciTACACSProvider_MultipleCreateDelete (29.92s)
=== STEP  testing tacacs_provider destroy
--- PASS: TestAccAciTACACSProviderDataSource_Basic (43.99s)
=== STEP  testing tacacs_provider destroy
--- PASS: TestAccAciTACACSProvider_Basic (53.67s)
=== STEP  testing tacacs_provider destroy
--- PASS: TestAccAciTACACSProvider_Negative (89.10s)
=== STEP  testing tacacs_provider destroy
--- PASS: TestAccAciTACACSProvider_Update (96.14s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   97.854s
$ go test -v -run TestAccAciLDAPGroupMapruleref -timeout=60m
=== RUN   TestAccAciLDAPGroupMaprulerefDataSource_Basic
=== STEP  Basic: testing ldap_group_map_rule_to_group_map Data Source without  ldap_group_map_dn
=== STEP  Basic: testing ldap_group_map_rule_to_group_map Data Source without  name
=== STEP  testing ldap_group_map_rule_to_group_map Data Source with required arguments only
=== STEP  testing ldap_group_map_rule_to_group_map Data Source with random attribute
=== STEP  testing ldap_group_map_rule_to_group_map Data Source with invalid name
=== STEP  testing ldap_group_map_rule_to_group_map Data Source with updated resource
=== PAUSE TestAccAciLDAPGroupMaprulerefDataSource_Basic
=== RUN   TestAccAciLDAPGroupMapruleref_Basic
=== STEP  Basic: testing ldap_group_map_rule_to_group_map creation without  ldap_group_map_dn
=== STEP  Basic: testing ldap_group_map_rule_to_group_map creation without  name
=== STEP  testing ldap_group_map_rule_to_group_map creation with required arguments only
=== STEP  Basic: testing ldap_group_map_rule_to_group_map creation with optional parameters
=== STEP  testing ldap_group_map_rule_to_group_map creation with invalid name =  go2xclrvg3pir01bbmc3uwjq2c1r4bmdnsyojmhrbc1wuccdvbcj09wcw70qekdyz
=== STEP  Basic: testing ldap_group_map_rule_to_group_map updation without required parameters
=== STEP  testing ldap_group_map_rule_to_group_map creation with updated naming arguments
=== STEP  testing ldap_group_map_rule_to_group_map creation with required arguments only
=== STEP  testing ldap_group_map_rule_to_group_map creation with updated naming arguments
=== PAUSE TestAccAciLDAPGroupMapruleref_Basic
=== RUN   TestAccAciLDAPGroupMapruleref_Negative
=== STEP  testing ldap_group_map_rule_to_group_map creation with required arguments only
=== STEP  Negative Case: testing ldap_group_map_rule_to_group_map creation with invalid parent Dn
=== STEP  testing ldap_group_map_rule_to_group_map attribute: description = s9nsxmxyy4ijxixszlsxdrtkq3jnb7id814ve48cfk7fy8mz6it14qapmb3wuz17w09ovg81nhc9fihyrfm8jdx3mh1el4d7ieews1jkfq4dgp47gn1kg0hv0comorjia
=== STEP  testing ldap_group_map_rule_to_group_map attribute: annotation = alr7m3vrg6a6d8bzbkk2qeah0epvlbjgn0rnbyfnl0igh00yskbg6y79p7xezvk9utgdptjg1tzfm3jvfcmcv72fk1s1xgdt3e2ukh4xh7w2lazuerh8eho7sl87ol9qa
=== STEP  testing ldap_group_map_rule_to_group_map attribute: name_alias = zn7wuqy3pt3fql0zp4grnaudm2bt8nqsosl28q33a3nu76x4yraw3hkpv3joco4x
=== STEP  testing ldap_group_map_rule_to_group_map attribute: mlbeq = yoore
=== STEP  testing ldap_group_map_rule_to_group_map creation with required arguments only
=== PAUSE TestAccAciLDAPGroupMapruleref_Negative
=== RUN   TestAccAciLDAPGroupMapruleref_MultipleCreateDelete
=== STEP  testing multiple ldap_group_map_rule_to_group_map creation with required arguments only
=== PAUSE TestAccAciLDAPGroupMapruleref_MultipleCreateDelete
=== CONT  TestAccAciLDAPGroupMaprulerefDataSource_Basic
=== CONT  TestAccAciLDAPGroupMapruleref_Negative
=== CONT  TestAccAciLDAPGroupMapruleref_Basic
=== CONT  TestAccAciLDAPGroupMapruleref_MultipleCreateDelete
=== STEP  testing ldap_group_map_rule_to_group_map destroy
--- PASS: TestAccAciLDAPGroupMapruleref_MultipleCreateDelete (30.94s)
=== STEP  testing ldap_group_map_rule_to_group_map destroy
--- PASS: TestAccAciLDAPGroupMaprulerefDataSource_Basic (54.04s)
=== STEP  testing ldap_group_map_rule_to_group_map destroy
--- PASS: TestAccAciLDAPGroupMapruleref_Negative (68.02s)
=== STEP  testing ldap_group_map_rule_to_group_map destroy
--- PASS: TestAccAciLDAPGroupMapruleref_Basic (92.18s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   93.649s
$ go test -v -run TestAccAciLDAPGroupMapRule -timeout=60m
=== RUN   TestAccAciLDAPGroupMapRuleDataSource_Basic
=== STEP  Basic: testing ldap_group_map_rule Data Source without  name
=== STEP  testing ldap_group_map_rule Data Source with required arguments only
=== STEP  testing ldap_group_map_rule Data Source with random attribute
=== STEP  testing ldap_group_map_rule Data Source with invalid name
=== STEP  testing ldap_group_map_rule Data Source with updated resource
=== PAUSE TestAccAciLDAPGroupMapRuleDataSource_Basic
=== RUN   TestAccAciLDAPGroupMapRule_Basic
=== STEP  Basic: testing ldap_group_map_rule creation without  name
=== STEP  Basic: testing ldap_group_map_rule creation without  type
=== STEP  testing ldap_group_map_rule creation with required arguments only
=== STEP  Basic: testing ldap_group_map_rule creation with optional parameters
=== STEP  testing ldap_group_map_rule creation with name acctest_j4r0v and type acctest_j4r0v
=== STEP  testing ldap_group_map_rule creation with invalid name =  jel2mspic6w0izgzn2md61ujqc1axlvxeuglkg18xd7l9z7bp0hz8ykf8p2dj2ok9
=== STEP  Basic: testing ldap_group_map_rule updation without required parameters
=== STEP  testing ldap_group_map_rule creation with name acctest_v6bxb and type duo
=== STEP  testing ldap_group_map_rule creation with required arguments only
=== STEP  testing ldap_group_map_rule creation with name acctest_j4r0v and type ldap
=== PAUSE TestAccAciLDAPGroupMapRule_Basic
=== RUN   TestAccAciLDAPGroupMapRule_Negative
=== STEP  testing ldap_group_map_rule creation with required arguments only
=== STEP  testing ldap_group_map_rule attribute: description = ib6fz2k7w39asvdl00qrtb9mosui8az8gy4v20b7ew1a9hb7fr84ygiri7ejyic0kf9yhxz8btaikhzy3fazzec2hibeqkly27gevzw2ziox9ngfldmyqfy2q1wco4d6y
=== STEP  testing ldap_group_map_rule attribute: annotation = dlgmon3mce9wm2toafx6p4fhpjfqq9q6u1wbsq1dekkor84ip9iilu9rfd3wyx0geo62yltsg4dvz84updz42shnojz4vm92hvwh183il7j4zwgtl81kbw0idx9fspmwk
=== STEP  testing ldap_group_map_rule attribute: name_alias = prjg8nu2d4098ae9jhpuapuhcajj6sno2s0bdqrfmtn4z67nwqbws3leqeklpfuk
=== STEP  testing ldap_group_map_rule attribute: groupdn = xhlkwvc10u22bm0quxrhk1s7javlioqi778eznjs0jlc6v6u8i7sw89l9uieirjx6okhk10qlodwhkkm4t7f4fd9s1wovv74hwiwgopn4hrgbioumbmwqgghuyxlu9ry
=== STEP  testing ldap_group_map_rule attribute: cgkff = qjnac
=== STEP  testing ldap_group_map_rule creation with required arguments only
=== PAUSE TestAccAciLDAPGroupMapRule_Negative
=== RUN   TestAccAciLDAPGroupMapRule_MultipleCreateDelete
=== STEP  testing multiple ldap_group_map_rule creation with required arguments only
=== PAUSE TestAccAciLDAPGroupMapRule_MultipleCreateDelete
=== CONT  TestAccAciLDAPGroupMapRuleDataSource_Basic
=== CONT  TestAccAciLDAPGroupMapRule_Negative
=== CONT  TestAccAciLDAPGroupMapRule_MultipleCreateDelete
=== CONT  TestAccAciLDAPGroupMapRule_Basic
=== STEP  testing ldap_group_map_rule destroy
--- PASS: TestAccAciLDAPGroupMapRule_MultipleCreateDelete (16.57s)
=== STEP  testing ldap_group_map_rule destroy
--- PASS: TestAccAciLDAPGroupMapRuleDataSource_Basic (35.81s)
=== STEP  testing ldap_group_map_rule destroy
--- PASS: TestAccAciLDAPGroupMapRule_Negative (52.60s)
=== STEP  testing ldap_group_map_rule destroy
--- PASS: TestAccAciLDAPGroupMapRule_Basic (77.65s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   78.977s
