### PR TITLE
Added Fabric Node Control and Updated Filter Entry

### DIFF
--- a/testacc/data_source_aci_fabricnodecontrol_test.go
+++ b/testacc/data_source_aci_fabricnodecontrol_test.go
@@ -1,0 +1,136 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciFabricNodeControlDataSource_Basic(t *testing.T) {
+	resourceName := "aci_fabric_node_control.test"
+	dataSourceName := "data.aci_fabric_node_control.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFabricNodeControlDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateFabricNodeControlDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccFabricNodeControlConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "control", resourceName, "control"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "feature_sel", resourceName, "feature_sel"),
+				),
+			},
+			{
+				Config:      CreateAccFabricNodeControlDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccFabricNodeControlDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccFabricNodeControlDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccFabricNodeControlConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing fabric_node_control Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_fabric_node_control" "test" {
+		name  = "%s"
+	}
+	data "aci_fabric_node_control" "test" {
+		name  = aci_fabric_node_control.test.name
+		depends_on = [ aci_fabric_node_control.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateFabricNodeControlDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing fabric_node_control Data Source without ", attrName)
+	rBlock := `
+	resource "aci_fabric_node_control" "test" {
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_fabric_node_control" "test" {
+	#	name  = aci_fabric_node_control.test.name
+		depends_on = [ aci_fabric_node_control.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccFabricNodeControlDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing fabric_node_control Data Source with Invalid Name")
+	resource := fmt.Sprintf(`
+	resource "aci_fabric_node_control" "test" {
+		name  = "%s"
+	}
+
+	data "aci_fabric_node_control" "test" {
+		name  = "${aci_fabric_node_control.test.name}_invalid"
+		depends_on = [ aci_fabric_node_control.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccFabricNodeControlDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing fabric_node_control Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	resource "aci_fabric_node_control" "test" {
+		name  = "%s"
+	}
+
+	data "aci_fabric_node_control" "test" {
+		name  = aci_fabric_node_control.test.name
+		%s = "%s"
+		depends_on = [ aci_fabric_node_control.test ]
+	}
+	`, rName, key, value)
+	return resource
+}
+
+func CreateAccFabricNodeControlDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing fabric_node_control Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	resource "aci_fabric_node_control" "test" {
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_fabric_node_control" "test" {
+		name  = aci_fabric_node_control.test.name
+		depends_on = [ aci_fabric_node_control.test ]
+	}
+	`, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_vzentry_test.go
+++ b/testacc/data_source_aci_vzentry_test.go
@@ -70,7 +70,7 @@ func TestAccAciFilterEntryDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccFilterEntryUpdatedConfigDataSourceRandomAttr(rName, attribute, value string) string {
-	fmt.Println("=== STEP  Basic: Testing filter entry data source with updated resource")
+	fmt.Println("=== STEP  Basic: Testing filter entry data source with Random Attribute")
 	resource := fmt.Sprintf(`
 	resource "aci_tenant" "test" {
 		name = "%s"

--- a/testacc/resource_aci_fabricnodecontrol_test.go
+++ b/testacc/resource_aci_fabricnodecontrol_test.go
@@ -1,0 +1,334 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciFabricNodeControl_Basic(t *testing.T) {
+	var fabric_node_control_default models.FabricNodeControl
+	var fabric_node_control_updated models.FabricNodeControl
+	resourceName := "aci_fabric_node_control.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFabricNodeControlDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateFabricNodeControlWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccFabricNodeControlConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeControlExists(resourceName, &fabric_node_control_default),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "control", "None"),
+					resource.TestCheckResourceAttr(resourceName, "feature_sel", "telemetry"),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeControlConfigWithOptionalValues(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeControlExists(resourceName, &fabric_node_control_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_fabric_node_control"),
+					resource.TestCheckResourceAttr(resourceName, "control", "Dom"),
+					resource.TestCheckResourceAttr(resourceName, "feature_sel", "analytics"),
+					testAccCheckAciFabricNodeControlIdEqual(&fabric_node_control_default, &fabric_node_control_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccFabricNodeControlConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			{
+				Config:      CreateAccFabricNodeControlRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccFabricNodeControlConfigWithRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeControlExists(resourceName, &fabric_node_control_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciFabricNodeControlIdNotEqual(&fabric_node_control_default, &fabric_node_control_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciFabricNodeControl_Update(t *testing.T) {
+	var fabric_node_control_default models.FabricNodeControl
+	var fabric_node_control_updated models.FabricNodeControl
+	resourceName := "aci_fabric_node_control.test"
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFabricNodeControlDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccFabricNodeControlConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeControlExists(resourceName, &fabric_node_control_default),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeControlUpdatedAttr(rName, "feature_sel", "netflow"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeControlExists(resourceName, &fabric_node_control_updated),
+					resource.TestCheckResourceAttr(resourceName, "feature_sel", "netflow"),
+					testAccCheckAciFabricNodeControlIdEqual(&fabric_node_control_default, &fabric_node_control_updated),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeControlConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciFabricNodeControl_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFabricNodeControlDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccFabricNodeControlConfig(rName),
+			},
+
+			{
+				Config:      CreateAccFabricNodeControlUpdatedAttr(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccFabricNodeControlUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccFabricNodeControlUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccFabricNodeControlUpdatedAttr(rName, "control", randomValue),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccFabricNodeControlUpdatedAttr(rName, "feature_sel", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccFabricNodeControlUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccFabricNodeControlConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciFabricNodeControl_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFabricNodeControlDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccFabricNodeControlConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciFabricNodeControlExists(name string, fabric_node_control *models.FabricNodeControl) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Fabric Node Control %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Fabric Node Control dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		fabric_node_controlFound := models.FabricNodeControlFromContainer(cont)
+		if fabric_node_controlFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Fabric Node Control %s not found", rs.Primary.ID)
+		}
+		*fabric_node_control = *fabric_node_controlFound
+		return nil
+	}
+}
+
+func testAccCheckAciFabricNodeControlDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing fabric_node_control destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_fabric_node_control" {
+			cont, err := client.Get(rs.Primary.ID)
+			fabric_node_control := models.FabricNodeControlFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Fabric Node Control %s Still exists", fabric_node_control.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciFabricNodeControlIdEqual(m1, m2 *models.FabricNodeControl) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("fabric_node_control DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciFabricNodeControlIdNotEqual(m1, m2 *models.FabricNodeControl) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("fabric_node_control DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateFabricNodeControlWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing fabric_node_control creation without ", attrName)
+	rBlock := `
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_fabric_node_control" "test" {
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccFabricNodeControlConfigWithRequiredParams(rName string) string {
+	fmt.Println("=== STEP  testing fabric_node_control creation with updated Name")
+	resource := fmt.Sprintf(`
+	resource "aci_fabric_node_control" "test" {	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+func CreateAccFabricNodeControlConfigUpdatedName(rName string) string {
+	fmt.Println("=== STEP  testing fabric_node_control creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	resource "aci_fabric_node_control" "test" {
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccFabricNodeControlConfig(rName string) string {
+	fmt.Println("=== STEP  testing fabric_node_control creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_fabric_node_control" "test" {
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccFabricNodeControlConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple fabric_node_control creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_fabric_node_control" "test" {
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccFabricNodeControlConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing fabric_node_control creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_fabric_node_control" "test" {
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_fabric_node_control"
+		control = "Dom"
+		feature_sel = "analytics"
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccFabricNodeControlRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing fabric_node_control updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_fabric_node_control" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_fabric_node_control"
+		control = "Dom"
+		feature_sel = "analytics"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccFabricNodeControlUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing fabric_node_control attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_fabric_node_control" "test" {
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_vzentry_test.go
+++ b/testacc/resource_aci_vzentry_test.go
@@ -66,6 +66,7 @@ func TestAccAciFilterEntry_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "test_description"),
 					resource.TestCheckResourceAttr(resourceName, "annotation", "test_annotation"),
 					resource.TestCheckResourceAttr(resourceName, "arp_opc", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "apply_to_frag", "no"),
 					resource.TestCheckResourceAttr(resourceName, "d_from_port", "https"),
 					resource.TestCheckResourceAttr(resourceName, "d_to_port", "https"),
 					resource.TestCheckResourceAttr(resourceName, "ether_t", "ip"),
@@ -961,16 +962,11 @@ func CreateAccFilterEntryWithInvalidFilter(rName string) string {
 		name = "%s"
 	}
 
-	resource "aci_filter" "test"{
-		tenant_dn = aci_tenant.test.id
-		name = "%s"
-	}
-
 	resource "aci_filter_entry" "test"{
 		filter_dn = aci_tenant.test.id
 		name = "%s"
 	}
-	`, rName, rName, rName)
+	`, rName, rName)
 	return resource
 }
 


### PR DESCRIPTION
$ go test -v -run TestAccAciFabricNodeControl -timeout=60m
=== RUN   TestAccAciFabricNodeControlDataSource_Basic
=== STEP  Basic: testing fabric_node_control Data Source without  name
=== STEP  testing fabric_node_control Data Source with required arguments only
=== STEP  testing fabric_node_control Data Source with random attribute
=== STEP  testing fabric_node_control Data Source with Invalid Name
=== STEP  testing fabric_node_control Data Source with updated resource
=== PAUSE TestAccAciFabricNodeControlDataSource_Basic
=== RUN   TestAccAciFabricNodeControl_Basic
=== STEP  Basic: testing fabric_node_control creation without  name
=== STEP  testing fabric_node_control creation with required arguments only
=== STEP  Basic: testing fabric_node_control creation with optional parameters
=== STEP  testing fabric_node_control creation with invalid name =  uhi9i3btzbzo21lbby4l6ifjc4pnrprzexl3ibiwuwxsoel83xhrydlgkbg9xodz3
=== STEP  Basic: testing fabric_node_control updation without required parameters
=== STEP  testing fabric_node_control creation with updated Name
=== PAUSE TestAccAciFabricNodeControl_Basic
=== RUN   TestAccAciFabricNodeControl_Update
=== STEP  testing fabric_node_control creation with required arguments only
=== STEP  testing fabric_node_control attribute: feature_sel = netflow
=== STEP  testing fabric_node_control creation with required arguments only
=== PAUSE TestAccAciFabricNodeControl_Update
=== RUN   TestAccAciFabricNodeControl_Negative
=== STEP  testing fabric_node_control creation with required arguments only
=== STEP  testing fabric_node_control attribute: description = rdmypgvy2mz3b1k7n0pf0hp2h3ut809fxz3glmm62mp1vj3ns7auzmjpcu6bfqzx0lx4xz0gjuuaqze8cxzdlwb1o0a1zhgrtitc3atidyk1gkf72l11qdaiuszr8t2sx
=== STEP  testing fabric_node_control attribute: annotation = wa9tjzng4psp7mlqnjkulq128u8ihlzn961oevs6lknqc20dqpf73kvtxctq16k1n06rbno31z38g4v6l0k1mw34j9p1gmgryno9ahl63jxz9tsqfi4ex67klepn97g6s
=== STEP  testing fabric_node_control attribute: name_alias = 18r48o27us92hxtzozo6dtc42vsnn6qp4jmqe2vp1u90utup9io9waovpuy6v7qr
=== STEP  testing fabric_node_control attribute: control = qwhs1
=== STEP  testing fabric_node_control attribute: feature_sel = qwhs1
=== STEP  testing fabric_node_control attribute: hbxvc = qwhs1
=== STEP  testing fabric_node_control creation with required arguments only
=== PAUSE TestAccAciFabricNodeControl_Negative
=== RUN   TestAccAciFabricNodeControl_MultipleCreateDelete
=== STEP  testing multiple fabric_node_control creation with required arguments only
=== PAUSE TestAccAciFabricNodeControl_MultipleCreateDelete
=== CONT  TestAccAciFabricNodeControlDataSource_Basic
=== CONT  TestAccAciFabricNodeControl_Negative
=== CONT  TestAccAciFabricNodeControl_MultipleCreateDelete
=== CONT  TestAccAciFabricNodeControl_Update
=== CONT  TestAccAciFabricNodeControl_Basic
=== STEP  testing fabric_node_control destroy
--- PASS: TestAccAciFabricNodeControl_MultipleCreateDelete (71.64s)
=== STEP  testing fabric_node_control destroy
--- PASS: TestAccAciFabricNodeControlDataSource_Basic (168.73s)
=== STEP  testing fabric_node_control destroy
--- PASS: TestAccAciFabricNodeControl_Update (177.56s)
=== STEP  testing fabric_node_control destroy
--- PASS: TestAccAciFabricNodeControl_Negative (206.77s)
=== STEP  testing fabric_node_control destroy
--- PASS: TestAccAciFabricNodeControl_Basic (219.76s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   222.664s

$ go test -v -run TestAccAciFilterEntry_Basic -timeout=60m
=== RUN   TestAccAciFilterEntry_Basic
=== STEP  Basic: testing filter entry without creating filter
=== STEP  Basic: testing filter entry without passing name attribute
=== STEP  Basic: testing filter entry creation with required paramters only
=== STEP  Basic: testing filter entry creation with optional paramters
=== STEP  Basic: testing filter entry creation with invalid name with long lenght
=== STEP  Basic: testing filter entry creation with filter name acctest_zjahv and filter entry name acctest_4v2tv
=== STEP  Basic: testing filter entry creation with required paramters only
=== STEP  Basic: testing filter entry creation with filter name acctest_rjjfy and filter entry name acctest_zjahv
=== PAUSE TestAccAciFilterEntry_Basic
=== CONT  TestAccAciFilterEntry_Basic
=== STEP  testing Filter Entry destroy
--- PASS: TestAccAciFilterEntry_Basic (354.04s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   358.006s