### PR TITLE
added authentication_properties

### DIFF
--- a/aci/data_source_aci_aaaauthrealm.go
+++ b/aci/data_source_aci_aaaauthrealm.go
@@ -44,7 +44,7 @@ func dataSourceAciAAAAuthenticationRead(ctx context.Context, d *schema.ResourceD
 
 	rnrealm := fmt.Sprintf("userext/authrealm")
 	dnrealm := fmt.Sprintf("uni/%s", rnrealm)
-	aaaAuthRealm, err := getRemoteAAAAuthentication(aciClient, dnrealm)
+	aaaAuthRealm, err := GetRemoteAAAAuthentication(aciClient, dnrealm)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -55,7 +55,7 @@ func dataSourceAciAAAAuthenticationRead(ctx context.Context, d *schema.ResourceD
 	}
 	rnpingep := fmt.Sprintf("userext/pingext")
 	dnpingep := fmt.Sprintf("uni/%s", rnpingep)
-	aaaPingEp, err := getRemoteDefaultRadiusAuthenticationSettings(aciClient, dnpingep)
+	aaaPingEp, err := GetRemoteDefaultRadiusAuthenticationSettings(aciClient, dnpingep)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/aci/resource_aci_aaaauthrealm.go
+++ b/aci/resource_aci_aaaauthrealm.go
@@ -57,7 +57,7 @@ func resourceAciAAAAuthentication() *schema.Resource {
 	}
 }
 
