### PR TITLE
added resource test file 24-01-22

### DIFF
--- a/aci/data_source_aci_infraporttrackpol.go
+++ b/aci/data_source_aci_infraporttrackpol.go
@@ -49,7 +49,7 @@ func dataSourceAciPortTrackingReadContext(ctx context.Context, d *schema.Resourc
 
 	rn := fmt.Sprintf("infra/trackEqptFabP-%s", name)
 	dn := fmt.Sprintf("uni/%s", rn)
-	infraPortTrackPol, err := getRemotePortTracking(aciClient, dn)
+	infraPortTrackPol, err := GetRemotePortTracking(aciClient, dn)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/aci/data_source_aci_pkiexportencryptionkey.go
+++ b/aci/data_source_aci_pkiexportencryptionkey.go
@@ -34,7 +34,7 @@ func dataSourceAciAESEncryptionPassphraseandKeysforConfigExportImportRead(ctx co
 
 	rn := fmt.Sprintf("exportcryptkey")
 	dn := fmt.Sprintf("uni/%s", rn)
-	pkiExportEncryptionKey, err := getRemoteAESEncryptionPassphraseandKeysforConfigExportImport(aciClient, dn)
+	pkiExportEncryptionKey, err := GetRemoteAESEncryptionPassphraseandKeysforConfigExportImport(aciClient, dn)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/aci/resource_aci_aaaduoprovidergroup.go
+++ b/aci/resource_aci_aaaduoprovidergroup.go
@@ -181,6 +181,10 @@ func resourceAciDuoProviderGroupCreate(ctx context.Context, d *schema.ResourceDa
 		for _, val := range SecFacAuthMethods.([]interface{}) {
 			secFacAuthMethodsList = append(secFacAuthMethodsList, val.(string))
 		}
+		err := checkDuplicate(secFacAuthMethodsList)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 		SecFacAuthMethods := strings.Join(secFacAuthMethodsList, ",")
 		aaaDuoProviderGroupAttr.SecFacAuthMethods = SecFacAuthMethods
 	}
@@ -231,6 +235,10 @@ func resourceAciDuoProviderGroupUpdate(ctx context.Context, d *schema.ResourceDa
 		secFacAuthMethodsList := make([]string, 0, 1)
 		for _, val := range SecFacAuthMethods.([]interface{}) {
 			secFacAuthMethodsList = append(secFacAuthMethodsList, val.(string))
+		}
+		err := checkDuplicate(secFacAuthMethodsList)
+		if err != nil {
+			return diag.FromErr(err)
 		}
 		SecFacAuthMethods := strings.Join(secFacAuthMethodsList, ",")
 		aaaDuoProviderGroupAttr.SecFacAuthMethods = SecFacAuthMethods

--- a/aci/resource_aci_infraporttrackpol.go
+++ b/aci/resource_aci_infraporttrackpol.go
@@ -58,7 +58,7 @@ func resourceAciPortTracking() *schema.Resource {
 	}
 }
 
-func getRemotePortTracking(client *client.Client, dn string) (*models.PortTracking, error) {
+func GetRemotePortTracking(client *client.Client, dn string) (*models.PortTracking, error) {
 	infraPortTrackPolCont, err := client.Get(dn)
 	if err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func resourceAciPortTrackingImport(d *schema.ResourceData, m interface{}) ([]*sc
 	log.Printf("[DEBUG] %s: Beginning Import", d.Id())
 	aciClient := m.(*client.Client)
 	dn := d.Id()
-	infraPortTrackPol, err := getRemotePortTracking(aciClient, dn)
+	infraPortTrackPol, err := GetRemotePortTracking(aciClient, dn)
 	if err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func resourceAciPortTrackingRead(ctx context.Context, d *schema.ResourceData, m 
 	log.Printf("[DEBUG] %s: Beginning Read", d.Id())
 	aciClient := m.(*client.Client)
 	dn := d.Id()
-	infraPortTrackPol, err := getRemotePortTracking(aciClient, dn)
+	infraPortTrackPol, err := GetRemotePortTracking(aciClient, dn)
 	if err != nil {
 		d.SetId("")
 		return diag.FromErr(err)

--- a/aci/resource_aci_pkiexportencryptionkey.go
+++ b/aci/resource_aci_pkiexportencryptionkey.go
@@ -62,7 +62,7 @@ func resourceAciAESEncryptionPassphraseandKeysforConfigExportImport() *schema.Re
 	}
 }
 
-func getRemoteAESEncryptionPassphraseandKeysforConfigExportImport(client *client.Client, dn string) (*models.AESEncryptionPassphraseandKeysforConfigExportImport, error) {
+func GetRemoteAESEncryptionPassphraseandKeysforConfigExportImport(client *client.Client, dn string) (*models.AESEncryptionPassphraseandKeysforConfigExportImport, error) {
 	pkiExportEncryptionKeyCont, err := client.Get(dn)
 	if err != nil {
 		return nil, err
@@ -92,7 +92,7 @@ func resourceAciAESEncryptionPassphraseandKeysforConfigExportImportImport(d *sch
 	log.Printf("[DEBUG] %s: Beginning Import", d.Id())
 	aciClient := m.(*client.Client)
 	dn := d.Id()
-	pkiExportEncryptionKey, err := getRemoteAESEncryptionPassphraseandKeysforConfigExportImport(aciClient, dn)
+	pkiExportEncryptionKey, err := GetRemoteAESEncryptionPassphraseandKeysforConfigExportImport(aciClient, dn)
 	if err != nil {
 		return nil, err
 	}
@@ -193,7 +193,7 @@ func resourceAciAESEncryptionPassphraseandKeysforConfigExportImportRead(ctx cont
 	log.Printf("[DEBUG] %s: Beginning Read", d.Id())
 	aciClient := m.(*client.Client)
 	dn := d.Id()
-	pkiExportEncryptionKey, err := getRemoteAESEncryptionPassphraseandKeysforConfigExportImport(aciClient, dn)
+	pkiExportEncryptionKey, err := GetRemoteAESEncryptionPassphraseandKeysforConfigExportImport(aciClient, dn)
 	if err != nil {
 		d.SetId("")
 		return diag.FromErr(err)

--- a/testacc/data_source_aci_aaaduoprovidergroup_test.go
+++ b/testacc/data_source_aci_aaaduoprovidergroup_test.go
@@ -1,0 +1,160 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciDuoProviderGroupDataSource_Basic(t *testing.T) {
+	resourceName := "aci_duo_provider_group.test"
+	dataSourceName := "data.aci_duo_provider_group.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciDuoProviderGroupDestroy,
+		Steps: []resource.TestStep{
+			
+			{
+				Config:      CreateDuoProviderGroupDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccDuoProviderGroupConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "auth_choice", resourceName, "auth_choice"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ldap_group_map_ref", resourceName, "ldap_group_map_ref"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "provider_type", resourceName, "provider_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "sec_fac_auth_methods.#", resourceName, "sec_fac_auth_methods.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "sec_fac_auth_methods.0", resourceName, "sec_fac_auth_methods.0"),
+					
+				),
+			},
+			{
+				Config:      CreateAccDuoProviderGroupDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			
+			{
+				Config:      CreateAccDuoProviderGroupDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccDuoProviderGroupDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+
+func CreateAccDuoProviderGroupConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing duo_provider_group Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_duo_provider_group" "test" {
+	
+		name  = aci_duo_provider_group.test.name
+		depends_on = [ aci_duo_provider_group.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateDuoProviderGroupDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing duo_provider_group Data Source without ",attrName)
+	rBlock := `
+	
+	resource "aci_duo_provider_group" "test" {
+	
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_duo_provider_group" "test" {
+	
+	#	name  = aci_duo_provider_group.test.name
+		depends_on = [ aci_duo_provider_group.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock,rName)
+}
+
+
+func CreateAccDuoProviderGroupDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing duo_provider_group Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_duo_provider_group" "test" {
+	
+		name  = "${aci_duo_provider_group.test.name}_invalid"
+		depends_on = [ aci_duo_provider_group.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccDuoProviderGroupDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing duo_provider_group Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_duo_provider_group" "test" {
+	
+		name  = aci_duo_provider_group.test.name
+		%s = "%s"
+		depends_on = [ aci_duo_provider_group.test ]
+	}
+	`, rName,key,value)
+	return resource
+}
+
+func CreateAccDuoProviderGroupDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing duo_provider_group Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_duo_provider_group" "test" {
+	
+		name  = aci_duo_provider_group.test.name
+		depends_on = [ aci_duo_provider_group.test ]
+	}
+	`, rName,key,value)
+	return resource
+}

--- a/testacc/data_source_aci_dhcpoptionpol_test.go
+++ b/testacc/data_source_aci_dhcpoptionpol_test.go
@@ -1,0 +1,189 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciDHCPOptionPolicyDataSource_Basic(t *testing.T) {
+	resourceName := "aci_dhcp_option_policy.test"
+	dataSourceName := "data.aci_dhcp_option_policy.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciDHCPOptionPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateDHCPOptionPolicyDSWithoutRequired(fvTenantName, rName, "tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateDHCPOptionPolicyDSWithoutRequired(fvTenantName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccDHCPOptionPolicyConfigDataSource(fvTenantName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "tenant_dn", resourceName, "tenant_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+				),
+			},
+			{
+				Config:      CreateAccDHCPOptionPolicyDataSourceUpdate(fvTenantName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccDHCPOptionPolicyDSWithInvalidName(fvTenantName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+
+			{
+				Config: CreateAccDHCPOptionPolicyDataSourceUpdatedResource(fvTenantName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccDHCPOptionPolicyConfigDataSource(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing dhcp_option_policy Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_dhcp_option_policy.test.name
+		depends_on = [ aci_dhcp_option_policy.test ]
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateDHCPOptionPolicyDSWithoutRequired(fvTenantName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing dhcp_option_policy Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	data "aci_dhcp_option_policy" "test" {
+	#	tenant_dn  = aci_tenant.test.id
+		name  = aci_dhcp_option_policy.test.name
+		depends_on = [ aci_dhcp_option_policy.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+	#	name  = aci_dhcp_option_policy.test.name
+		depends_on = [ aci_dhcp_option_policy.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, rName)
+}
+
+func CreateAccDHCPOptionPolicyDSWithInvalidName(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing dhcp_option_policy Data Source with Invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "${aci_dhcp_option_policy.test.name}_invalid"
+		depends_on = [ aci_dhcp_option_policy.test ]
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccDHCPOptionPolicyDataSourceUpdate(fvTenantName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing dhcp_option_policy Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_dhcp_option_policy.test.name
+		%s = "%s"
+		depends_on = [ aci_dhcp_option_policy.test ]
+	}
+	`, fvTenantName, rName, key, value)
+	return resource
+}
+
+func CreateAccDHCPOptionPolicyDataSourceUpdatedResource(fvTenantName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing dhcp_option_policy Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_dhcp_option_policy.test.name
+		depends_on = [ aci_dhcp_option_policy.test ]
+	}
+	`, fvTenantName, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_infraporttrackpol_test.go
+++ b/testacc/data_source_aci_infraporttrackpol_test.go
@@ -1,0 +1,97 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aci/aci"
+)
+
+func TestAccAciPortTrackingDataSource_Basic(t *testing.T) {
+	resourceName := "aci_port_tracking.test"
+	dataSourceName := "data.aci_port_tracking.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	infraPortTrackPol, err := aci.GetRemotePortTracking(sharedAciClient(), "uni/infra/trackEqptFabP-default")
+	if err != nil {
+		t.Errorf("reading initial config of infraPortTrackPol")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccPortTrackingConfigDataSource(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "admin_st", resourceName, "admin_st"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "delay", resourceName, "delay"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "include_apic_ports", resourceName, "include_apic_ports"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "minlinks", resourceName, "minlinks"),
+				),
+			},
+			{
+				Config:      CreateAccPortTrackingDataSourceUpdate(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccPortTrackingDataSourceUpdatedResource("annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+			{
+				Config: restorePortTrackingConfig(infraPortTrackPol),
+			},
+		},
+	})
+}
+
+func CreateAccPortTrackingConfigDataSource() string {
+	fmt.Println("=== STEP  testing port_tracking Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_port_tracking" "test" {
+	}
+
+	data "aci_port_tracking" "test" {
+		depends_on = [ aci_port_tracking.test ]
+	}
+	`)
+	return resource
+}
+
+func CreateAccPortTrackingDataSourceUpdate(key, value string) string {
+	fmt.Println("=== STEP  testing port_tracking Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_port_tracking" "test" {
+	}
+
+	data "aci_port_tracking" "test" {
+		%s = "%s"
+		depends_on = [ aci_port_tracking.test ]
+	}
+	`, key, value)
+	return resource
+}
+
+func CreateAccPortTrackingDataSourceUpdatedResource(key, value string) string {
+	fmt.Println("=== STEP  testing port_tracking Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_port_tracking" "test" {
+		%s = "%s"
+	}
+
+	data "aci_port_tracking" "test" {
+		depends_on = [ aci_port_tracking.test ]
+	}
+	`, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_pkiexportencryptionkey_test.go
+++ b/testacc/data_source_aci_pkiexportencryptionkey_test.go
@@ -1,0 +1,119 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aci/aci"
+)
+
+func TestAccAciAESEncryptionPassphraseandKeysforConfigExportImportDataSource_Basic(t *testing.T) {
+	resourceName := "aci_encryption_key.test"
+	dataSourceName := "data.aci_encryption_key.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	pkiExportEncryptionKey, err := aci.GetRemoteAESEncryptionPassphraseandKeysforConfigExportImport(sharedAciClient(), "uni/exportcryptkey")
+	if err != nil {
+		t.Errorf("reading initial config of pkiExportEncryptionKey")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccAESEncryptionPassphraseandKeysforConfigExportImportConfigDataSource(),
+				Check: resource.ComposeTestCheckFunc(
+
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "passphrase_key_derivation_version", resourceName, "passphrase_key_derivation_version"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "strong_encryption_enabled", resourceName, "strong_encryption_enabled"),
+				),
+			},
+			{
+				Config:      CreateAccAESEncryptionPassphraseandKeysforConfigExportImportDataSourceUpdate(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config: CreateAccAESEncryptionPassphraseandKeysforConfigExportImportDataSourceUpdatedResource("annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+			{
+				Config: restoreAESEncryptionPassphraseandKeysforConfigExportImport(pkiExportEncryptionKey),
+			},
+		},
+	})
+}
+
+func CreateAccAESEncryptionPassphraseandKeysforConfigExportImportConfigDataSource() string {
+	fmt.Println("=== STEP  testing encryption_key Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_encryption_key" "test" {
+	
+	}
+
+	data "aci_encryption_key" "test" {
+	
+		depends_on = [ aci_encryption_key.test ]
+	}
+	`)
+	return resource
+}
+
+func CreateAccAESEncryptionPassphraseandKeysforConfigExportImportDSWithInvalidName(string) string {
+	fmt.Println("=== STEP  testing encryption_key Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_encryption_key" "test" {
+	
+	}
+
+	data "aci_encryption_key" "test" {
+	
+		depends_on = [ aci_encryption_key.test ]
+	}
+	`)
+	return resource
+}
+
+func CreateAccAESEncryptionPassphraseandKeysforConfigExportImportDataSourceUpdate(key, value string) string {
+	fmt.Println("=== STEP  testing encryption_key Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_encryption_key" "test" {
+	
+	}
+
+	data "aci_encryption_key" "test" {
+	
+		%s = "%s"
+		depends_on = [ aci_encryption_key.test ]
+	}
+	`, key, value)
+	return resource
+}
+
+func CreateAccAESEncryptionPassphraseandKeysforConfigExportImportDataSourceUpdatedResource(key, value string) string {
+	fmt.Println("=== STEP  testing encryption_key Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_encryption_key" "test" {
+	
+		%s = "%s"
+	}
+
+	data "aci_encryption_key" "test" {
+	
+		depends_on = [ aci_encryption_key.test ]
+	}
+	`, key, value)
+	return resource
+}

--- a/testacc/resource_aci_aaaduoprovidergroup_test.go
+++ b/testacc/resource_aci_aaaduoprovidergroup_test.go
@@ -1,0 +1,486 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciDuoProviderGroup_Basic(t *testing.T) {
+	var duo_provider_group_default models.DuoProviderGroup
+	var duo_provider_group_updated models.DuoProviderGroup
+	resourceName := "aci_duo_provider_group.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciDuoProviderGroupDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateDuoProviderGroupWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccDuoProviderGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDuoProviderGroupExists(resourceName, &duo_provider_group_default),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "auth_choice", "CiscoAVPair"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_group_map_ref", ""),
+					resource.TestCheckResourceAttr(resourceName, "provider_type", "radius"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.0", "auto"),
+				),
+			},
+			{
+				Config: CreateAccDuoProviderGroupConfigWithOptionalValues(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDuoProviderGroupExists(resourceName, &duo_provider_group_updated),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_duo_provider_group"),
+					resource.TestCheckResourceAttr(resourceName, "auth_choice", "LdapGroupMap"),
+					resource.TestCheckResourceAttr(resourceName, "ldap_group_map_ref", "DuoEmpGroupMap"),
+					resource.TestCheckResourceAttr(resourceName, "provider_type", "ldap"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.0", "passcode"),
+					testAccCheckAciDuoProviderGroupIdEqual(&duo_provider_group_default, &duo_provider_group_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccDuoProviderGroupConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccDuoProviderGroupRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+
+			{
+				Config: CreateAccDuoProviderGroupConfigWithRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDuoProviderGroupExists(resourceName, &duo_provider_group_updated),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciDuoProviderGroupIdNotEqual(&duo_provider_group_default, &duo_provider_group_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciDuoProviderGroup_Update(t *testing.T) {
+	var duo_provider_group_default models.DuoProviderGroup
+	var duo_provider_group_updated models.DuoProviderGroup
+	resourceName := "aci_duo_provider_group.test"
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciDuoProviderGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccDuoProviderGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDuoProviderGroupExists(resourceName, &duo_provider_group_default),
+				),
+			},
+
+			{
+
+				Config: CreateAccDuoProviderGroupUpdatedAttrList(rName, "sec_fac_auth_methods", StringListtoString([]string{"auto", "passcode"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDuoProviderGroupExists(resourceName, &duo_provider_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.0", "auto"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.1", "passcode"),
+				),
+			},
+			{
+
+				Config: CreateAccDuoProviderGroupUpdatedAttrList(rName, "sec_fac_auth_methods", StringListtoString([]string{"passcode"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDuoProviderGroupExists(resourceName, &duo_provider_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.0", "passcode"),
+				),
+			},
+			{
+
+				Config: CreateAccDuoProviderGroupUpdatedAttrList(rName, "sec_fac_auth_methods", StringListtoString([]string{"auto", "passcode", "phone"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDuoProviderGroupExists(resourceName, &duo_provider_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.0", "auto"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.1", "passcode"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.2", "phone"),
+				),
+			},
+			{
+
+				Config: CreateAccDuoProviderGroupUpdatedAttrList(rName, "sec_fac_auth_methods", StringListtoString([]string{"passcode", "phone"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDuoProviderGroupExists(resourceName, &duo_provider_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.0", "passcode"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.1", "phone"),
+				),
+			},
+			{
+
+				Config: CreateAccDuoProviderGroupUpdatedAttrList(rName, "sec_fac_auth_methods", StringListtoString([]string{"phone"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDuoProviderGroupExists(resourceName, &duo_provider_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.0", "phone"),
+				),
+			},
+			{
+
+				Config: CreateAccDuoProviderGroupUpdatedAttrList(rName, "sec_fac_auth_methods", StringListtoString([]string{"auto", "passcode", "phone", "push"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDuoProviderGroupExists(resourceName, &duo_provider_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.0", "auto"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.1", "passcode"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.2", "phone"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.3", "push"),
+				),
+			},
+			{
+
+				Config: CreateAccDuoProviderGroupUpdatedAttrList(rName, "sec_fac_auth_methods", StringListtoString([]string{"passcode", "phone", "push"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDuoProviderGroupExists(resourceName, &duo_provider_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.0", "passcode"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.1", "phone"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.2", "push"),
+				),
+			},
+			{
+
+				Config: CreateAccDuoProviderGroupUpdatedAttrList(rName, "sec_fac_auth_methods", StringListtoString([]string{"phone", "push"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDuoProviderGroupExists(resourceName, &duo_provider_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.0", "phone"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.1", "push"),
+				),
+			},
+			{
+
+				Config: CreateAccDuoProviderGroupUpdatedAttrList(rName, "sec_fac_auth_methods", StringListtoString([]string{"push"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDuoProviderGroupExists(resourceName, &duo_provider_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.0", "push"),
+				),
+			},
+			{
+				Config: CreateAccDuoProviderGroupUpdatedAttrList(rName, "sec_fac_auth_methods", StringListtoString([]string{"push", "phone", "passcode", "auto"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDuoProviderGroupExists(resourceName, &duo_provider_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.0", "push"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.1", "phone"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.2", "passcode"),
+					resource.TestCheckResourceAttr(resourceName, "sec_fac_auth_methods.3", "auto"),
+				),
+			},
+			{
+				Config: CreateAccDuoProviderGroupConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciDuoProviderGroup_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciDuoProviderGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccDuoProviderGroupConfig(rName),
+			},
+
+			{
+				Config:      CreateAccDuoProviderGroupUpdatedAttr(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccDuoProviderGroupUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccDuoProviderGroupUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccDuoProviderGroupUpdatedAttr(rName, "auth_choice", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccDuoProviderGroupUpdatedAttr(rName, "ldap_group_map_ref", acctest.RandString(513)),
+				ExpectError: regexp.MustCompile(`failed validation for value ''`),
+			},
+
+			{
+				Config:      CreateAccDuoProviderGroupUpdatedAttr(rName, "provider_type", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccDuoProviderGroupUpdatedAttrList(rName, "sec_fac_auth_methods", StringListtoString([]string{randomValue})),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccDuoProviderGroupUpdatedAttrList(rName, "sec_fac_auth_methods", StringListtoString([]string{"auto", "auto"})),
+				ExpectError: regexp.MustCompile(`duplication is not supported in list`),
+			},
+			{
+				Config:      CreateAccDuoProviderGroupUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccDuoProviderGroupConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciDuoProviderGroup_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciDuoProviderGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccDuoProviderGroupConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciDuoProviderGroupExists(name string, duo_provider_group *models.DuoProviderGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Duo Provider Group %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Duo Provider Group dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		duo_provider_groupFound := models.DuoProviderGroupFromContainer(cont)
+		if duo_provider_groupFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Duo Provider Group %s not found", rs.Primary.ID)
+		}
+		*duo_provider_group = *duo_provider_groupFound
+		return nil
+	}
+}
+
+func testAccCheckAciDuoProviderGroupDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing duo_provider_group destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_duo_provider_group" {
+			cont, err := client.Get(rs.Primary.ID)
+			duo_provider_group := models.DuoProviderGroupFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Duo Provider Group %s Still exists", duo_provider_group.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciDuoProviderGroupIdEqual(m1, m2 *models.DuoProviderGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("duo_provider_group DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciDuoProviderGroupIdNotEqual(m1, m2 *models.DuoProviderGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("duo_provider_group DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateDuoProviderGroupWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing duo_provider_group creation without ", attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_duo_provider_group" "test" {
+	
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccDuoProviderGroupConfigWithRequiredParams(rName string) string {
+	fmt.Println("=== STEP  testing duo_provider_group creation with name =", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+func CreateAccDuoProviderGroupConfigUpdatedName(rName string) string {
+	fmt.Println("=== STEP  testing duo_provider_group creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccDuoProviderGroupConfig(rName string) string {
+	fmt.Println("=== STEP  testing duo_provider_group creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccDuoProviderGroupConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple duo_provider_group creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+	
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccDuoProviderGroupConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing duo_provider_group creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+	
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_duo_provider_group"
+		auth_choice = "LdapGroupMap"
+		ldap_group_map_ref = "DuoEmpGroupMap"
+		provider_type = "ldap"
+		sec_fac_auth_methods = ["passcode"]
+		
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccDuoProviderGroupRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing duo_provider_group updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_duo_provider_group" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_duo_provider_group"
+		auth_choice = "LdapGroupMap"
+		ldap_group_map_ref = ""
+		provider_type = "ldap"
+		sec_fac_auth_methods = ["passcode"]
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccDuoProviderGroupUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing duo_provider_group attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName, attribute, value)
+	return resource
+}
+
+func CreateAccDuoProviderGroupUpdatedAttrList(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing duo_provider_group attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+	
+		name  = "%s"
+		%s = %s
+	}
+	`, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_dhcpoptionpol_test.go
+++ b/testacc/resource_aci_dhcpoptionpol_test.go
@@ -1,0 +1,557 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciDHCPOptionPolicy_Basic(t *testing.T) {
+	var dhcp_option_policy_default models.DHCPOptionPolicy
+	var dhcp_option_policy_updated models.DHCPOptionPolicy
+	resourceName := "aci_dhcp_option_policy.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciDHCPOptionPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateDHCPOptionPolicyWithoutRequired(fvTenantName, rName, "tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateDHCPOptionPolicyWithoutRequired(fvTenantName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccDHCPOptionPolicyConfig(fvTenantName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDHCPOptionPolicyExists(resourceName, &dhcp_option_policy_default),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", fvTenantName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+				),
+			},
+			{
+				Config: CreateAccDHCPOptionPolicyConfigWithOptionalValues(fvTenantName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDHCPOptionPolicyExists(resourceName, &dhcp_option_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", fvTenantName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_dhcp_option_policy"),
+
+					testAccCheckAciDHCPOptionPolicyIdEqual(&dhcp_option_policy_default, &dhcp_option_policy_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: CreateAccDHCPOptionPolicyConfigWithAllOptionalValues(fvTenantName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDHCPOptionPolicyExists(resourceName, &dhcp_option_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", fvTenantName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_dhcp_option_policy"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option.0.annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option.0.name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option.0.data", ""),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option.0.dhcp_option_id", "0"),
+					testAccCheckAciDHCPOptionPolicyIdEqual(&dhcp_option_policy_default, &dhcp_option_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccDHCPOptionPolicyConfigWithAllOptionalValuesofOption(fvTenantName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDHCPOptionPolicyExists(resourceName, &dhcp_option_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", fvTenantName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_dhcp_option_policy"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option.0.annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option.0.name", rName),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option.0.name_alias", "test_dhcp_option"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option.0.data", "test_data"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_option.0.dhcp_option_id", "1"),
+					testAccCheckAciDHCPOptionPolicyIdEqual(&dhcp_option_policy_default, &dhcp_option_policy_updated),
+				),
+			},
+			{
+				Config:      CreateAccDHCPOptionPolicyConfigUpdatedName(fvTenantName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccDHCPOptionPolicyRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateAccDHCPOptionPolicyOptionWithoutName(fvTenantName, rName),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccDHCPOptionPolicyConfigWithRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDHCPOptionPolicyExists(resourceName, &dhcp_option_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciDHCPOptionPolicyIdNotEqual(&dhcp_option_policy_default, &dhcp_option_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccDHCPOptionPolicyConfig(fvTenantName, rName),
+			},
+			{
+				Config: CreateAccDHCPOptionPolicyConfigWithRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciDHCPOptionPolicyExists(resourceName, &dhcp_option_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciDHCPOptionPolicyIdNotEqual(&dhcp_option_policy_default, &dhcp_option_policy_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciDHCPOptionPolicy_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciDHCPOptionPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccDHCPOptionPolicyConfig(fvTenantName, rName),
+			},
+			{
+				Config:      CreateAccDHCPOptionPolicyWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccDHCPOptionPolicyUpdatedAttr(fvTenantName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccDHCPOptionPolicyUpdatedAttr(fvTenantName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccDHCPOptionPolicyUpdatedAttr(fvTenantName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccDHCPOptionPolicyUpdatedAttr(fvTenantName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccDHCPOptionPolicyOptionUpdatedAttr(fvTenantName, rName, "data", acctest.RandString(257)),
+				ExpectError: regexp.MustCompile(`failed validation for value`),
+			},
+			{
+				Config:      CreateAccDHCPOptionPolicyOptionUpdatedAttr(fvTenantName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccDHCPOptionPolicyOptionUpdatedAttr(fvTenantName, rName, "dhcp_option_id", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccDHCPOptionPolicyOptionUpdatedAttr(fvTenantName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccDHCPOptionPolicyOptionUpdatedAttr(fvTenantName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`Unsupported argument`),
+			},
+			{
+				Config: CreateAccDHCPOptionPolicyConfig(fvTenantName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciDHCPOptionPolicy_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciDHCPOptionPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccDHCPOptionPolicyConfigMultiple(fvTenantName, rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciDHCPOptionPolicyExists(name string, dhcp_option_policy *models.DHCPOptionPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("DHCP Option Policy %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No DHCP Option Policy dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		dhcp_option_policyFound := models.DHCPOptionPolicyFromContainer(cont)
+		if dhcp_option_policyFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("DHCP Option Policy %s not found", rs.Primary.ID)
+		}
+		*dhcp_option_policy = *dhcp_option_policyFound
+		return nil
+	}
+}
+
+func testAccCheckAciDHCPOptionPolicyDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing dhcp_option_policy destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_dhcp_option_policy" {
+			cont, err := client.Get(rs.Primary.ID)
+			dhcp_option_policy := models.DHCPOptionPolicyFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("DHCP Option Policy %s Still exists", dhcp_option_policy.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciDHCPOptionPolicyIdEqual(m1, m2 *models.DHCPOptionPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("dhcp_option_policy DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciDHCPOptionPolicyIdNotEqual(m1, m2 *models.DHCPOptionPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("dhcp_option_policy DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateDHCPOptionPolicyWithoutRequired(fvTenantName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing dhcp_option_policy creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		
+	}
+	
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	resource "aci_dhcp_option_policy" "test" {
+	#	tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, rName)
+}
+
+func CreateAccDHCPOptionPolicyConfigWithRequiredParams(fvTenantName, rName string) string {
+	fmt.Printf("=== STEP  testing dhcp_option_policy creation with parent resource name %s and resource name %s\n", fvTenantName, rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+func CreateAccDHCPOptionPolicyConfigUpdatedName(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing dhcp_option_policy creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccDHCPOptionPolicyOptionWithoutName(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing dhcp_option creation without name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		dhcp_option {}
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccDHCPOptionPolicyConfig(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing dhcp_option_policy creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccDHCPOptionPolicyConfigMultiple(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing multiple dhcp_option_policy creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccDHCPOptionPolicyWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing dhcp_option_policy creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_application_profile" "test"{
+		name = "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_application_profile.test.id
+		name  = "%s"	
+	}
+	`, rName, rName, rName)
+	return resource
+}
+
+func CreateAccDHCPOptionPolicyConfigWithAllOptionalValues(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing dhcp_option_policy creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = "${aci_tenant.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_dhcp_option_policy"
+		dhcp_option {
+			name  = "%s"
+		}
+	}
+	`, fvTenantName, rName, rName)
+
+	return resource
+}
+
+func CreateAccDHCPOptionPolicyConfigWithAllOptionalValuesofOption(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing dhcp_option_policy creation with optional parameters of dhcp_option_policy and dhcp_option")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = "${aci_tenant.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_dhcp_option_policy"
+		dhcp_option {
+			name  = "%s"
+			annotation = "orchestrator:terraform_testacc"
+			name_alias = "test_dhcp_option"
+			data = "test_data"
+			dhcp_option_id = "1"
+		}
+	}
+	`, fvTenantName, rName, rName)
+
+	return resource
+}
+
+func CreateAccDHCPOptionPolicyConfigWithOptionalValues(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing dhcp_option_policy creation with optional parameters of dhcp_option_policy")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = "${aci_tenant.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_dhcp_option_policy"
+		
+	}
+	`, fvTenantName, rName)
+
+	return resource
+}
+
+func CreateAccDHCPOptionPolicyRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing dhcp_option_policy updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_dhcp_option_policy" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_dhcp_option_policy"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccDHCPOptionPolicyOptionUpdatedAttr(fvTenantName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing dhcp_option attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		dhcp_option {
+			name = "%s"
+			%s = "%s"
+		}
+	}
+	`, fvTenantName, rName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccDHCPOptionPolicyUpdatedAttr(fvTenantName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing dhcp_option_policy attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, fvTenantName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccDHCPOptionPolicyUpdatedAttrList(fvTenantName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing dhcp_option_policy attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = %s
+	}
+	`, fvTenantName, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_infraporttrackpol_test.go
+++ b/testacc/resource_aci_infraporttrackpol_test.go
@@ -1,0 +1,303 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aci/aci"
+)
+
+func TestAccAciPortTracking_Basic(t *testing.T) {
+	var port_tracking_default models.PortTracking
+	var port_tracking_updated models.PortTracking
+	resourceName := "aci_port_tracking.test"
+	infraPortTrackPol, err := aci.GetRemotePortTracking(sharedAciClient(), "uni/infra/trackEqptFabP-default")
+	if err != nil {
+		t.Errorf("reading initial config of infraPortTrackPol")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccPortTrackingConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciPortTrackingExists(resourceName, &port_tracking_default),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttrSet(resourceName, "admin_st"),
+					resource.TestCheckResourceAttrSet(resourceName, "delay"),
+					resource.TestCheckResourceAttrSet(resourceName, "include_apic_ports"),
+					resource.TestCheckResourceAttrSet(resourceName, "minlinks"),
+				),
+			},
+			{
+				Config: CreateAccPortTrackingConfigWithOptionalValues(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciPortTrackingExists(resourceName, &port_tracking_updated),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_port_tracking"),
+					resource.TestCheckResourceAttr(resourceName, "admin_st", "on"),
+					resource.TestCheckResourceAttr(resourceName, "delay", "1"),
+					resource.TestCheckResourceAttr(resourceName, "include_apic_ports", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "minlinks", "0"),
+					testAccCheckAciPortTrackingIdEqual(&port_tracking_default, &port_tracking_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: restorePortTrackingConfig(infraPortTrackPol),
+			},
+		},
+	})
+}
+
+func TestAccAciPortTracking_Update(t *testing.T) {
+	var port_tracking_default models.PortTracking
+	var port_tracking_updated models.PortTracking
+	resourceName := "aci_port_tracking.test"
+	infraPortTrackPol, err := aci.GetRemotePortTracking(sharedAciClient(), "uni/infra/trackEqptFabP-default")
+	if err != nil {
+		t.Errorf("reading initial config of infraPortTrackPol")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccPortTrackingConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciPortTrackingExists(resourceName, &port_tracking_default),
+				),
+			},
+			{
+				Config: CreateAccPortTrackingUpdatedAttr("delay", "300"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciPortTrackingExists(resourceName, &port_tracking_updated),
+					resource.TestCheckResourceAttr(resourceName, "delay", "300"),
+					testAccCheckAciPortTrackingIdEqual(&port_tracking_default, &port_tracking_updated),
+				),
+			},
+			{
+				Config: CreateAccPortTrackingUpdatedAttr("delay", "150"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciPortTrackingExists(resourceName, &port_tracking_updated),
+					resource.TestCheckResourceAttr(resourceName, "delay", "150"),
+					testAccCheckAciPortTrackingIdEqual(&port_tracking_default, &port_tracking_updated),
+				),
+			},
+			{
+				Config: CreateAccPortTrackingUpdatedAttr("minlinks", "48"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciPortTrackingExists(resourceName, &port_tracking_updated),
+					resource.TestCheckResourceAttr(resourceName, "minlinks", "48"),
+					testAccCheckAciPortTrackingIdEqual(&port_tracking_default, &port_tracking_updated),
+				),
+			},
+			{
+				Config: CreateAccPortTrackingUpdatedAttr("minlinks", "24"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciPortTrackingExists(resourceName, &port_tracking_updated),
+					resource.TestCheckResourceAttr(resourceName, "minlinks", "24"),
+					testAccCheckAciPortTrackingIdEqual(&port_tracking_default, &port_tracking_updated),
+				),
+			},
+			{
+				Config: CreateAccPortTrackingUpdatedAttr("admin_st", "off"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciPortTrackingExists(resourceName, &port_tracking_updated),
+					resource.TestCheckResourceAttr(resourceName, "admin_st", "off"),
+					testAccCheckAciPortTrackingIdEqual(&port_tracking_default, &port_tracking_updated),
+				),
+			},
+			{
+				Config: CreateAccPortTrackingUpdatedAttr("include_apic_ports", "no"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciPortTrackingExists(resourceName, &port_tracking_updated),
+					resource.TestCheckResourceAttr(resourceName, "include_apic_ports", "no"),
+					testAccCheckAciPortTrackingIdEqual(&port_tracking_default, &port_tracking_updated),
+				),
+			},
+			{
+				Config: restorePortTrackingConfig(infraPortTrackPol),
+			},
+		},
+	})
+}
+
+func TestAccAciPortTracking_Negative(t *testing.T) {
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	infraPortTrackPol, err := aci.GetRemotePortTracking(sharedAciClient(), "uni/infra/trackEqptFabP-default")
+	if err != nil {
+		t.Errorf("reading initial config of infraPortTrackPol")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccPortTrackingConfig(),
+			},
+
+			{
+				Config:      CreateAccPortTrackingUpdatedAttr("description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccPortTrackingUpdatedAttr("annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccPortTrackingUpdatedAttr("name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccPortTrackingUpdatedAttr("admin_st", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccPortTrackingUpdatedAttr("delay", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccPortTrackingUpdatedAttr("delay", "0"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccPortTrackingUpdatedAttr("delay", "301"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccPortTrackingUpdatedAttr("include_apic_ports", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccPortTrackingUpdatedAttr("minlinks", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccPortTrackingUpdatedAttr("minlinks", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccPortTrackingUpdatedAttr("minlinks", "49"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccPortTrackingUpdatedAttr(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: restorePortTrackingConfig(infraPortTrackPol),
+			},
+		},
+	})
+}
+
+func restorePortTrackingConfig(infraPortTrackPol *models.PortTracking) string {
+	resource := fmt.Sprintf(`
+	resource "aci_port_tracking" "test" {
+		description = "%s"
+		annotation = "%s"
+		name_alias = "%s"
+		admin_st = "%s"
+		delay = "%s"
+		include_apic_ports = "%s"
+		minlinks = "%s"
+		
+	}
+	`, infraPortTrackPol.Description, infraPortTrackPol.Annotation, infraPortTrackPol.NameAlias, infraPortTrackPol.AdminSt, infraPortTrackPol.Delay, infraPortTrackPol.IncludeApicPorts, infraPortTrackPol.Minlinks)
+	return resource
+}
+
+func testAccCheckAciPortTrackingExists(name string, port_tracking *models.PortTracking) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Port Tracking %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Port Tracking dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		port_trackingFound := models.PortTrackingFromContainer(cont)
+		if port_trackingFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Port Tracking %s not found", rs.Primary.ID)
+		}
+		*port_tracking = *port_trackingFound
+		return nil
+	}
+}
+
+func testAccCheckAciPortTrackingIdEqual(m1, m2 *models.PortTracking) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("port_tracking DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func CreateAccPortTrackingConfig() string {
+	fmt.Println("=== STEP  testing port_tracking creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_port_tracking" "test" {}
+	`)
+	return resource
+}
+
+func CreateAccPortTrackingConfigWithOptionalValues() string {
+	fmt.Println("=== STEP  Basic: testing port_tracking creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_port_tracking" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_port_tracking"
+		admin_st = "on"
+		delay = "1"
+		include_apic_ports = "yes"
+		minlinks = "0"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccPortTrackingUpdatedAttr(attribute, value string) string {
+	fmt.Printf("=== STEP  testing port_tracking attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_port_tracking" "test" {
+		%s = "%s"
+	}
+	`, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_pkiexportencryptionkey_test.go
+++ b/testacc/resource_aci_pkiexportencryptionkey_test.go
@@ -1,0 +1,248 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/terraform-providers/terraform-provider-aci/aci"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciAESEncryptionPassphraseandKeysforConfigExportImport_Basic(t *testing.T) {
+	var encryption_key_default models.AESEncryptionPassphraseandKeysforConfigExportImport
+	var encryption_key_updated models.AESEncryptionPassphraseandKeysforConfigExportImport
+	resourceName := "aci_encryption_key.test"
+	pkiExportEncryptionKey, err := aci.GetRemoteAESEncryptionPassphraseandKeysforConfigExportImport(sharedAciClient(), "uni/exportcryptkey")
+	if err != nil {
+		t.Errorf("reading initial config of pkiExportEncryptionKey")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccAESEncryptionPassphraseandKeysforConfigExportImportConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciAESEncryptionPassphraseandKeysforConfigExportImportExists(resourceName, &encryption_key_default),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttrSet(resourceName, "name_alias"),
+					resource.TestCheckResourceAttr(resourceName, "clear_encryption_key", "no"),
+					resource.TestCheckResourceAttr(resourceName, "passphrase_key_derivation_version", "v1"),
+					resource.TestCheckResourceAttrSet(resourceName, "strong_encryption_enabled"),
+				),
+			},
+			{
+				Config: CreateAccAESEncryptionPassphraseandKeysforConfigExportImportConfigWithOptionalValues(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciAESEncryptionPassphraseandKeysforConfigExportImportExists(resourceName, &encryption_key_updated),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_encryption_key"),
+					resource.TestCheckResourceAttr(resourceName, "clear_encryption_key", "no"),
+					resource.TestCheckResourceAttr(resourceName, "passphrase", "abcdefghijklmnop"),
+					resource.TestCheckResourceAttr(resourceName, "passphrase_key_derivation_version", "v1"),
+					resource.TestCheckResourceAttr(resourceName, "strong_encryption_enabled", "yes"),
+					testAccCheckAciAESEncryptionPassphraseandKeysforConfigExportImportIdEqual(&encryption_key_default, &encryption_key_updated),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"clear_encryption_key", "passphrase"},
+			},
+			{
+				Config: CreateAccAESEncryptionPassphraseandKeysforConfigExportImportUpdatedAttr("strong_encryption_enabled", "no"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "strong_encryption_enabled", "no"),
+					testAccCheckAciAESEncryptionPassphraseandKeysforConfigExportImportIdEqual(&encryption_key_default, &encryption_key_updated),
+				),
+			},
+			{
+				Config: CreateAccAESEncryptionPassphraseandKeysforConfigExportImportUpdatedAttr("clear_encryption_key", "yes"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "clear_encryption_key", "yes"),
+					testAccCheckAciAESEncryptionPassphraseandKeysforConfigExportImportIdEqual(&encryption_key_default, &encryption_key_updated),
+				),
+			},
+			{
+				Config: restoreAESEncryptionPassphraseandKeysforConfigExportImport(pkiExportEncryptionKey),
+			},
+		},
+	})
+}
+
+func TestAccAciAESEncryptionPassphraseandKeysforConfigExportImport_Negative(t *testing.T) {
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	pkiExportEncryptionKey, err := aci.GetRemoteAESEncryptionPassphraseandKeysforConfigExportImport(sharedAciClient(), "uni/exportcryptkey")
+	if err != nil {
+		t.Errorf("reading initial config of pkiExportEncryptionKey")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccAESEncryptionPassphraseandKeysforConfigExportImportConfig(),
+			},
+
+			{
+				Config:      CreateAccAESEncryptionPassphraseandKeysforConfigExportImportUpdatedAttr("description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccAESEncryptionPassphraseandKeysforConfigExportImportUpdatedAttr("annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccAESEncryptionPassphraseandKeysforConfigExportImportUpdatedAttr("name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccAESEncryptionPassphraseandKeysforConfigExportImportUpdatedAttr("clear_encryption_key", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccAESEncryptionPassphraseandKeysforConfigExportImportUpdatedAttr("passphrase", acctest.RandString(15)),
+				ExpectError: regexp.MustCompile(`smaller than minimum required`),
+			},
+			{
+				Config:      CreateAccAESEncryptionPassphraseandKeysforConfigExportImportUpdatedAttr("passphrase", acctest.RandString(33)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccAESEncryptionPassphraseandKeysforConfigExportImportUpdatedAttr("passphrase_key_derivation_version", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccAESEncryptionPassphraseandKeysforConfigExportImportUpdatedAttr("strong_encryption_enabled", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccAESEncryptionPassphraseandKeysforConfigExportImportUpdatedAttr(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: restoreAESEncryptionPassphraseandKeysforConfigExportImport(pkiExportEncryptionKey),
+			},
+		},
+	})
+}
+
+func restoreAESEncryptionPassphraseandKeysforConfigExportImport(pkiExportEncryptionKey *models.AESEncryptionPassphraseandKeysforConfigExportImport) string {
+	var resource string
+	if pkiExportEncryptionKey.KeyConfigured == "yes" {
+		resource = fmt.Sprintf(`
+		resource "aci_encryption_key" "test" {
+			description = "%s"
+			annotation = "%s"
+			name_alias = "%s"
+			clear_encryption_key = "no"
+			passphrase = "abcdefghijklmnop"
+			passphrase_key_derivation_version = "%s"
+			strong_encryption_enabled = "%s"
+		}`, pkiExportEncryptionKey.Description, pkiExportEncryptionKey.Annotation, pkiExportEncryptionKey.NameAlias, pkiExportEncryptionKey.PassphraseKeyDerivationVersion, pkiExportEncryptionKey.StrongEncryptionEnabled)
+	} else {
+		resource = fmt.Sprintf(`
+		resource "aci_encryption_key" "test" {
+			description = "%s"
+			annotation = "%s"
+			name_alias = "%s"
+			clear_encryption_key = "yes"
+		}
+		`, pkiExportEncryptionKey.Description, pkiExportEncryptionKey.Annotation, pkiExportEncryptionKey.NameAlias)
+	}
+	return resource
+}
+
+func testAccCheckAciAESEncryptionPassphraseandKeysforConfigExportImportExists(name string, encryption_key *models.AESEncryptionPassphraseandKeysforConfigExportImport) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("AES Encryption Passphraseand KeysforConfig Export Import %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No AES Encryption Passphraseand KeysforConfig Export Import dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		encryption_keyFound := models.AESEncryptionPassphraseandKeysforConfigExportImportFromContainer(cont)
+		if encryption_keyFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("AES Encryption Passphraseand KeysforConfig Export Import %s not found", rs.Primary.ID)
+		}
+		*encryption_key = *encryption_keyFound
+		return nil
+	}
+}
+
+func testAccCheckAciAESEncryptionPassphraseandKeysforConfigExportImportIdEqual(m1, m2 *models.AESEncryptionPassphraseandKeysforConfigExportImport) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("encryption_key DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func CreateAccAESEncryptionPassphraseandKeysforConfigExportImportConfig() string {
+	fmt.Println("=== STEP  Basic: testing encryption_key creation with required parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_encryption_key" "test" {}
+	`)
+
+	return resource
+}
+
+func CreateAccAESEncryptionPassphraseandKeysforConfigExportImportConfigWithOptionalValues() string {
+	fmt.Println("=== STEP  Basic: testing encryption_key creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_encryption_key" "test" {
+	
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_encryption_key"
+		clear_encryption_key = "no"
+		passphrase = "abcdefghijklmnop"
+		passphrase_key_derivation_version = "v1"
+		strong_encryption_enabled = "yes"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccAESEncryptionPassphraseandKeysforConfigExportImportUpdatedAttr(attribute, value string) string {
+	fmt.Printf("=== STEP  testing encryption_key attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_encryption_key" "test" {
+	
+		%s = "%s"
+	}
+	`, attribute, value)
+	return resource
+}


### PR DESCRIPTION
=== RUN   TestAccAciAESEncryptionPassphraseandKeysforConfigExportImportDataSource_Basic
=== STEP  testing encryption_key Data Source with required arguments only
=== STEP  testing encryption_key Data Source with random attribute
=== STEP  testing encryption_key Data Source with updated resource
--- PASS: TestAccAciAESEncryptionPassphraseandKeysforConfigExportImportDataSource_Basic (33.95s)
=== RUN   TestAccAciAESEncryptionPassphraseandKeysforConfigExportImport_Basic
=== STEP  Basic: testing encryption_key creation with required parameters
=== STEP  Basic: testing encryption_key creation with optional parameters
=== STEP  testing encryption_key attribute: strong_encryption_enabled = no
=== STEP  testing encryption_key attribute: clear_encryption_key = yes
--- PASS: TestAccAciAESEncryptionPassphraseandKeysforConfigExportImport_Basic (53.76s)
=== RUN   TestAccAciAESEncryptionPassphraseandKeysforConfigExportImport_Negative
=== STEP  Basic: testing encryption_key creation with required parameters
=== STEP  testing encryption_key attribute: description = 6hzge60heflavbolvocesi1wqidy6ml3hyo0coh6bbvf0tk6a2frwskp8xnj3fz0duot2intllqoioo43ji7vofbame8hiwkzpqmw48mhllfr66k7wj8qu9316rra3rss
=== STEP  testing encryption_key attribute: annotation = mbtrddg7g3tshbdwkimnu078q3efadmvmnk6n663nvtpmzkgyg3nv7jk84p4aakeare0ol0l842i3b3e4fcpurvdb33zswtk9yzllto2vt2dihu2l1044s9mvg36wxkd6
=== STEP  testing encryption_key attribute: name_alias = jstdihad2x7boxr3bkxksm0htz9ir1yoi7th1kruq9thuw1b2kosnq48sfihotzk
=== STEP  testing encryption_key attribute: clear_encryption_key = jml8u
=== STEP  testing encryption_key attribute: passphrase = yel2axklhyl8zmw
=== STEP  testing encryption_key attribute: passphrase = y2zyy04ixcsp93dek60nlyb4vrhvvfmvf
=== STEP  testing encryption_key attribute: passphrase_key_derivation_version = jml8u
=== STEP  testing encryption_key attribute: strong_encryption_enabled = jml8u
=== STEP  testing encryption_key attribute: bmyre = jml8u
--- PASS: TestAccAciAESEncryptionPassphraseandKeysforConfigExportImport_Negative (59.93s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   149.053s
=== RUN   TestAccAciPortTrackingDataSource_Basic
=== STEP  testing port_tracking Data Source with required arguments only
=== STEP  testing port_tracking Data Source with random attribute
=== STEP  testing port_tracking Data Source with updated resource
--- PASS: TestAccAciPortTrackingDataSource_Basic (72.69s)
=== RUN   TestAccAciPortTracking_Basic
=== STEP  testing port_tracking creation with required arguments only
=== STEP  Basic: testing port_tracking creation with optional parameters
--- PASS: TestAccAciPortTracking_Basic (69.61s)
=== RUN   TestAccAciPortTracking_Update
=== STEP  testing port_tracking creation with required arguments only
=== STEP  testing port_tracking attribute: delay = 300
=== STEP  testing port_tracking attribute: delay = 150
=== STEP  testing port_tracking attribute: minlinks = 48
=== STEP  testing port_tracking attribute: minlinks = 24
=== STEP  testing port_tracking attribute: admin_st = off
=== STEP  testing port_tracking attribute: include_apic_ports = no
--- PASS: TestAccAciPortTracking_Update (132.17s)
=== RUN   TestAccAciPortTracking_Negative
=== STEP  testing port_tracking creation with required arguments only
=== STEP  testing port_tracking attribute: description = hytpotuyt90c3fsl8r8u7hdjw2gjfgm6q89vy03ln3u9nyj8t4oe3b3i8rabi9uksc6uu6liqcikqig6ys1gxtagq2jr4pvzly9e7wdhpdc8sqck0xoou2nxlouqry2la
=== STEP  testing port_tracking attribute: annotation = pn07cthylynd8eqnd0kacq94t64h89st8rglayd6j0fohx4de9qxn37tnowf8q9toeobpvc18yk61i79ma3tuos1aziwylvupog9zstv8zev9hwhug6syxz99o9ta3vkj
=== STEP  testing port_tracking attribute: name_alias = kjwcwvoeha10xpg8cgoft1dbtxqu8svkhtdhzfqp37lh6pbs3zc6myewbsmao44g
=== STEP  testing port_tracking attribute: admin_st = 7uhwd
=== STEP  testing port_tracking attribute: delay = 7uhwd
=== STEP  testing port_tracking attribute: delay = 0
=== STEP  testing port_tracking attribute: delay = 301
=== STEP  testing port_tracking attribute: include_apic_ports = 7uhwd
=== STEP  testing port_tracking attribute: minlinks = 7uhwd
=== STEP  testing port_tracking attribute: minlinks = -1
=== STEP  testing port_tracking attribute: minlinks = 49
=== STEP  testing port_tracking attribute: pvnqg = 7uhwd
--- PASS: TestAccAciPortTracking_Negative (127.53s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   403.431s
=== RUN   TestAccAciDuoProviderGroupDataSource_Basic
=== STEP  Basic: testing duo_provider_group Data Source without  name
=== STEP  testing duo_provider_group Data Source with required arguments only
=== STEP  testing duo_provider_group Data Source with random attribute
=== STEP  testing duo_provider_group Data Source with invalid name
=== STEP  testing duo_provider_group Data Source with updated resource
=== PAUSE TestAccAciDuoProviderGroupDataSource_Basic
=== RUN   TestAccAciDuoProviderGroup_Basic
=== STEP  Basic: testing duo_provider_group creation without  name
=== STEP  testing duo_provider_group creation with required arguments only
=== STEP  Basic: testing duo_provider_group creation with optional parameters
=== STEP  testing duo_provider_group creation with invalid name =  vh4s1r6wxzut6f2qxsxlkxfvu7z04gnbh2mqsnvd2gdfvad68drdojk26jtl0v0ss
=== STEP  Basic: testing duo_provider_group updation without required parameters
=== STEP  testing duo_provider_group creation with name = acctest_p9fmc
=== PAUSE TestAccAciDuoProviderGroup_Basic
=== RUN   TestAccAciDuoProviderGroup_Update
=== STEP  testing duo_provider_group creation with required arguments only
=== STEP  testing duo_provider_group attribute: sec_fac_auth_methods = ["auto","passcode"]
=== STEP  testing duo_provider_group attribute: sec_fac_auth_methods = ["passcode"]
=== STEP  testing duo_provider_group attribute: sec_fac_auth_methods = ["auto","passcode","phone"]
=== STEP  testing duo_provider_group attribute: sec_fac_auth_methods = ["passcode","phone"]
=== STEP  testing duo_provider_group attribute: sec_fac_auth_methods = ["phone"]
=== STEP  testing duo_provider_group attribute: sec_fac_auth_methods = ["auto","passcode","phone","push"]
=== STEP  testing duo_provider_group attribute: sec_fac_auth_methods = ["passcode","phone","push"]
=== STEP  testing duo_provider_group attribute: sec_fac_auth_methods = ["phone","push"]
=== STEP  testing duo_provider_group attribute: sec_fac_auth_methods = ["push"]
=== STEP  testing duo_provider_group attribute: sec_fac_auth_methods = ["push","phone","passcode","auto"]
=== STEP  testing duo_provider_group creation with required arguments only
=== PAUSE TestAccAciDuoProviderGroup_Update
=== RUN   TestAccAciDuoProviderGroup_Negative
=== STEP  testing duo_provider_group creation with required arguments only
=== STEP  testing duo_provider_group attribute: description = yawakt8kd7ay6bso6rbzzztcx7yh0bmh1i7bhqeuo6sl8l4q3pvl3boob9abt1j87iq6ia8uenh4n174le8epiciihfl2vjfo60eqph062p4yvwu3uu9ifuzj9n38x88v
=== STEP  testing duo_provider_group attribute: annotation = piffhkz8l42dl1znfk23nz3n0rmr9wo3r0yd3m6qdt6mmi64ogbgkrave8msabuxskel1lip3ij3a64o96woxmbi878q3xvww2kw8j8qcgr9vag8thlw8hkmsjkqiwmhw
=== STEP  testing duo_provider_group attribute: name_alias = zg8drb2pcaq280463dt2c7lbx22c87qz7hne19xqyp31jo7knd3oep9mgn9443l1
=== STEP  testing duo_provider_group attribute: auth_choice = baxmf
=== STEP  testing duo_provider_group attribute: ldap_group_map_ref = qafeacg6vn2k8lm2kah1tgsnndxml14g78wee3fo0cha20lfzyffp6wp3catmhtimi8kfcfuke4rfm1hr8yb1hh934l17efmpkaozsxosjz2gxr39imbh79n99d3jtesvsrxsdecwxruztp2ytdyepraogk1vkkq77pg4cuaicjolynuc1yfqmgm3uw2lpilvpgdky91qrglbei4wpe39ahje7a2qvjq203lbvkyjrfk8ms66qx6dec6028ks6b0sawsfdt3h1udfggnnx1fpihk7vbf1ay92v6rpwptcwfs0uwi6wbhhfdg8rd6tuauh8fwzgfg1eoiahxf6tkzctcs8hifpouied9ww6uphtxjwiupri6ow9z2cm4mk7tvk1bt2q01iav01debrhxp0fdsjvm26xmal41npcenfsro49p7kdlgai2dy0ni2fhqvf9cnj10utjhyshomf0ae638rlsu6yx6lltpp131tk87a48gqupgzkttxcygiulyt
=== STEP  testing duo_provider_group attribute: provider_type = baxmf
=== STEP  testing duo_provider_group attribute: sec_fac_auth_methods = ["baxmf"]
=== STEP  testing duo_provider_group attribute: sec_fac_auth_methods = ["auto","auto"]
=== STEP  testing duo_provider_group attribute: sovza = baxmf
=== STEP  testing duo_provider_group creation with required arguments only
=== PAUSE TestAccAciDuoProviderGroup_Negative
=== RUN   TestAccAciDuoProviderGroup_MultipleCreateDelete
=== STEP  testing multiple duo_provider_group creation with required arguments only
=== PAUSE TestAccAciDuoProviderGroup_MultipleCreateDelete
=== CONT  TestAccAciDuoProviderGroupDataSource_Basic
=== CONT  TestAccAciDuoProviderGroup_Negative
=== CONT  TestAccAciDuoProviderGroup_MultipleCreateDelete
=== CONT  TestAccAciDuoProviderGroup_Update
=== CONT  TestAccAciDuoProviderGroup_Basic
=== STEP  testing duo_provider_group destroy
--- PASS: TestAccAciDuoProviderGroup_MultipleCreateDelete (33.12s)
=== STEP  testing duo_provider_group destroy
--- PASS: TestAccAciDuoProviderGroupDataSource_Basic (57.56s)
=== STEP  testing duo_provider_group destroy
--- PASS: TestAccAciDuoProviderGroup_Basic (89.03s)
=== STEP  testing duo_provider_group destroy
--- PASS: TestAccAciDuoProviderGroup_Negative (111.13s)
=== STEP  testing duo_provider_group destroy
--- PASS: TestAccAciDuoProviderGroup_Update (201.54s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   204.086s
=== RUN   TestAccAciDHCPOptionPolicyDataSource_Basic
=== STEP  Basic: testing dhcp_option_policy Data Source without  tenant_dn
=== STEP  Basic: testing dhcp_option_policy Data Source without  name
=== STEP  testing dhcp_option_policy Data Source with required arguments only
=== STEP  testing dhcp_option_policy Data Source with random attribute
=== STEP  testing dhcp_option_policy Data Source with Invalid name
=== STEP  testing dhcp_option_policy Data Source with updated resource
=== PAUSE TestAccAciDHCPOptionPolicyDataSource_Basic
=== RUN   TestAccAciDHCPOptionPolicy_Basic
=== STEP  Basic: testing dhcp_option_policy creation without  tenant_dn
=== STEP  Basic: testing dhcp_option_policy creation without  name
=== STEP  testing dhcp_option_policy creation with required arguments only
=== STEP  Basic: testing dhcp_option_policy creation with optional parameters of dhcp_option_policy
=== STEP  Basic: testing dhcp_option_policy creation with optional parameters
=== STEP  Basic: testing dhcp_option_policy creation with optional parameters of dhcp_option_policy and dhcp_option
=== STEP  testing dhcp_option_policy creation with invalid name =  vnjfi67ehm2ho2hwdhkgrbz7qj07edfr1lebnff8ktl2wauayk1xitjq3hgncpbmr
=== STEP  Basic: testing dhcp_option_policy updation without required parameters
=== STEP  testing dhcp_option creation without name
=== STEP  testing dhcp_option_policy creation with parent resource name acctest_707va and resource name acctest_eixg0
=== STEP  testing dhcp_option_policy creation with required arguments only
=== STEP  testing dhcp_option_policy creation with parent resource name acctest_eixg0 and resource name acctest_707va
=== PAUSE TestAccAciDHCPOptionPolicy_Basic
=== RUN   TestAccAciDHCPOptionPolicy_Negative
=== STEP  testing dhcp_option_policy creation with required arguments only
=== STEP  Negative Case: testing dhcp_option_policy creation with invalid parent Dn
=== STEP  testing dhcp_option_policy attribute: description = dkooeynd84e3yoywux4mh2r36iv41d04k1xnji4xbmw3iz9t2hf8n2uvrqinwh4erc3omhe8ym1jkt2nnk1ddrqcuxqdili4ovycirl02jykv8b0k4jsqe7q48scz668o
=== STEP  testing dhcp_option_policy attribute: annotation = 0v71j4ejregvyg01ec80ir6dmb3x1bp3lg73uva1rw4l0trtwrqqould3d669dsjeonzhsk84d4zfcvxamaijnfoecpnt8zvmk6lab22ytme22t02wxl8lunisn1besk2
=== STEP  testing dhcp_option_policy attribute: name_alias = vmq6garnuwkbuwzyfy3pc3ewmzhimppsmwvnjai4m641pjutybra6fxr08kh9d0o
=== STEP  testing dhcp_option_policy attribute: lrdde = 7lcts
=== STEP  testing dhcp_option attribute: data = h3pqvhp1w6gesia6pbu7jj139jrjo7spfk76fiytn6f7ea2s4qzqth9b0lc3sfeq1ewi8wpad74sodqnzesu0i9u9aoo6dxr3cp7vqyfx2mnzyslensdz71w91wcd4hw6r7lmic3re4oejkt26lcn0kymw3g72wl4uib49rqbqzh6qa24sqsykaqsyufmtrsdiyn31grg6w7wmppnlfxkmiq3e7q48yxf01dugl9oa4v8s8ng6k0mv8itwxtbl6nz
=== STEP  testing dhcp_option attribute: name_alias = 7hidmtmmtg3kqde7tphwgyyy88za960w6c8aiqiyxyt79v02mqo0nqk0rmj1p2q6
=== STEP  testing dhcp_option attribute: dhcp_option_id = 7lcts
=== STEP  testing dhcp_option attribute: annotation = fz7qv6w4mcbzxzvor8t3qexo0q0airxecmat180gkuh2vo178t7ageru6qvvflhnm4gg6srkvzy2ozqrmw31ug7jtmdztnjq7sghxu16lxa8zjyv8f0k9ltkzu0901gdz
=== STEP  testing dhcp_option attribute: lrdde = 7lcts
=== STEP  testing dhcp_option_policy creation with required arguments only
=== PAUSE TestAccAciDHCPOptionPolicy_Negative
=== RUN   TestAccAciDHCPOptionPolicy_MultipleCreateDelete
=== STEP  testing multiple dhcp_option_policy creation with required arguments only
=== PAUSE TestAccAciDHCPOptionPolicy_MultipleCreateDelete
=== CONT  TestAccAciDHCPOptionPolicyDataSource_Basic
=== CONT  TestAccAciDHCPOptionPolicy_Negative
=== CONT  TestAccAciDHCPOptionPolicy_MultipleCreateDelete
=== CONT  TestAccAciDHCPOptionPolicy_Basic
=== STEP  testing dhcp_option_policy destroy
--- PASS: TestAccAciDHCPOptionPolicy_MultipleCreateDelete (21.13s)
=== STEP  testing dhcp_option_policy destroy
--- PASS: TestAccAciDHCPOptionPolicyDataSource_Basic (47.17s)
=== STEP  testing dhcp_option_policy destroy
--- PASS: TestAccAciDHCPOptionPolicy_Negative (87.29s)
=== STEP  testing dhcp_option_policy destroy
--- PASS: TestAccAciDHCPOptionPolicy_Basic (110.91s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   112.394s