-func getRemoteDefaultRadiusAuthenticationSettings(client *client.Client, dn string) (*models.DefaultRadiusAuthenticationSettings, error) {
+func GetRemoteDefaultRadiusAuthenticationSettings(client *client.Client, dn string) (*models.DefaultRadiusAuthenticationSettings, error) {
 	aaaPingEpCont, err := client.Get(dn)
 	if err != nil {
 		return nil, err
@@ -69,7 +69,7 @@ func getRemoteDefaultRadiusAuthenticationSettings(client *client.Client, dn stri
 	return aaaPingEp, nil
 }
 
-func getRemoteAAAAuthentication(client *client.Client, dn string) (*models.AAAAuthentication, error) {
+func GetRemoteAAAAuthentication(client *client.Client, dn string) (*models.AAAAuthentication, error) {
 	aaaAuthRealmCont, err := client.Get(dn)
 	if err != nil {
 		return nil, err
@@ -113,7 +113,7 @@ func resourceAciAAAAuthenticationImport(d *schema.ResourceData, m interface{}) (
 	log.Printf("[DEBUG] %s: Beginning Import", d.Id())
 	aciClient := m.(*client.Client)
 	dn := d.Id()
-	aaaAuthRealm, err := getRemoteAAAAuthentication(aciClient, dn)
+	aaaAuthRealm, err := GetRemoteAAAAuthentication(aciClient, dn)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +246,7 @@ func resourceAciAAAAuthenticationRead(ctx context.Context, d *schema.ResourceDat
 	log.Printf("[DEBUG] %s: Beginning Read", d.Id())
 	aciClient := m.(*client.Client)
 	dnauthrealm := "uni/userext/authrealm"
-	aaaAuthRealm, err := getRemoteAAAAuthentication(aciClient, dnauthrealm)
+	aaaAuthRealm, err := GetRemoteAAAAuthentication(aciClient, dnauthrealm)
 	if err != nil {
 		d.SetId("")
 		return diag.FromErr(err)
@@ -257,7 +257,7 @@ func resourceAciAAAAuthenticationRead(ctx context.Context, d *schema.ResourceDat
 		return nil
 	}
 	dnpingep := "uni/userext/pingext"
-	aaaPingEp, err := getRemoteDefaultRadiusAuthenticationSettings(aciClient, dnpingep)
+	aaaPingEp, err := GetRemoteDefaultRadiusAuthenticationSettings(aciClient, dnpingep)
 	if err != nil {
 		d.SetId("")
 		return diag.FromErr(err)

--- a/testacc/data_source_aci_aaaauthrealm_test.go
+++ b/testacc/data_source_aci_aaaauthrealm_test.go
@@ -1,0 +1,126 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aci/aci"
+)
+
+func TestAccAciAAAAuthenticationDataSource_Basic(t *testing.T) {
+	resourceName := "aci_authentication_properties.test"
+	dataSourceName := "data.aci_authentication_properties.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	aaaAuthRealm, err := aci.GetRemoteAAAAuthentication(sharedAciClient(), "uni/userext/authrealm")
+	if err != nil {
+		t.Errorf("reading initial config of authenticationProperties")
+	}
+	aaaPingEp, err := aci.GetRemoteDefaultRadiusAuthenticationSettings(sharedAciClient(), "uni/userext/pingext")
+	if err != nil {
+		t.Errorf("reading initial config of authenticationProperties")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccAAAAuthenticationConfigDataSource(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "def_role_policy", resourceName, "def_role_policy"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ping_check", resourceName, "ping_check"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "retries", resourceName, "retries"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "timeout", resourceName, "timeout"),
+				),
+			},
+			{
+				Config:      CreateAccAAAAuthenticationDataSourceUpdate(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config: CreateAccAAAAuthenticationDataSourceUpdatedResource("annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+
+			{
+				Config: CreateAccAAAAuthenticationInitialConfig(aaaAuthRealm, aaaPingEp),
+			},
+		},
+	})
+}
+
+func CreateAccAAAAuthenticationConfigDataSource() string {
+	fmt.Println("=== STEP  testing authentication_properties Data Source with required arguments only")
+	resource := fmt.Sprintln(`
+	
+	resource "aci_authentication_properties" "test" {
+	
+	}
+
+	data "aci_authentication_properties" "test" {
+	
+		depends_on = [ aci_authentication_properties.test ]
+	}
+	`)
+	return resource
+}
+
+func CreateAccAAAAuthenticationDataSourceUpdate(key, value string) string {
+	fmt.Println("=== STEP  testing authentication_properties Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_authentication_properties" "test" {
+	
+	}
+
+	data "aci_authentication_properties" "test" {
+	
+		%s = "%s"
+		depends_on = [ aci_authentication_properties.test ]
+	}
+	`, key, value)
+	return resource
+}
+
+func CreateAccAAAAuthenticationDataSourceUpdatedResource(key, value string) string {
+	fmt.Println("=== STEP  testing authentication_properties Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_authentication_properties" "test" {
+	
+		%s = "%s"
+	}
+
+	data "aci_authentication_properties" "test" {
+	
+		depends_on = [ aci_authentication_properties.test ]
+	}
+	`, key, value)
+	return resource
+}
+
+func CreateAccAAAAuthenticationInitialConfig(aaaAuthRealm *models.AAAAuthentication, aaaPingEp *models.DefaultRadiusAuthenticationSettings) string {
+	resource := fmt.Sprintf(`
+	
+	resource "aci_authentication_properties" "test" {
+		annotation = "%s"
+		name_alias = "%s"
+		description = "%s"
+		def_role_policy = "%s"
+		ping_check = "%s"
+		retries = "%s"
+		timeout = "%s"
+	}
+	`, aaaAuthRealm.Annotation, aaaAuthRealm.NameAlias, aaaAuthRealm.Description, aaaAuthRealm.DefRolePolicy, aaaPingEp.PingCheck, aaaPingEp.Retries, aaaPingEp.Timeout)
+	return resource
+}

--- a/testacc/data_source_aci_aaaldapgroupmaprule_test.go
+++ b/testacc/data_source_aci_aaaldapgroupmaprule_test.go
@@ -27,6 +27,10 @@ func TestAccAciLDAPGroupMapRuleDataSource_Basic(t *testing.T) {
 				ExpectError: regexp.MustCompile(`Missing required argument`),
 			},
 			{
+				Config:      CreateLDAPGroupMapRuleDSWithoutRequired(rName, "type"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
 				Config: CreateAccLDAPGroupMapRuleConfigDataSource(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "type", resourceName, "type"),

--- a/testacc/resource_aci_aaaauthrealm_test.go
+++ b/testacc/resource_aci_aaaauthrealm_test.go
@@ -1,0 +1,293 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aci/aci"
+)
+
+func TestAccAciAAAAuthentication_Basic(t *testing.T) {
+	var authentication_properties_default models.AAAAuthentication
+	var authentication_properties_updated models.AAAAuthentication
+	resourceName := "aci_authentication_properties.test"
+	aaaAuthRealm, err := aci.GetRemoteAAAAuthentication(sharedAciClient(), "uni/userext/authrealm")
+	if err != nil {
+		t.Errorf("reading initial config of authenticationProperties")
+	}
+	aaaPingEp, err := aci.GetRemoteDefaultRadiusAuthenticationSettings(sharedAciClient(), "uni/userext/pingext")
+	if err != nil {
+		t.Errorf("reading initial config of authenticationProperties")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccAAAAuthenticationConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciAAAAuthenticationExists(resourceName, &authentication_properties_default),
+					resource.TestCheckResourceAttrSet(resourceName, "def_role_policy"),
+					resource.TestCheckResourceAttrSet(resourceName, "ping_check"),
+					resource.TestCheckResourceAttrSet(resourceName, "retries"),
+					resource.TestCheckResourceAttrSet(resourceName, "timeout"),
+				),
+			},
+			{
+				Config: CreateAccAAAAuthenticationConfigWithOptionalValues(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciAAAAuthenticationExists(resourceName, &authentication_properties_updated),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_authentication_properties"),
+					resource.TestCheckResourceAttr(resourceName, "def_role_policy", "assign-default-role"),
+					resource.TestCheckResourceAttr(resourceName, "ping_check", "false"),
+					resource.TestCheckResourceAttr(resourceName, "retries", "0"),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "1"),
+					testAccCheckAciAAAAuthenticationIdEqual(&authentication_properties_default, &authentication_properties_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: CreateAccAAAAuthenticationInitialConfig(aaaAuthRealm, aaaPingEp),
+			},
+		},
+	})
+}
+
+func TestAccAciAAAAuthentication_Update(t *testing.T) {
+	var authentication_properties_default models.AAAAuthentication
+	var authentication_properties_updated models.AAAAuthentication
+	resourceName := "aci_authentication_properties.test"
+	aaaAuthRealm, err := aci.GetRemoteAAAAuthentication(sharedAciClient(), "uni/userext/authrealm")
+	if err != nil {
+		t.Errorf("reading initial config of authenticationProperties")
+	}
+	aaaPingEp, err := aci.GetRemoteDefaultRadiusAuthenticationSettings(sharedAciClient(), "uni/userext/pingext")
+	if err != nil {
+		t.Errorf("reading initial config of authenticationProperties")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccAAAAuthenticationConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciAAAAuthenticationExists(resourceName, &authentication_properties_default),
+				),
+			},
+			{
+				Config: CreateAccAAAAuthenticationUpdatedAttr("def_role_policy", "no-login"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciAAAAuthenticationExists(resourceName, &authentication_properties_updated),
+					resource.TestCheckResourceAttr(resourceName, "def_role_policy", "no-login"),
+					testAccCheckAciAAAAuthenticationIdEqual(&authentication_properties_default, &authentication_properties_updated),
+				),
+			},
+			{
+				Config: CreateAccAAAAuthenticationUpdatedAttr("ping_check", "true"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciAAAAuthenticationExists(resourceName, &authentication_properties_updated),
+					resource.TestCheckResourceAttr(resourceName, "ping_check", "true"),
+					testAccCheckAciAAAAuthenticationIdEqual(&authentication_properties_default, &authentication_properties_updated),
+				),
+			},
+			{
+				Config: CreateAccAAAAuthenticationUpdatedAttr("retries", "5"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciAAAAuthenticationExists(resourceName, &authentication_properties_updated),
+					resource.TestCheckResourceAttr(resourceName, "retries", "5"),
+					testAccCheckAciAAAAuthenticationIdEqual(&authentication_properties_default, &authentication_properties_updated),
+				),
+			},
+			{
+				Config: CreateAccAAAAuthenticationUpdatedAttr("retries", "2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciAAAAuthenticationExists(resourceName, &authentication_properties_updated),
+					resource.TestCheckResourceAttr(resourceName, "retries", "2"),
+					testAccCheckAciAAAAuthenticationIdEqual(&authentication_properties_default, &authentication_properties_updated),
+				),
+			},
+			{
+				Config: CreateAccAAAAuthenticationUpdatedAttr("timeout", "60"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciAAAAuthenticationExists(resourceName, &authentication_properties_updated),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "60"),
+					testAccCheckAciAAAAuthenticationIdEqual(&authentication_properties_default, &authentication_properties_updated),
+				),
+			},
+			{
+				Config: CreateAccAAAAuthenticationUpdatedAttr("timeout", "30"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciAAAAuthenticationExists(resourceName, &authentication_properties_updated),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "30"),
+					testAccCheckAciAAAAuthenticationIdEqual(&authentication_properties_default, &authentication_properties_updated),
+				),
+			},
+			{
+				Config: CreateAccAAAAuthenticationInitialConfig(aaaAuthRealm, aaaPingEp),
+			},
+		},
+	})
+}
+
+func TestAccAciAAAAuthentication_Negative(t *testing.T) {
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	aaaAuthRealm, err := aci.GetRemoteAAAAuthentication(sharedAciClient(), "uni/userext/authrealm")
+	if err != nil {
+		t.Errorf("reading initial config of authenticationProperties")
+	}
+	aaaPingEp, err := aci.GetRemoteDefaultRadiusAuthenticationSettings(sharedAciClient(), "uni/userext/pingext")
+	if err != nil {
+		t.Errorf("reading initial config of authenticationProperties")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccAAAAuthenticationConfig(),
+			},
+
+			{
+				Config:      CreateAccAAAAuthenticationUpdatedAttr("description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccAAAAuthenticationUpdatedAttr("annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccAAAAuthenticationUpdatedAttr("name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccAAAAuthenticationUpdatedAttr("def_role_policy", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccAAAAuthenticationUpdatedAttr("retries", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccAAAAuthenticationUpdatedAttr("retries", "6"),
+				ExpectError: regexp.MustCompile(`is out of range`),
+			},
+			{
+				Config:      CreateAccAAAAuthenticationUpdatedAttr("retries", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccAAAAuthenticationUpdatedAttr("timeout", "0"),
+				ExpectError: regexp.MustCompile(`is out of range`),
+			},
+			{
+				Config:      CreateAccAAAAuthenticationUpdatedAttr("timeout", "61"),
+				ExpectError: regexp.MustCompile(`is out of range`),
+			},
+			{
+				Config:      CreateAccAAAAuthenticationUpdatedAttr("timeout", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccAAAAuthenticationUpdatedAttr(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccAAAAuthenticationInitialConfig(aaaAuthRealm, aaaPingEp),
+			},
+		},
+	})
+}
+
+func testAccCheckAciAAAAuthenticationExists(name string, authentication_properties *models.AAAAuthentication) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("AAA Authentication %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No AAA Authentication dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		authentication_propertiesFound := models.AAAAuthenticationFromContainer(cont)
+		if authentication_propertiesFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("AAA Authentication %s not found", rs.Primary.ID)
+		}
+		*authentication_properties = *authentication_propertiesFound
+		return nil
+	}
+}
+
+func testAccCheckAciAAAAuthenticationIdEqual(m1, m2 *models.AAAAuthentication) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("authentication_properties DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func CreateAccAAAAuthenticationConfig() string {
+	fmt.Println("=== STEP  testing authentication_properties creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_authentication_properties" "test" {
+	
+	}
+	`)
+	return resource
+}
+
+func CreateAccAAAAuthenticationConfigWithOptionalValues() string {
+	fmt.Println("=== STEP  Basic: testing authentication_properties creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_authentication_properties" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_authentication_properties"
+		def_role_policy = "assign-default-role"
+		ping_check = "false"
+		retries = "0"
+		timeout = "1"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccAAAAuthenticationUpdatedAttr(attribute, value string) string {
+	fmt.Printf("=== STEP  testing authentication_properties attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_authentication_properties" "test" {
+	
+		%s = "%s"
+	}
+	`, attribute, value)
+	return resource
+}


### PR DESCRIPTION
$ go test -v -run TestAccAciAAAAuthentication -timeout=60m
=== RUN   TestAccAciAAAAuthenticationDataSource_Basic
=== STEP  testing authentication_properties Data Source with required arguments only
=== STEP  testing authentication_properties Data Source with random attribute
=== STEP  testing authentication_properties Data Source with updated resource
--- PASS: TestAccAciAAAAuthenticationDataSource_Basic (47.27s)
=== RUN   TestAccAciAAAAuthentication_Basic
=== STEP  testing authentication_properties creation with required arguments only
=== STEP  Basic: testing authentication_properties creation with optional parameters
--- PASS: TestAccAciAAAAuthentication_Basic (45.47s)
=== RUN   TestAccAciAAAAuthentication_Update
=== STEP  testing authentication_properties creation with required arguments only
=== STEP  testing authentication_properties attribute: def_role_policy = no-login
=== STEP  testing authentication_properties attribute: ping_check = true
=== STEP  testing authentication_properties attribute: retries = 5
=== STEP  testing authentication_properties attribute: retries = 2
=== STEP  testing authentication_properties attribute: timeout = 60
=== STEP  testing authentication_properties attribute: timeout = 30
--- PASS: TestAccAciAAAAuthentication_Update (99.27s)
=== RUN   TestAccAciAAAAuthentication_Negative
=== STEP  testing authentication_properties creation with required arguments only
=== STEP  testing authentication_properties attribute: description = 08flp8cd8rr618y4jae8fjxixazei0h3v4ec6bhn0fwhors7ubpkd88pefl1q8tr7fg8w6m4jfablyay0mdziw9q6n8p1ugxg7wgj11ssknrc6rl4d8fqugb9mnq0ili1
=== STEP  testing authentication_properties attribute: annotation = s74jact2fzmddpfoa1m69zrx9wvknhlhc3et3pc0h1gclauq9vnyk9th0co6jdqyeo2undvb8picoal02de39483tt4qpbh2800el8nypae7mi23aa8mxpudc3d27xmbd
=== STEP  testing authentication_properties attribute: name_alias = 2xlxxvmr6z1kxb7jho6hiamsyp4bavjy3e3z4zsc2yuky346h3uz68wklycajfir
=== STEP  testing authentication_properties attribute: def_role_policy = grjb6
=== STEP  testing authentication_properties attribute: retries = -1
=== STEP  testing authentication_properties attribute: retries = 6
=== STEP  testing authentication_properties attribute: retries = grjb6
=== STEP  testing authentication_properties attribute: timeout = 0
=== STEP  testing authentication_properties attribute: timeout = 61
=== STEP  testing authentication_properties attribute: timeout = grjb6
=== STEP  testing authentication_properties attribute: zaavx = grjb6
--- PASS: TestAccAciAAAAuthentication_Negative (69.33s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   262.723s
$ go test -v -run TestAccAciLDAPGroupMapRule -timeout=60m
=== RUN   TestAccAciLDAPGroupMapRuleDataSource_Basic
=== STEP  Basic: testing ldap_group_map_rule Data Source without  name
=== STEP  Basic: testing ldap_group_map_rule Data Source without  type
=== STEP  testing ldap_group_map_rule Data Source with required arguments only
=== STEP  testing ldap_group_map_rule Data Source with random attribute
=== STEP  testing ldap_group_map_rule Data Source with invalid name
=== STEP  testing ldap_group_map_rule Data Source with updated resource
=== PAUSE TestAccAciLDAPGroupMapRuleDataSource_Basic
=== RUN   TestAccAciLDAPGroupMapRule_Basic
=== STEP  Basic: testing ldap_group_map_rule creation without  name
=== STEP  Basic: testing ldap_group_map_rule creation without  type
=== STEP  testing ldap_group_map_rule creation with required arguments only
=== STEP  Basic: testing ldap_group_map_rule creation with optional parameters
=== STEP  testing ldap_group_map_rule creation with name acctest_1rgbf and type acctest_1rgbf
=== STEP  testing ldap_group_map_rule creation with invalid name =  3zrvj1bvhkn7wt6mxw4cllkzius3jxiikmwa166engv3nz6fa9achh3yaneptd9qo
=== STEP  Basic: testing ldap_group_map_rule updation without required parameters
=== STEP  testing ldap_group_map_rule creation with name acctest_utc9k and type duo
=== STEP  testing ldap_group_map_rule creation with required arguments only
=== STEP  testing ldap_group_map_rule creation with name acctest_1rgbf and type ldap
=== PAUSE TestAccAciLDAPGroupMapRule_Basic
=== RUN   TestAccAciLDAPGroupMapRule_Negative
=== STEP  testing ldap_group_map_rule creation with required arguments only
=== STEP  testing ldap_group_map_rule attribute: description = 176swe8csegzfi3joag3y2ns2lk6xziqwwf13rgffch2ikdgarw6etyvlvr8fia8ybf3tmtw3vqlg0j27tt6ijipcflzlsmcdhnzv1n81dzk0khphe28luyvnvz2zrds2
=== STEP  testing ldap_group_map_rule attribute: annotation = ugzndxi1fysoifxlk0p3dy1js8qorkeqjdmmsw7oksqw3mgevumuarivnfchjowahe9o6qqh2kj2gtsyf2e8rcjhnwobor9ntxkp3z4tfoqqvclgynrsspierog3m107g
=== STEP  testing ldap_group_map_rule attribute: name_alias = 3uhdzvrgsbejkygvuabhyglicmeph11o6syam440olqh2zvzof2317wc0aenijah
=== STEP  testing ldap_group_map_rule attribute: groupdn = j8w7z1tyottfdjf0cwr74xaf3nubrvr366r8khnn3uhlppjgoj4sxi1w030o8dpluivobrsgqxn1hoo3cml3nrk7miwwdk7xugzlxxaiv42ou4koq2noiu3bcfzsth0b
=== STEP  testing ldap_group_map_rule attribute: tomca = ermk4
=== STEP  testing ldap_group_map_rule creation with required arguments only
=== PAUSE TestAccAciLDAPGroupMapRule_Negative
=== RUN   TestAccAciLDAPGroupMapRule_MultipleCreateDelete
=== STEP  testing multiple ldap_group_map_rule creation with required arguments only
=== PAUSE TestAccAciLDAPGroupMapRule_MultipleCreateDelete
=== CONT  TestAccAciLDAPGroupMapRuleDataSource_Basic
=== CONT  TestAccAciLDAPGroupMapRule_Negative
=== CONT  TestAccAciLDAPGroupMapRule_MultipleCreateDelete
=== CONT  TestAccAciLDAPGroupMapRule_Basic
=== STEP  testing ldap_group_map_rule destroy
--- PASS: TestAccAciLDAPGroupMapRule_MultipleCreateDelete (18.23s)
=== STEP  testing ldap_group_map_rule destroy
--- PASS: TestAccAciLDAPGroupMapRule_Negative (47.05s)
=== STEP  testing ldap_group_map_rule destroy
--- PASS: TestAccAciLDAPGroupMapRuleDataSource_Basic (48.34s)
=== STEP  testing ldap_group_map_rule destroy
--- PASS: TestAccAciLDAPGroupMapRule_Basic (78.41s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   80.150s
