### PR TITLE
added resources for 25-01-22

### DIFF
--- a/testacc/data_source_aci_aaaproviderref_test.go
+++ b/testacc/data_source_aci_aaaproviderref_test.go
@@ -1,0 +1,193 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciProviderGroupMemberDataSource_Basic(t *testing.T) {
+	resourceName := "aci_login_domain_provider.test"
+	dataSourceName := "data.aci_login_domain_provider.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	
+	aaaDuoProviderGroupName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciProviderGroupMemberDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateProviderGroupMemberDSWithoutRequired(aaaDuoProviderGroupName, rName,"parent_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateProviderGroupMemberDSWithoutRequired(aaaDuoProviderGroupName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccProviderGroupMemberConfigDataSource(aaaDuoProviderGroupName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "parent_dn", resourceName, "parent_dn",),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "order", resourceName, "order"),
+					
+				),
+			},
+			{
+				Config:      CreateAccProviderGroupMemberDataSourceUpdate(aaaDuoProviderGroupName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			
+			{
+				Config:      CreateAccProviderGroupMemberDSWithInvalidName(aaaDuoProviderGroupName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			
+			{
+				Config: CreateAccProviderGroupMemberDataSourceUpdatedResource(aaaDuoProviderGroupName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+
+func CreateAccProviderGroupMemberConfigDataSource(aaaDuoProviderGroupName, rName string) string {
+	fmt.Println("=== STEP  testing login_domain_provider Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_login_domain_provider" "test" {
+		parent_dn  = aci_duo_provider_group.test.id
+		name  = "%s"
+	}
+
+	data "aci_login_domain_provider" "test" {
+		parent_dn  = aci_duo_provider_group.test.id
+		name  = aci_login_domain_provider.test.name
+		depends_on = [ aci_login_domain_provider.test ]
+	}
+	`, aaaDuoProviderGroupName, rName)
+	return resource
+}
+
+func CreateProviderGroupMemberDSWithoutRequired(aaaDuoProviderGroupName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing login_domain_provider Data Source without ",attrName)
+	rBlock := `
+	
+	resource "aci_duo_provider_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_login_domain_provider" "test" {
+		parent_dn  = aci_duo_provider_group.test.id
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "parent_dn":
+		rBlock += `
+	data "aci_login_domain_provider" "test" {
+	#	parent_dn  = aci_duo_provider_group.test.id
+		name  = aci_login_domain_provider.test.name
+		depends_on = [ aci_login_domain_provider.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_login_domain_provider" "test" {
+		parent_dn  = aci_duo_provider_group.test.id
+	#	name  = aci_login_domain_provider.test.name
+		depends_on = [ aci_login_domain_provider.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock,aaaDuoProviderGroupName, rName)
+}
+
+func CreateAccProviderGroupMemberDSWithInvalidName(aaaDuoProviderGroupName, rName string) string {
+	fmt.Println("=== STEP  testing login_domain_provider Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_login_domain_provider" "test" {
+		parent_dn  = aci_duo_provider_group.test.id
+		name  = "%s"
+	}
+
+	data "aci_login_domain_provider" "test" {
+		parent_dn  = aci_duo_provider_group.test.id
+		name  = "${aci_login_domain_provider.test.name}_invalid"
+		depends_on = [ aci_login_domain_provider.test ]
+	}
+	`, aaaDuoProviderGroupName, rName)
+	return resource
+}
+
+func CreateAccProviderGroupMemberDataSourceUpdate(aaaDuoProviderGroupName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing login_domain_provider Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_login_domain_provider" "test" {
+		parent_dn  = aci_duo_provider_group.test.id
+		name  = "%s"
+	}
+
+	data "aci_login_domain_provider" "test" {
+		parent_dn  = aci_duo_provider_group.test.id
+		name  = aci_login_domain_provider.test.name
+		%s = "%s"
+		depends_on = [ aci_login_domain_provider.test ]
+	}
+	`, aaaDuoProviderGroupName, rName,key,value)
+	return resource
+}
+
+func CreateAccProviderGroupMemberDataSourceUpdatedResource(aaaDuoProviderGroupName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing login_domain_provider Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_login_domain_provider" "test" {
+		parent_dn  = aci_duo_provider_group.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_login_domain_provider" "test" {
+		parent_dn  = aci_duo_provider_group.test.id
+		name  = aci_login_domain_provider.test.name
+		depends_on = [ aci_login_domain_provider.test ]
+	}
+	`, aaaDuoProviderGroupName, rName,key,value)
+	return resource
+}

--- a/testacc/data_source_aci_rtctrlmatchrtdest_test.go
+++ b/testacc/data_source_aci_rtctrlmatchrtdest_test.go
@@ -1,0 +1,220 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciMatchRouteDestinationRuleDataSource_Basic(t *testing.T) {
+	resourceName := "aci_match_route_destination_rule.test"
+	dataSourceName := "data.aci_match_route_destination_rule.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)	 
+	ip, _ := acctest.RandIpAddress("10.4.0.0/16")
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	rtctrlSubjPName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciMatchRouteDestinationRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateMatchRouteDestinationRuleDSWithoutRequired(fvTenantName, rtctrlSubjPName, ip,"match_rule_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateMatchRouteDestinationRuleDSWithoutRequired(fvTenantName, rtctrlSubjPName, ip, "ip"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccMatchRouteDestinationRuleConfigDataSource(fvTenantName, rtctrlSubjPName, ip),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "match_rule_dn", resourceName, "match_rule_dn",),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ip", resourceName, "ip"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "aggregate", resourceName, "aggregate"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "greater_than_mask", resourceName, "greater_than_mask"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "less_than_mask", resourceName, "less_than_mask"),
+					
+				),
+			},
+			{
+				Config:      CreateAccMatchRouteDestinationRuleDataSourceUpdate(fvTenantName, rtctrlSubjPName, ip, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			
+			{
+				Config:      CreateAccMatchRouteDestinationRuleDSWithInvalidParentDn(fvTenantName, rtctrlSubjPName, ip),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			
+			{
+				Config: CreateAccMatchRouteDestinationRuleDataSourceUpdatedResource(fvTenantName, rtctrlSubjPName, ip, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+
+func CreateAccMatchRouteDestinationRuleConfigDataSource(fvTenantName, rtctrlSubjPName, ip string) string {
+	fmt.Println("=== STEP  testing match_route_destination_rule Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_match_rule" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = aci_match_rule.test.id
+		ip  = "%s"
+	}
+
+	data "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = aci_match_rule.test.id
+		ip  = aci_match_route_destination_rule.test.ip
+		depends_on = [ aci_match_route_destination_rule.test ]
+	}
+	`, fvTenantName, rtctrlSubjPName, ip)
+	return resource
+}
+
+func CreateMatchRouteDestinationRuleDSWithoutRequired(fvTenantName, rtctrlSubjPName, ip, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing match_route_destination_rule Data Source without ",attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_match_rule" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = aci_match_rule.test.id
+		ip  = "%s"
+	}
+	`
+	switch attrName {
+	case "match_rule_dn":
+		rBlock += `
+	data "aci_match_route_destination_rule" "test" {
+	#	match_rule_dn  = aci_match_rule.test.id
+		ip  = aci_match_route_destination_rule.test.ip
+		depends_on = [ aci_match_route_destination_rule.test ]
+	}
+		`
+	case "ip":
+		rBlock += `
+	data "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = aci_match_rule.test.id
+	#	ip  = aci_match_route_destination_rule.test.ip
+		depends_on = [ aci_match_route_destination_rule.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock,fvTenantName, rtctrlSubjPName, ip)
+}
+
+func CreateAccMatchRouteDestinationRuleDSWithInvalidParentDn(fvTenantName, rtctrlSubjPName, ip string) string {
+	fmt.Println("=== STEP  testing match_route_destination_rule Data Source with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_match_rule" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = aci_match_rule.test.id
+		ip  = "%s"
+	}
+
+	data "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = "${aci_match_rule.test.id}_invalid"
+		ip  = "${aci_match_route_destination_rule.test.ip}"
+		depends_on = [ aci_match_route_destination_rule.test ]
+	}
+	`, fvTenantName, rtctrlSubjPName, ip)
+	return resource
+}
+
+func CreateAccMatchRouteDestinationRuleDataSourceUpdate(fvTenantName, rtctrlSubjPName, ip, key, value string) string {
+	fmt.Println("=== STEP  testing match_route_destination_rule Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_match_rule" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = aci_match_rule.test.id
+		ip  = "%s"
+	}
+
+	data "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = aci_match_rule.test.id
+		ip  = aci_match_route_destination_rule.test.ip
+		%s = "%s"
+		depends_on = [ aci_match_route_destination_rule.test ]
+	}
+	`, fvTenantName, rtctrlSubjPName, ip,key,value)
+	return resource
+}
+
+func CreateAccMatchRouteDestinationRuleDataSourceUpdatedResource(fvTenantName, rtctrlSubjPName, ip, key, value string) string {
+	fmt.Println("=== STEP  testing match_route_destination_rule Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_match_rule" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = aci_match_rule.test.id
+		ip  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = aci_match_rule.test.id
+		ip  = aci_match_route_destination_rule.test.ip
+		depends_on = [ aci_match_route_destination_rule.test ]
+	}
+	`, fvTenantName, rtctrlSubjPName, ip,key,value)
+	return resource
+}

--- a/testacc/data_source_aci_tacacsgroup_test.go
+++ b/testacc/data_source_aci_tacacsgroup_test.go
@@ -1,0 +1,155 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciTACACSMonitoringDestinationGroupDataSource_Basic(t *testing.T) {
+	resourceName := "aci_tacacs_accounting.test"
+	dataSourceName := "data.aci_tacacs_accounting.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciTACACSMonitoringDestinationGroupDestroy,
+		Steps: []resource.TestStep{
+			
+			{
+				Config:      CreateTACACSMonitoringDestinationGroupDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccTACACSMonitoringDestinationGroupConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					
+				),
+			},
+			{
+				Config:      CreateAccTACACSMonitoringDestinationGroupDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			
+			{
+				Config:      CreateAccTACACSMonitoringDestinationGroupDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccTACACSMonitoringDestinationGroupDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+
+func CreateAccTACACSMonitoringDestinationGroupConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing tacacs_accounting Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_tacacs_accounting" "test" {
+	
+		name  = aci_tacacs_accounting.test.name
+		depends_on = [ aci_tacacs_accounting.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateTACACSMonitoringDestinationGroupDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing tacacs_accounting Data Source without ",attrName)
+	rBlock := `
+	
+	resource "aci_tacacs_accounting" "test" {
+	
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_tacacs_accounting" "test" {
+	
+	#	name  = aci_tacacs_accounting.test.name
+		depends_on = [ aci_tacacs_accounting.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock,rName)
+}
+
+
+func CreateAccTACACSMonitoringDestinationGroupDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing tacacs_accounting Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_tacacs_accounting" "test" {
+	
+		name  = "${aci_tacacs_accounting.test.name}_invalid"
+		depends_on = [ aci_tacacs_accounting.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccTACACSMonitoringDestinationGroupDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing tacacs_accounting Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_tacacs_accounting" "test" {
+	
+		name  = aci_tacacs_accounting.test.name
+		%s = "%s"
+		depends_on = [ aci_tacacs_accounting.test ]
+	}
+	`, rName,key,value)
+	return resource
+}
+
+func CreateAccTACACSMonitoringDestinationGroupDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing tacacs_accounting Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_tacacs_accounting" "test" {
+	
+		name  = aci_tacacs_accounting.test.name
+		depends_on = [ aci_tacacs_accounting.test ]
+	}
+	`, rName,key,value)
+	return resource
+}

--- a/testacc/data_source_aci_tacacstacacsdest_test.go
+++ b/testacc/data_source_aci_tacacstacacsdest_test.go
@@ -1,0 +1,192 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciTACACSDestinationDataSource_Basic(t *testing.T) {
+	resourceName := "aci_tacacs_accounting_destination.test"
+	dataSourceName := "data.aci_tacacs_accounting_destination.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	host := fmt.Sprintf("%s.com", acctest.RandString(5))
+	tacacsGroupName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciTACACSDestinationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateTACACSDestinationDSWithoutRequired(tacacsGroupName, host,  "tacacs_accounting_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateTACACSDestinationDSWithoutRequired(tacacsGroupName, host,  "host"),
+				ExpectError: regexp.MustCompile(`Invalid RN`),
+			},
+			{
+				Config: CreateAccTACACSDestinationConfigDataSource(tacacsGroupName, host),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "tacacs_accounting_dn", resourceName, "tacacs_accounting_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "host", resourceName, "host"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "port", resourceName, "port"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "auth_protocol", resourceName, "auth_protocol"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "key", resourceName, "key"),
+				),
+			},
+			{
+				Config:      CreateAccTACACSDestinationDataSourceUpdate(tacacsGroupName, host,  randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccTACACSDestinationDSWithInvalidParentDn(tacacsGroupName, host),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+
+			{
+				Config: CreateAccTACACSDestinationDataSourceUpdatedResource(tacacsGroupName, host,  "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccTACACSDestinationConfigDataSource(tacacsGroupName, host string) string {
+	fmt.Println("=== STEP  testing tacacs_accounting_destination Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_tacacs_accounting_destination" "test" {
+		tacacs_accounting_dn  = aci_tacacs_accounting.test.id
+		host  = "%s"
+	}
+
+	data "aci_tacacs_accounting_destination" "test" {
+		tacacs_accounting_dn  = aci_tacacs_accounting.test.id
+		host  = aci_tacacs_accounting_destination.test.host
+		depends_on = [ aci_tacacs_accounting_destination.test ]
+	}
+	`, tacacsGroupName, host)
+	return resource
+}
+
+func CreateTACACSDestinationDSWithoutRequired(tacacsGroupName, host, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing tacacs_accounting_destination Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_tacacs_accounting" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_tacacs_accounting_destination" "test" {
+		tacacs_accounting_dn  = aci_tacacs_accounting.test.id
+		host  = "%s"
+	}
+	`
+	switch attrName {
+	case "tacacs_accounting_dn":
+		rBlock += `
+	data "aci_tacacs_accounting_destination" "test" {
+	#	tacacs_accounting_dn  = aci_tacacs_accounting.test.id
+		host  = aci_tacacs_accounting_destination.test.host	
+		depends_on = [ aci_tacacs_accounting_destination.test ]
+	}
+		`
+	case "host":
+		rBlock += `
+	data "aci_tacacs_accounting_destination" "test" {
+		tacacs_accounting_dn  = aci_tacacs_accounting.test.id
+	#	host  = aci_tacacs_accounting_destination.test.host
+		depends_on = [ aci_tacacs_accounting_destination.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, tacacsGroupName, host)
+}
+
+func CreateAccTACACSDestinationDSWithInvalidParentDn(tacacsGroupName, host string) string {
+	fmt.Println("=== STEP  testing tacacs_accounting_destination Data Source with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_tacacs_accounting_destination" "test" {
+		tacacs_accounting_dn  = aci_tacacs_accounting.test.id
+		host  = "%s"
+	}
+
+	data "aci_tacacs_accounting_destination" "test" {
+		tacacs_accounting_dn  = "${aci_tacacs_accounting.test.id}_invalid"
+		host  = "${aci_tacacs_accounting_destination.test.host}"
+		depends_on = [ aci_tacacs_accounting_destination.test ]
+	}
+	`, tacacsGroupName, host)
+	return resource
+}
+
+func CreateAccTACACSDestinationDataSourceUpdate(tacacsGroupName, host, key, value string) string {
+	fmt.Println("=== STEP  testing tacacs_accounting_destination Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_tacacs_accounting_destination" "test" {
+		tacacs_accounting_dn  = aci_tacacs_accounting.test.id
+		host  = "%s"
+	}
+
+	data "aci_tacacs_accounting_destination" "test" {
+		tacacs_accounting_dn  = aci_tacacs_accounting.test.id
+		host  = aci_tacacs_accounting_destination.test.host
+		%s = "%s"
+		depends_on = [ aci_tacacs_accounting_destination.test ]
+	}
+	`, tacacsGroupName, host, key, value)
+	return resource
+}
+
+func CreateAccTACACSDestinationDataSourceUpdatedResource(tacacsGroupName, host,  key, value string) string {
+	fmt.Println("=== STEP  testing tacacs_accounting_destination Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_tacacs_accounting_destination" "test" {
+		tacacs_accounting_dn  = aci_tacacs_accounting.test.id
+		host  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_tacacs_accounting_destination" "test" {
+		tacacs_accounting_dn  = aci_tacacs_accounting.test.id
+		host  = aci_tacacs_accounting_destination.test.host
+		depends_on = [ aci_tacacs_accounting_destination.test ]
+	}
+	`, tacacsGroupName, host,  key, value)
+	return resource
+}

--- a/testacc/resource_aci_aaaproviderref_test.go
+++ b/testacc/resource_aci_aaaproviderref_test.go
@@ -1,0 +1,462 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciProviderGroupMember_Basic(t *testing.T) {
+	var login_domain_provider_default models.ProviderGroupMember
+	var login_domain_provider_updated models.ProviderGroupMember
+	resourceName := "aci_login_domain_provider.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	aaaDuoProviderGroupName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciProviderGroupMemberDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateProviderGroupMemberWithoutRequired(aaaDuoProviderGroupName, rName, "parent_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateProviderGroupMemberWithoutRequired(aaaDuoProviderGroupName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccProviderGroupMemberConfig(aaaDuoProviderGroupName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciProviderGroupMemberExists(resourceName, &login_domain_provider_default),
+					resource.TestCheckResourceAttr(resourceName, "parent_dn", fmt.Sprintf("uni/userext/duoext/duoprovidergroup-%s", aaaDuoProviderGroupName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "order", "0"),
+				),
+			},
+			{
+				Config: CreateAccProviderGroupMemberConfigWithOptionalValues(aaaDuoProviderGroupName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciProviderGroupMemberExists(resourceName, &login_domain_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "parent_dn", fmt.Sprintf("uni/userext/duoext/duoprovidergroup-%s", aaaDuoProviderGroupName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_login_domain_provider"),
+					resource.TestCheckResourceAttr(resourceName, "order", "lowest-available"),
+					testAccCheckAciProviderGroupMemberIdEqual(&login_domain_provider_default, &login_domain_provider_updated),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"order"},
+			},
+			{
+				Config:      CreateAccProviderGroupMemberConfigUpdatedName(aaaDuoProviderGroupName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccProviderGroupMemberRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccProviderGroupMemberConfigWithRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciProviderGroupMemberExists(resourceName, &login_domain_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "parent_dn", fmt.Sprintf("uni/userext/duoext/duoprovidergroup-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciProviderGroupMemberIdNotEqual(&login_domain_provider_default, &login_domain_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccProviderGroupMemberConfig(aaaDuoProviderGroupName, rName),
+			},
+			{
+				Config: CreateAccProviderGroupMemberConfigWithRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciProviderGroupMemberExists(resourceName, &login_domain_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "parent_dn", fmt.Sprintf("uni/userext/duoext/duoprovidergroup-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciProviderGroupMemberIdNotEqual(&login_domain_provider_default, &login_domain_provider_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciProviderGroupMember_Update(t *testing.T) {
+	var login_domain_provider_default models.ProviderGroupMember
+	var login_domain_provider_updated models.ProviderGroupMember
+	resourceName := "aci_login_domain_provider.test"
+	rName := makeTestVariable(acctest.RandString(5))
+
+	aaaDuoProviderGroupName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciProviderGroupMemberDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccProviderGroupMemberConfig(aaaDuoProviderGroupName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciProviderGroupMemberExists(resourceName, &login_domain_provider_default),
+				),
+			},
+			{
+				Config: CreateAccProviderGroupMemberUpdatedAttr(aaaDuoProviderGroupName, rName, "order", "16"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciProviderGroupMemberExists(resourceName, &login_domain_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "order", "16"),
+					testAccCheckAciProviderGroupMemberIdEqual(&login_domain_provider_default, &login_domain_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccProviderGroupMemberUpdatedAttr(aaaDuoProviderGroupName, rName, "order", "8"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciProviderGroupMemberExists(resourceName, &login_domain_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "order", "8"),
+					testAccCheckAciProviderGroupMemberIdEqual(&login_domain_provider_default, &login_domain_provider_updated),
+				),
+			},
+
+			{
+				Config: CreateAccProviderGroupMemberConfig(aaaDuoProviderGroupName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciProviderGroupMember_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	aaaDuoProviderGroupName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciProviderGroupMemberDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccProviderGroupMemberConfig(aaaDuoProviderGroupName, rName),
+			},
+			{
+				Config:      CreateAccProviderGroupMemberWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccProviderGroupMemberUpdatedAttr(aaaDuoProviderGroupName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccProviderGroupMemberUpdatedAttr(aaaDuoProviderGroupName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccProviderGroupMemberUpdatedAttr(aaaDuoProviderGroupName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccProviderGroupMemberUpdatedAttr(aaaDuoProviderGroupName, rName, "order", randomValue),
+				ExpectError: regexp.MustCompile(`invalid syntax`),
+			},
+			{
+				Config:      CreateAccProviderGroupMemberUpdatedAttr(aaaDuoProviderGroupName, rName, "order", "-1"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccProviderGroupMemberUpdatedAttr(aaaDuoProviderGroupName, rName, "order", "17"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccProviderGroupMemberUpdatedAttr(aaaDuoProviderGroupName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccProviderGroupMemberConfig(aaaDuoProviderGroupName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciProviderGroupMember_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	aaaDuoProviderGroupName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciProviderGroupMemberDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccProviderGroupMemberConfigMultiple(aaaDuoProviderGroupName, rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciProviderGroupMemberExists(name string, login_domain_provider *models.ProviderGroupMember) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Provider Group Member %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Provider Group Member dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		login_domain_providerFound := models.ProviderGroupMemberFromContainer(cont)
+		if login_domain_providerFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Provider Group Member %s not found", rs.Primary.ID)
+		}
+		*login_domain_provider = *login_domain_providerFound
+		return nil
+	}
+}
+
+func testAccCheckAciProviderGroupMemberDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing login_domain_provider destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_login_domain_provider" {
+			cont, err := client.Get(rs.Primary.ID)
+			login_domain_provider := models.ProviderGroupMemberFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Provider Group Member %s Still exists", login_domain_provider.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciProviderGroupMemberIdEqual(m1, m2 *models.ProviderGroupMember) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("login_domain_provider DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciProviderGroupMemberIdNotEqual(m1, m2 *models.ProviderGroupMember) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("login_domain_provider DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateProviderGroupMemberWithoutRequired(aaaDuoProviderGroupName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing login_domain_provider creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_duo_provider_group" "test" {
+		name 		= "%s"
+		
+	}
+	
+	`
+	switch attrName {
+	case "parent_dn":
+		rBlock += `
+	resource "aci_login_domain_provider" "test" {
+	#	parent_dn  = aci_duo_provider_group.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_login_domain_provider" "test" {
+		parent_dn  = aci_duo_provider_group.test.id
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, aaaDuoProviderGroupName, rName)
+}
+
+func CreateAccProviderGroupMemberConfigWithRequiredParams(aaaDuoProviderGroupName, rName string) string {
+	fmt.Printf("=== STEP  testing login_domain_provider creation with parent resource name %s and name %s\n", aaaDuoProviderGroupName, rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_login_domain_provider" "test" {
+		parent_dn  = aci_duo_provider_group.test.id
+		name  = "%s"
+	}
+	`, aaaDuoProviderGroupName, rName)
+	return resource
+}
+func CreateAccProviderGroupMemberConfigUpdatedName(aaaDuoProviderGroupName, rName string) string {
+	fmt.Println("=== STEP  testing login_domain_provider creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_login_domain_provider" "test" {
+		parent_dn  = aci_duo_provider_group.test.id
+		name  = "%s"
+	}
+	`, aaaDuoProviderGroupName, rName)
+	return resource
+}
+
+func CreateAccProviderGroupMemberConfig(aaaDuoProviderGroupName, rName string) string {
+	fmt.Println("=== STEP  testing login_domain_provider creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_login_domain_provider" "test" {
+		parent_dn  = aci_duo_provider_group.test.id
+		name  = "%s"
+	}
+	`, aaaDuoProviderGroupName, rName)
+	return resource
+}
+
+func CreateAccProviderGroupMemberConfigMultiple(aaaDuoProviderGroupName, rName string) string {
+	fmt.Println("=== STEP  testing multiple login_domain_provider creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_login_domain_provider" "test" {
+		parent_dn  = aci_duo_provider_group.test.id
+		name  = "%s_${count.index}"
+		order = "${count.index}"
+		count = 5
+	}
+	`, aaaDuoProviderGroupName, rName)
+	return resource
+}
+
+func CreateAccProviderGroupMemberWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing login_domain_provider creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_login_domain_provider" "test" {
+		parent_dn  = aci_tenant.test.id
+		name  = "%s"	
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccProviderGroupMemberConfigWithOptionalValues(aaaDuoProviderGroupName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing login_domain_provider creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_login_domain_provider" "test" {
+		parent_dn  = "${aci_duo_provider_group.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_login_domain_provider"
+		order = "lowest-available"
+		
+	}
+	`, aaaDuoProviderGroupName, rName)
+
+	return resource
+}
+
+func CreateAccProviderGroupMemberRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing login_domain_provider updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_login_domain_provider" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_login_domain_provider"
+		order = "1"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccProviderGroupMemberUpdatedAttr(aaaDuoProviderGroupName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing login_domain_provider attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_login_domain_provider" "test" {
+		parent_dn  = aci_duo_provider_group.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, aaaDuoProviderGroupName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccProviderGroupMemberUpdatedAttrList(aaaDuoProviderGroupName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing login_domain_provider attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_duo_provider_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_login_domain_provider" "test" {
+		parent_dn  = aci_duo_provider_group.test.id
+		name  = "%s"
+		%s = %s
+	}
+	`, aaaDuoProviderGroupName, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_rtctrlmatchrtdest_test.go
+++ b/testacc/resource_aci_rtctrlmatchrtdest_test.go
@@ -1,0 +1,522 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciMatchRouteDestinationRule_Basic(t *testing.T) {
+	var match_route_destination_rule_default models.MatchRouteDestinationRule
+	var match_route_destination_rule_updated models.MatchRouteDestinationRule
+	resourceName := "aci_match_route_destination_rule.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	ip, _ := acctest.RandIpAddress("10.0.0.0/16")
+	ip = fmt.Sprintf("%s/16", ip)
+	ipUpdated, _ := acctest.RandIpAddress("10.1.0.0/16")
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	rtctrlSubjPName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciMatchRouteDestinationRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateMatchRouteDestinationRuleWithoutRequired(fvTenantName, rtctrlSubjPName, ip, "match_rule_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateMatchRouteDestinationRuleWithoutRequired(fvTenantName, rtctrlSubjPName, ip, "ip"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccMatchRouteDestinationRuleConfig(fvTenantName, rtctrlSubjPName, ip),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMatchRouteDestinationRuleExists(resourceName, &match_route_destination_rule_default),
+					resource.TestCheckResourceAttr(resourceName, "match_rule_dn", fmt.Sprintf("uni/tn-%s/subj-%s", fvTenantName, rtctrlSubjPName)),
+					resource.TestCheckResourceAttr(resourceName, "ip", ip),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "aggregate", "no"),
+					resource.TestCheckResourceAttr(resourceName, "greater_than_mask", "0"),
+					resource.TestCheckResourceAttr(resourceName, "less_than_mask", "0"),
+				),
+			},
+			{
+				Config: CreateAccMatchRouteDestinationRuleConfigWithOptionalValues(fvTenantName, rtctrlSubjPName, ip),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMatchRouteDestinationRuleExists(resourceName, &match_route_destination_rule_updated),
+					resource.TestCheckResourceAttr(resourceName, "match_rule_dn", fmt.Sprintf("uni/tn-%s/subj-%s", fvTenantName, rtctrlSubjPName)),
+					resource.TestCheckResourceAttr(resourceName, "ip", ip),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_match_route_destination_rule"),
+					resource.TestCheckResourceAttr(resourceName, "aggregate", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "greater_than_mask", "32"),
+					resource.TestCheckResourceAttr(resourceName, "less_than_mask", "32"),
+					testAccCheckAciMatchRouteDestinationRuleIdEqual(&match_route_destination_rule_default, &match_route_destination_rule_updated),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"match_rule_dn"},
+			},
+			{
+				Config:      CreateAccMatchRouteDestinationRuleWithInavalidIP(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccMatchRouteDestinationRuleRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccMatchRouteDestinationRuleConfigWithRequiredParams(rNameUpdated, ip),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMatchRouteDestinationRuleExists(resourceName, &match_route_destination_rule_updated),
+					resource.TestCheckResourceAttr(resourceName, "match_rule_dn", fmt.Sprintf("uni/tn-%s/subj-%s", rNameUpdated, rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "ip", ip),
+					testAccCheckAciMatchRouteDestinationRuleIdNotEqual(&match_route_destination_rule_default, &match_route_destination_rule_updated),
+				),
+			},
+			{
+				Config: CreateAccMatchRouteDestinationRuleConfig(fvTenantName, rtctrlSubjPName, ip),
+			},
+			{
+				Config: CreateAccMatchRouteDestinationRuleConfigWithRequiredParams(rName, ipUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMatchRouteDestinationRuleExists(resourceName, &match_route_destination_rule_updated),
+					resource.TestCheckResourceAttr(resourceName, "match_rule_dn", fmt.Sprintf("uni/tn-%s/subj-%s", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "ip", ipUpdated),
+					testAccCheckAciMatchRouteDestinationRuleIdNotEqual(&match_route_destination_rule_default, &match_route_destination_rule_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciMatchRouteDestinationRule_Update(t *testing.T) {
+	var match_route_destination_rule_default models.MatchRouteDestinationRule
+	var match_route_destination_rule_updated models.MatchRouteDestinationRule
+	resourceName := "aci_match_route_destination_rule.test"
+	ip := "2001:db8:85a3::8a2e:370:7334/24"
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	rtctrlSubjPName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciMatchRouteDestinationRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccMatchRouteDestinationRuleConfig(fvTenantName, rtctrlSubjPName, ip),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMatchRouteDestinationRuleExists(resourceName, &match_route_destination_rule_default),
+				),
+			},
+			{
+				Config: CreateAccMatchRouteDestinationRuleUpdatedAttr(fvTenantName, rtctrlSubjPName, ip, "greater_than_mask", "64"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMatchRouteDestinationRuleExists(resourceName, &match_route_destination_rule_updated),
+					resource.TestCheckResourceAttr(resourceName, "greater_than_mask", "64"),
+					testAccCheckAciMatchRouteDestinationRuleIdEqual(&match_route_destination_rule_default, &match_route_destination_rule_updated),
+				),
+			},
+			{
+				Config: CreateAccMatchRouteDestinationRuleUpdatedAttr(fvTenantName, rtctrlSubjPName, ip, "less_than_mask", "64"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMatchRouteDestinationRuleExists(resourceName, &match_route_destination_rule_updated),
+					resource.TestCheckResourceAttr(resourceName, "less_than_mask", "64"),
+					testAccCheckAciMatchRouteDestinationRuleIdEqual(&match_route_destination_rule_default, &match_route_destination_rule_updated),
+				),
+			},
+			{
+				Config: CreateAccMatchRouteDestinationRuleUpdatedAttr(fvTenantName, rtctrlSubjPName, ip, "greater_than_mask", "128"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMatchRouteDestinationRuleExists(resourceName, &match_route_destination_rule_updated),
+					resource.TestCheckResourceAttr(resourceName, "greater_than_mask", "128"),
+					testAccCheckAciMatchRouteDestinationRuleIdEqual(&match_route_destination_rule_default, &match_route_destination_rule_updated),
+				),
+			},
+			{
+				Config: CreateAccMatchRouteDestinationRuleUpdatedAttr(fvTenantName, rtctrlSubjPName, ip, "less_than_mask", "128"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMatchRouteDestinationRuleExists(resourceName, &match_route_destination_rule_updated),
+					resource.TestCheckResourceAttr(resourceName, "less_than_mask", "128"),
+					testAccCheckAciMatchRouteDestinationRuleIdEqual(&match_route_destination_rule_default, &match_route_destination_rule_updated),
+				),
+			},
+			{
+				Config: CreateAccMatchRouteDestinationRuleConfig(fvTenantName, rtctrlSubjPName, ip),
+			},
+		},
+	})
+}
+
+func TestAccAciMatchRouteDestinationRule_Negative(t *testing.T) {
+	ip, _ := acctest.RandIpAddress("10.3.0.0/16")
+	rName := makeTestVariable(acctest.RandString(5))
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	rtctrlSubjPName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciMatchRouteDestinationRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccMatchRouteDestinationRuleConfig(fvTenantName, rtctrlSubjPName, ip),
+			},
+			{
+				Config:      CreateAccMatchRouteDestinationRuleWithInValidParentDn(rName, ip),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccMatchRouteDestinationRuleUpdatedAttr(fvTenantName, rtctrlSubjPName, ip, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccMatchRouteDestinationRuleUpdatedAttr(fvTenantName, rtctrlSubjPName, ip, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccMatchRouteDestinationRuleUpdatedAttr(fvTenantName, rtctrlSubjPName, ip, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccMatchRouteDestinationRuleUpdatedAttr(fvTenantName, rtctrlSubjPName, ip, "aggregate", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccMatchRouteDestinationRuleUpdatedAttr(fvTenantName, rtctrlSubjPName, ip, "greater_than_mask", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccMatchRouteDestinationRuleUpdatedAttr(fvTenantName, rtctrlSubjPName, ip, "greater_than_mask", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccMatchRouteDestinationRuleUpdatedAttr(fvTenantName, rtctrlSubjPName, ip, "greater_than_mask", "129"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccMatchRouteDestinationRuleUpdatedAttr(fvTenantName, rtctrlSubjPName, ip, "less_than_mask", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccMatchRouteDestinationRuleUpdatedAttr(fvTenantName, rtctrlSubjPName, ip, "less_than_mask", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccMatchRouteDestinationRuleUpdatedAttr(fvTenantName, rtctrlSubjPName, ip, "less_than_mask", "129"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccMatchRouteDestinationRuleUpdatedAttr(fvTenantName, rtctrlSubjPName, ip, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccMatchRouteDestinationRuleConfig(fvTenantName, rtctrlSubjPName, ip),
+			},
+		},
+	})
+}
+
+func TestAccAciMatchRouteDestinationRule_MultipleCreateDelete(t *testing.T) {
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	rtctrlSubjPName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciMatchRouteDestinationRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccMatchRouteDestinationRuleConfigMultiple(fvTenantName, rtctrlSubjPName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciMatchRouteDestinationRuleExists(name string, match_route_destination_rule *models.MatchRouteDestinationRule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Match Route Destination Rule %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Match Route Destination Rule dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		match_route_destination_ruleFound := models.MatchRouteDestinationRuleFromContainer(cont)
+		if match_route_destination_ruleFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Match Route Destination Rule %s not found", rs.Primary.ID)
+		}
+		*match_route_destination_rule = *match_route_destination_ruleFound
+		return nil
+	}
+}
+
+func testAccCheckAciMatchRouteDestinationRuleDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing match_route_destination_rule destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_match_route_destination_rule" {
+			cont, err := client.Get(rs.Primary.ID)
+			match_route_destination_rule := models.MatchRouteDestinationRuleFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Match Route Destination Rule %s Still exists", match_route_destination_rule.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciMatchRouteDestinationRuleIdEqual(m1, m2 *models.MatchRouteDestinationRule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("match_route_destination_rule DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciMatchRouteDestinationRuleIdNotEqual(m1, m2 *models.MatchRouteDestinationRule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("match_route_destination_rule DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateMatchRouteDestinationRuleWithoutRequired(fvTenantName, rtctrlSubjPName, ip, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing match_route_destination_rule creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		
+	}
+	
+	resource "aci_match_rule" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	`
+	switch attrName {
+	case "match_rule_dn":
+		rBlock += `
+	resource "aci_match_route_destination_rule" "test" {
+	#	match_rule_dn  = aci_match_rule.test.id
+		ip  = "%s"
+	}
+		`
+	case "ip":
+		rBlock += `
+	resource "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = aci_match_rule.test.id
+	#	ip  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, rtctrlSubjPName, ip)
+}
+
+func CreateAccMatchRouteDestinationRuleConfigWithRequiredParams(prName, ip string) string {
+	fmt.Printf("=== STEP  testing match_route_destination_rule creation with parent resource name %s and ip %s\n", prName, ip)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_match_rule" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = aci_match_rule.test.id
+		ip  = "%s"
+	}
+	`, prName, prName, ip)
+	return resource
+}
+
+func CreateAccMatchRouteDestinationRuleConfig(fvTenantName, rtctrlSubjPName, ip string) string {
+	fmt.Println("=== STEP  testing match_route_destination_rule creation with required arguments")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_match_rule" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = aci_match_rule.test.id
+		ip  = "%s"
+	}
+	`, fvTenantName, rtctrlSubjPName, ip)
+	return resource
+}
+
+func CreateAccMatchRouteDestinationRuleWithInavalidIP(rName string) string {
+	fmt.Println("=== STEP  testing match_route_destination_rule creation with required invalid ip")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_match_rule" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = aci_match_rule.test.id
+		ip  = "%s"
+	}
+	`, rName, rName, rName)
+	return resource
+}
+
+func CreateAccMatchRouteDestinationRuleConfigMultiple(fvTenantName, rtctrlSubjPName string) string {
+	fmt.Println("=== STEP  testing multiple match_route_destination_rule creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_match_rule" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = aci_match_rule.test.id
+		ip  = "10.4.0.${count.index}"
+		count = 5
+	}
+	`, fvTenantName, rtctrlSubjPName)
+	return resource
+}
+
+func CreateAccMatchRouteDestinationRuleWithInValidParentDn(rName, ip string) string {
+	fmt.Println("=== STEP  Negative Case: testing match_route_destination_rule creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = aci_tenant.test.id
+		ip  = "%s"	
+	}
+	`, rName, ip)
+	return resource
+}
+
+func CreateAccMatchRouteDestinationRuleConfigWithOptionalValues(fvTenantName, rtctrlSubjPName, ip string) string {
+	fmt.Println("=== STEP  Basic: testing match_route_destination_rule creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_match_rule" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = "${aci_match_rule.test.id}"
+		ip  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_match_route_destination_rule"
+		aggregate = "yes"
+		greater_than_mask = "32"
+		less_than_mask = "32"
+		
+	}
+	`, fvTenantName, rtctrlSubjPName, ip)
+
+	return resource
+}
+
+func CreateAccMatchRouteDestinationRuleRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing match_route_destination_rule updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_match_route_destination_rule" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_match_route_destination_rule"
+		aggregate = "yes"
+		from_pfx_len = "1"
+		to_pfx_len = "1"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccMatchRouteDestinationRuleUpdatedAttr(fvTenantName, rtctrlSubjPName, ip, attribute, value string) string {
+	fmt.Printf("=== STEP  testing match_route_destination_rule attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_match_rule" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_match_route_destination_rule" "test" {
+		match_rule_dn  = aci_match_rule.test.id
+		ip  = "%s"
+		%s = "%s"
+	}
+	`, fvTenantName, rtctrlSubjPName, ip, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_tacacsgroup_test.go
+++ b/testacc/resource_aci_tacacsgroup_test.go
@@ -1,0 +1,325 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+
+func TestAccAciTACACSMonitoringDestinationGroup_Basic(t *testing.T) {
+	var tacacs_accounting_default models.TACACSMonitoringDestinationGroup
+	var tacacs_accounting_updated models.TACACSMonitoringDestinationGroup
+	resourceName := "aci_tacacs_accounting.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciTACACSMonitoringDestinationGroupDestroy,
+		Steps: []resource.TestStep{
+			
+			{
+				Config:      CreateTACACSMonitoringDestinationGroupWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccTACACSMonitoringDestinationGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSMonitoringDestinationGroupExists(resourceName, &tacacs_accounting_default),
+					
+					resource.TestCheckResourceAttr(resourceName, "name",rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation","orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description",""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias",""),
+					
+				),
+			},
+			{
+				Config: CreateAccTACACSMonitoringDestinationGroupConfigWithOptionalValues(rName), 
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSMonitoringDestinationGroupExists(resourceName, &tacacs_accounting_updated),
+					
+					resource.TestCheckResourceAttr(resourceName, "name",rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_tacacs_accounting"),
+					
+					testAccCheckAciTACACSMonitoringDestinationGroupIdEqual(&tacacs_accounting_default, &tacacs_accounting_updated),
+				),
+			},  
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccTACACSMonitoringDestinationGroupConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			
+			{
+				Config:      CreateAccTACACSMonitoringDestinationGroupRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			
+			{
+				Config: CreateAccTACACSMonitoringDestinationGroupConfigWithRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSMonitoringDestinationGroupExists(resourceName, &tacacs_accounting_updated),
+					
+					resource.TestCheckResourceAttr(resourceName, "name",rNameUpdated),
+					testAccCheckAciTACACSMonitoringDestinationGroupIdNotEqual(&tacacs_accounting_default, &tacacs_accounting_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciTACACSMonitoringDestinationGroup_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciTACACSMonitoringDestinationGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccTACACSMonitoringDestinationGroupConfig(rName),
+			},
+			
+			{
+				Config:      CreateAccTACACSMonitoringDestinationGroupUpdatedAttr(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccTACACSMonitoringDestinationGroupUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccTACACSMonitoringDestinationGroupUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			
+			{
+				Config:      CreateAccTACACSMonitoringDestinationGroupUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccTACACSMonitoringDestinationGroupConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciTACACSMonitoringDestinationGroup_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciTACACSMonitoringDestinationGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccTACACSMonitoringDestinationGroupConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciTACACSMonitoringDestinationGroupExists(name string, tacacs_accounting *models.TACACSMonitoringDestinationGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("TACACS Monitoring Destination Group %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No TACACS Monitoring Destination Group dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		tacacs_accountingFound := models.TACACSMonitoringDestinationGroupFromContainer(cont)
+		if tacacs_accountingFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("TACACS Monitoring Destination Group %s not found", rs.Primary.ID)
+		}
+		*tacacs_accounting = *tacacs_accountingFound
+		return nil
+	}
+}
+
+func testAccCheckAciTACACSMonitoringDestinationGroupDestroy(s *terraform.State) error {	
+	fmt.Println("=== STEP  testing tacacs_accounting destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		 if rs.Type == "aci_tacacs_accounting" {
+			cont,err := client.Get(rs.Primary.ID)
+			tacacs_accounting := models.TACACSMonitoringDestinationGroupFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("TACACS Monitoring Destination Group %s Still exists",tacacs_accounting.DistinguishedName)
+			}
+		}else{
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciTACACSMonitoringDestinationGroupIdEqual(m1, m2 *models.TACACSMonitoringDestinationGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("tacacs_accounting DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciTACACSMonitoringDestinationGroupIdNotEqual(m1, m2 *models.TACACSMonitoringDestinationGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("tacacs_accounting DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateTACACSMonitoringDestinationGroupWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing tacacs_accounting creation without ",attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_tacacs_accounting" "test" {
+	
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock,rName)
+}
+
+func CreateAccTACACSMonitoringDestinationGroupConfigWithRequiredParams(rName string) string {
+	fmt.Println("=== STEP  testing tacacs_accounting creation with updated naming arguments")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+func CreateAccTACACSMonitoringDestinationGroupConfigUpdatedName(rName string) string {
+	fmt.Println("=== STEP  testing tacacs_accounting creation with invalid name = ",rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccTACACSMonitoringDestinationGroupConfig(rName string) string {
+	fmt.Println("=== STEP  testing tacacs_accounting creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccTACACSMonitoringDestinationGroupConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple tacacs_accounting creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+	
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+
+
+func CreateAccTACACSMonitoringDestinationGroupConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing tacacs_accounting creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+	
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_tacacs_accounting"
+		
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccTACACSMonitoringDestinationGroupRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing tacacs_accounting updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_tacacs_accounting" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_tacacs_accounting"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccTACACSMonitoringDestinationGroupUpdatedAttr(rName,attribute,value string) string {
+	fmt.Printf("=== STEP  testing tacacs_accounting attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName,attribute,value)
+	return resource
+}
+
+func CreateAccTACACSMonitoringDestinationGroupUpdatedAttrList(rName,attribute,value string) string {
+	fmt.Printf("=== STEP  testing tacacs_accounting attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+	
+		name  = "%s"
+		%s = %s
+	}
+	`, rName,attribute,value)
+	return resource
+}

--- a/testacc/resource_aci_tacacstacacsdest_test.go
+++ b/testacc/resource_aci_tacacstacacsdest_test.go
@@ -1,0 +1,448 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciTACACSDestination_Basic(t *testing.T) {
+	var tacacs_accounting_destination_default models.TACACSDestination
+	var tacacs_accounting_destination_updated models.TACACSDestination
+	resourceName := "aci_tacacs_accounting_destination.test"
+	rNameUpdated := acctest.RandString(5)
+	host := fmt.Sprintf("%s.com", acctest.RandString(5))
+	hostUpdated := fmt.Sprintf("%s.com", acctest.RandString(5))
+	tacacsGroupName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciTACACSDestinationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateTACACSDestinationWithoutRequired(tacacsGroupName, host, "tacacs_accounting_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateTACACSDestinationWithoutRequired(tacacsGroupName, host, "host"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccTACACSDestinationConfig(tacacsGroupName, host),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSDestinationExists(resourceName, &tacacs_accounting_destination_default),
+					resource.TestCheckResourceAttr(resourceName, "tacacs_accounting_dn", fmt.Sprintf("uni/fabric/tacacsgroup-%s", tacacsGroupName)),
+					resource.TestCheckResourceAttr(resourceName, "host", host),
+					resource.TestCheckResourceAttr(resourceName, "port", "49"),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "auth_protocol", "pap"),
+				),
+			},
+			{
+				Config: CreateAccTACACSDestinationConfigWithOptionalValues(tacacsGroupName, host),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSDestinationExists(resourceName, &tacacs_accounting_destination_updated),
+					resource.TestCheckResourceAttr(resourceName, "tacacs_accounting_dn", fmt.Sprintf("uni/fabric/tacacsgroup-%s", tacacsGroupName)),
+					resource.TestCheckResourceAttr(resourceName, "host", host),
+					resource.TestCheckResourceAttr(resourceName, "port", "49"),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_tacacs_accounting_destination"),
+					resource.TestCheckResourceAttr(resourceName, "auth_protocol", "chap"),
+					resource.TestCheckResourceAttr(resourceName, "key", "test_key"),
+					testAccCheckAciTACACSDestinationIdEqual(&tacacs_accounting_destination_default, &tacacs_accounting_destination_updated),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"key"},
+			},
+			{
+				Config:      CreateAccTACACSDestinationRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateAccTACACSDestinationConfigWithRequiredParams(rNameUpdated, host, "0"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccTACACSDestinationConfigWithRequiredParams(rNameUpdated, host, "65536"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config: CreateAccTACACSDestinationConfigWithRequiredParams(rNameUpdated, host, "49"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSDestinationExists(resourceName, &tacacs_accounting_destination_updated),
+					resource.TestCheckResourceAttr(resourceName, "tacacs_accounting_dn", fmt.Sprintf("uni/fabric/tacacsgroup-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "host", host),
+					resource.TestCheckResourceAttr(resourceName, "port", "49"),
+					testAccCheckAciTACACSDestinationIdNotEqual(&tacacs_accounting_destination_default, &tacacs_accounting_destination_updated),
+				),
+			},
+			{
+				Config: CreateAccTACACSDestinationConfig(tacacsGroupName, host),
+			},
+			{
+				Config: CreateAccTACACSDestinationConfigWithRequiredParams(tacacsGroupName, hostUpdated, "49"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSDestinationExists(resourceName, &tacacs_accounting_destination_updated),
+					resource.TestCheckResourceAttr(resourceName, "tacacs_accounting_dn", fmt.Sprintf("uni/fabric/tacacsgroup-%s", tacacsGroupName)),
+					resource.TestCheckResourceAttr(resourceName, "host", hostUpdated),
+					resource.TestCheckResourceAttr(resourceName, "port", "49"),
+					testAccCheckAciTACACSDestinationIdNotEqual(&tacacs_accounting_destination_default, &tacacs_accounting_destination_updated),
+				),
+			},
+			{
+				Config: CreateAccTACACSDestinationConfig(tacacsGroupName, host),
+			},
+			{
+				Config: CreateAccTACACSDestinationConfigWithRequiredParams(tacacsGroupName, host, "50"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSDestinationExists(resourceName, &tacacs_accounting_destination_updated),
+					resource.TestCheckResourceAttr(resourceName, "tacacs_accounting_dn", fmt.Sprintf("uni/fabric/tacacsgroup-%s", tacacsGroupName)),
+					resource.TestCheckResourceAttr(resourceName, "port", "50"),
+					resource.TestCheckResourceAttr(resourceName, "host", host),
+					testAccCheckAciTACACSDestinationIdNotEqual(&tacacs_accounting_destination_default, &tacacs_accounting_destination_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciTACACSDestination_Update(t *testing.T) {
+	var tacacs_accounting_destination_default models.TACACSDestination
+	var tacacs_accounting_destination_updated models.TACACSDestination
+	resourceName := "aci_tacacs_accounting_destination.test"
+	host := fmt.Sprintf("%s.com", acctest.RandString(5))
+	tacacsGroupName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciTACACSDestinationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccTACACSDestinationConfig(tacacsGroupName, host),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSDestinationExists(resourceName, &tacacs_accounting_destination_default),
+				),
+			},
+			{
+				Config: CreateAccTACACSDestinationUpdatedAttr(tacacsGroupName, host, "auth_protocol", "mschap"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSDestinationExists(resourceName, &tacacs_accounting_destination_updated),
+					resource.TestCheckResourceAttr(resourceName, "auth_protocol", "mschap"),
+					testAccCheckAciTACACSDestinationIdEqual(&tacacs_accounting_destination_default, &tacacs_accounting_destination_updated),
+				),
+			},
+			{
+				Config: CreateAccTACACSDestinationConfigWithRequiredParams(tacacsGroupName, host, "1"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSDestinationExists(resourceName, &tacacs_accounting_destination_updated),
+					resource.TestCheckResourceAttr(resourceName, "tacacs_accounting_dn", fmt.Sprintf("uni/fabric/tacacsgroup-%s", tacacsGroupName)),
+					resource.TestCheckResourceAttr(resourceName, "host", host),
+					resource.TestCheckResourceAttr(resourceName, "port", "1"),
+					testAccCheckAciTACACSDestinationIdNotEqual(&tacacs_accounting_destination_default, &tacacs_accounting_destination_updated),
+				),
+			},
+			{
+				Config: CreateAccTACACSDestinationConfigWithRequiredParams(tacacsGroupName, host, "32000"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciTACACSDestinationExists(resourceName, &tacacs_accounting_destination_updated),
+					resource.TestCheckResourceAttr(resourceName, "tacacs_accounting_dn", fmt.Sprintf("uni/fabric/tacacsgroup-%s", tacacsGroupName)),
+					resource.TestCheckResourceAttr(resourceName, "host", host),
+					resource.TestCheckResourceAttr(resourceName, "port", "32000"),
+					testAccCheckAciTACACSDestinationIdNotEqual(&tacacs_accounting_destination_default, &tacacs_accounting_destination_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciTACACSDestination_Negative(t *testing.T) {
+	host := fmt.Sprintf("%s.com", acctest.RandString(5))
+	tacacsGroupName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciTACACSDestinationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccTACACSDestinationConfig(tacacsGroupName, host),
+			},
+			{
+				Config:      CreateAccTACACSDestinationWithInValidParentDn(tacacsGroupName, host),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccTACACSDestinationUpdatedAttr(tacacsGroupName, host, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccTACACSDestinationUpdatedAttr(tacacsGroupName, host, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccTACACSDestinationUpdatedAttr(tacacsGroupName, host, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccTACACSDestinationUpdatedAttr(tacacsGroupName, host, "auth_protocol", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccTACACSDestinationUpdatedAttr(tacacsGroupName, host, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccTACACSDestinationConfig(tacacsGroupName, host),
+			},
+		},
+	})
+}
+
+func TestAccAciTACACSDestination_MultipleCreateDelete(t *testing.T) {
+	host := acctest.RandString(5)
+	tacacsGroupName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciTACACSDestinationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccTACACSDestinationConfigMultiple(tacacsGroupName, host),
+			},
+		},
+	})
+}
+
+func testAccCheckAciTACACSDestinationExists(name string, tacacs_accounting_destination *models.TACACSDestination) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("TACACSDestination %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No TACACSDestination dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		tacacs_accounting_destinationFound := models.TACACSDestinationFromContainer(cont)
+		if tacacs_accounting_destinationFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("TACACSDestination %s not found", rs.Primary.ID)
+		}
+		*tacacs_accounting_destination = *tacacs_accounting_destinationFound
+		return nil
+	}
+}
+
+func testAccCheckAciTACACSDestinationDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing tacacs_accounting_destination destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_tacacs_accounting_destination" {
+			cont, err := client.Get(rs.Primary.ID)
+			tacacs_accounting_destination := models.TACACSDestinationFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("TACACSDestination %s Still exists", tacacs_accounting_destination.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciTACACSDestinationIdEqual(m1, m2 *models.TACACSDestination) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("tacacs_accounting_destination DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciTACACSDestinationIdNotEqual(m1, m2 *models.TACACSDestination) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("tacacs_accounting_destination DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateTACACSDestinationWithoutRequired(tacacsGroupName, host, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing tacacs_accounting_destination creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_tacacs_accounting" "test" {
+		name 		= "%s"
+		
+	}
+	
+	`
+	switch attrName {
+	case "tacacs_accounting_dn":
+		rBlock += `
+	resource "aci_tacacs_accounting_destination" "test" {
+	#	tacacs_accounting_dn  = aci_tacacs_accounting.test.id
+		host  = "%s"	
+	}
+		`
+	case "host":
+		rBlock += `
+	resource "aci_tacacs_accounting_destination" "test" {
+		tacacs_accounting_dn  = aci_tacacs_accounting.test.id
+	#	host  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, tacacsGroupName, host)
+}
+
+func CreateAccTACACSDestinationConfigWithRequiredParams(tacacsGroupName, host, port string) string {
+	fmt.Printf("=== STEP  testing tacacs_accounting_destination creation with parent resource name %s, host %s and port %s\n", tacacsGroupName, host, port)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_tacacs_accounting_destination" "test" {
+		tacacs_accounting_dn  = aci_tacacs_accounting.test.id
+		host  = "%s"
+		port  = "%s"
+	}
+	`, tacacsGroupName, host, port)
+	return resource
+}
+
+func CreateAccTACACSDestinationConfig(tacacsGroupName, host string) string {
+	fmt.Println("=== STEP  testing tacacs_accounting_destination creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_tacacs_accounting_destination" "test" {
+		tacacs_accounting_dn  = aci_tacacs_accounting.test.id
+		host  = "%s"
+	}
+	`, tacacsGroupName, host)
+	return resource
+}
+
+func CreateAccTACACSDestinationConfigMultiple(tacacsGroupName, host string) string {
+	fmt.Println("=== STEP  testing multiple tacacs_accounting_destination creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_tacacs_accounting_destination" "test" {
+		tacacs_accounting_dn  = aci_tacacs_accounting.test.id
+		host  = "%s${count.index}.com"
+		count = 5
+	}
+	`, tacacsGroupName, host)
+	return resource
+}
+
+func CreateAccTACACSDestinationWithInValidParentDn(rName, host string) string {
+	fmt.Println("=== STEP  Negative Case: testing tacacs_accounting_destination creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_tacacs_accounting_destination" "test" {
+		tacacs_accounting_dn  = aci_tenant.test.id
+		host  = "%s"	
+	}
+	`, rName, host)
+	return resource
+}
+
+func CreateAccTACACSDestinationConfigWithOptionalValues(tacacsGroupName, host string) string {
+	fmt.Println("=== STEP  Basic: testing tacacs_accounting_destination creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_tacacs_accounting_destination" "test" {
+		tacacs_accounting_dn  = "${aci_tacacs_accounting.test.id}"
+		host  = "%s"
+		port  = "49"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_tacacs_accounting_destination"
+		auth_protocol = "chap"
+		key = "test_key"
+		
+	}
+	`, tacacsGroupName, host)
+
+	return resource
+}
+
+func CreateAccTACACSDestinationRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing tacacs_accounting_destination updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_tacacs_accounting_destination" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_tacacs_accounting_destination"
+		auth_protocol = "chap"
+		key = ""
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccTACACSDestinationUpdatedAttr(tacacsGroupName, host, attribute, value string) string {
+	fmt.Printf("=== STEP  testing tacacs_accounting_destination attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tacacs_accounting" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_tacacs_accounting_destination" "test" {
+		tacacs_accounting_dn  = aci_tacacs_accounting.test.id
+		host  = "%s"
+		%s = "%s"
+	}
+	`, tacacsGroupName, host, attribute, value)
+	return resource
+}

--- a/website/docs/d/match_route_destination_rule.html.markdown
+++ b/website/docs/d/match_route_destination_rule.html.markdown
@@ -41,3 +41,5 @@ data "aci_match_route_destination_rule" "example" {
 * `aggregate` - (Optional) Aggregated Route. Aggregated Route
 * `greater_than_mask` - (Optional) Start of Prefix Length. Prefix list range
 * `less_than_mask` - (Optional) End of Prefix Length. 
+* `description` - (Optional) Description of object Match Route Destination Rule.
+* `name_alias` - (Optional) Name alias of object Match Route Destination Rule.

--- a/website/docs/r/match_route_destination_rule.html.markdown
+++ b/website/docs/r/match_route_destination_rule.html.markdown
@@ -41,6 +41,8 @@ resource "aci_match_route_destination_rule" "destination" {
 * `aggregate` - (Optional) Aggregated Route. Allowed values are "false", "true" and default value is "false". Type: String.
 * `greater_than_mask` - (Optional) Start of Prefix Length. Allowed range is 0-128 and default value is "0".
 * `less_than_mask` - (Optional) End of Prefix Length. Allowed range is 0-128 and default value is "0".
+* `description` - (Optional) Description of object Match Route Destination Rule.
+* `name_alias` - (Optional) Name alias of object Match Route Destination Rule.
 
 
 ## Importing ##


### PR DESCRIPTION
=== RUN   TestAccAciMatchRouteDestinationRuleDataSource_Basic
=== STEP  Basic: testing match_route_destination_rule Data Source without  match_rule_dn
=== STEP  Basic: testing match_route_destination_rule Data Source without  ip
=== STEP  testing match_route_destination_rule Data Source with required arguments only
=== STEP  testing match_route_destination_rule Data Source with random attribute
=== STEP  testing match_route_destination_rule Data Source with Invalid Parent Dn
=== STEP  testing match_route_destination_rule Data Source with updated resource
=== PAUSE TestAccAciMatchRouteDestinationRuleDataSource_Basic
=== RUN   TestAccAciMatchRouteDestinationRule_Basic
=== STEP  Basic: testing match_route_destination_rule creation without  match_rule_dn
=== STEP  Basic: testing match_route_destination_rule creation without  ip
=== STEP  testing match_route_destination_rule creation with required arguments
=== STEP  Basic: testing match_route_destination_rule creation with optional parameters
=== STEP  testing match_route_destination_rule creation with required invalid ip
=== STEP  Basic: testing match_route_destination_rule updation without required parameters
=== STEP  testing match_route_destination_rule creation with parent resource name acctest_p0bqo and ip 10.0.84.136/16
=== STEP  testing match_route_destination_rule creation with required arguments
=== STEP  testing match_route_destination_rule creation with parent resource name acctest_v3vls and ip 10.1.84.136
=== PAUSE TestAccAciMatchRouteDestinationRule_Basic
=== RUN   TestAccAciMatchRouteDestinationRule_Update
=== STEP  testing match_route_destination_rule creation with required arguments
=== STEP  testing match_route_destination_rule attribute: greater_than_mask = 64
=== STEP  testing match_route_destination_rule attribute: less_than_mask = 64
=== STEP  testing match_route_destination_rule attribute: greater_than_mask = 128
=== STEP  testing match_route_destination_rule attribute: less_than_mask = 128
=== STEP  testing match_route_destination_rule creation with required arguments
=== PAUSE TestAccAciMatchRouteDestinationRule_Update
=== RUN   TestAccAciMatchRouteDestinationRule_Negative
=== STEP  testing match_route_destination_rule creation with required arguments
=== STEP  Negative Case: testing match_route_destination_rule creation with invalid parent Dn
=== STEP  testing match_route_destination_rule attribute: description = 4cmjafntsb417ka20bhglehxww0h39er9l3403zvi6z69x7afznwi01l2swh8d7y9l7qdg03jtfgetue791aevzm1iirzlngajapi91t0zoqlj16dcz0uxrh8x6rkz621
=== STEP  testing match_route_destination_rule attribute: annotation = cnuyxszlzdplfusmb78h4ulms1x3109gygl13crmkyaypgamkk9c1vo7j8ith7vv4nnklolv6msp1dh6qdozu1k1xhgcgi4wz9gumpcridmdc8ziepua0qu9kkdbrzkdk
=== STEP  testing match_route_destination_rule attribute: name_alias = cu81mlmtr3ll2vg4r4nafvfnjd1nts6gmnl4pnk8a0hojop011hdzd2lisandnz2
=== STEP  testing match_route_destination_rule attribute: aggregate = oxh6j
=== STEP  testing match_route_destination_rule attribute: greater_than_mask = oxh6j
=== STEP  testing match_route_destination_rule attribute: greater_than_mask = -1
=== STEP  testing match_route_destination_rule attribute: greater_than_mask = 129
=== STEP  testing match_route_destination_rule attribute: less_than_mask = oxh6j
=== STEP  testing match_route_destination_rule attribute: less_than_mask = -1
=== STEP  testing match_route_destination_rule attribute: less_than_mask = 129
=== STEP  testing match_route_destination_rule attribute: hugof = oxh6j
=== STEP  testing match_route_destination_rule creation with required arguments
=== PAUSE TestAccAciMatchRouteDestinationRule_Negative
=== RUN   TestAccAciMatchRouteDestinationRule_MultipleCreateDelete
=== STEP  testing multiple match_route_destination_rule creation with required arguments only
=== PAUSE TestAccAciMatchRouteDestinationRule_MultipleCreateDelete
=== CONT  TestAccAciMatchRouteDestinationRuleDataSource_Basic
=== CONT  TestAccAciMatchRouteDestinationRule_Negative
=== CONT  TestAccAciMatchRouteDestinationRule_Update
=== CONT  TestAccAciMatchRouteDestinationRule_Basic
=== CONT  TestAccAciMatchRouteDestinationRule_MultipleCreateDelete
=== STEP  testing match_route_destination_rule destroy
--- PASS: TestAccAciMatchRouteDestinationRule_MultipleCreateDelete (28.20s)
=== STEP  testing match_route_destination_rule destroy
--- PASS: TestAccAciMatchRouteDestinationRuleDataSource_Basic (48.33s)
=== STEP  testing match_route_destination_rule destroy
--- PASS: TestAccAciMatchRouteDestinationRule_Update (88.39s)
=== STEP  testing match_route_destination_rule destroy
--- PASS: TestAccAciMatchRouteDestinationRule_Basic (100.19s)
=== STEP  testing match_route_destination_rule destroy
--- PASS: TestAccAciMatchRouteDestinationRule_Negative (105.24s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   106.595s
=== RUN   TestAccAciProviderGroupMemberDataSource_Basic
=== STEP  Basic: testing login_domain_provider Data Source without  parent_dn
=== STEP  Basic: testing login_domain_provider Data Source without  name
=== STEP  testing login_domain_provider Data Source with required arguments only
=== STEP  testing login_domain_provider Data Source with random attribute
=== STEP  testing login_domain_provider Data Source with invalid name
=== STEP  testing login_domain_provider Data Source with updated resource
=== PAUSE TestAccAciProviderGroupMemberDataSource_Basic
=== RUN   TestAccAciProviderGroupMember_Basic
=== STEP  Basic: testing login_domain_provider creation without  parent_dn
=== STEP  Basic: testing login_domain_provider creation without  name
=== STEP  testing login_domain_provider creation with required arguments only
=== STEP  Basic: testing login_domain_provider creation with optional parameters
=== STEP  testing login_domain_provider creation with invalid name =  j1lneb3oqtepx8i70md8ljla79xm932xpmqzudeee4ikw3b74vldjauzr89wx4tir
=== STEP  Basic: testing login_domain_provider updation without required parameters
=== STEP  testing login_domain_provider creation with parent resource name acctest_peffg and name acctest_1dz83
=== STEP  testing login_domain_provider creation with required arguments only
=== STEP  testing login_domain_provider creation with parent resource name acctest_1dz83 and name acctest_peffg
=== PAUSE TestAccAciProviderGroupMember_Basic
=== RUN   TestAccAciProviderGroupMember_Update
=== STEP  testing login_domain_provider creation with required arguments only
=== STEP  testing login_domain_provider attribute: order = 16
=== STEP  testing login_domain_provider attribute: order = 8
=== STEP  testing login_domain_provider creation with required arguments only
=== PAUSE TestAccAciProviderGroupMember_Update
=== RUN   TestAccAciProviderGroupMember_Negative
=== STEP  testing login_domain_provider creation with required arguments only
=== STEP  Negative Case: testing login_domain_provider creation with invalid parent Dn
=== STEP  testing login_domain_provider attribute: description = 48li4ou1whxfqxnmxnvzoiukhuunh32huz86q0vmdovqe1je6w6oas8iwqfcigqknnspv4m4slvjvjdabk3zk8qqvoxnwr6fblykvyjf90eeb0o1ymx1r6e8iokec910g
=== STEP  testing login_domain_provider attribute: annotation = xvfyoy1sjk4fd1almoikgz9vbwbwl1d8ocs1b8v9uh0sm2bgvup4zwlyyicbesd60iaty3r1kigbaguwqhxaiv8cvx7v2pcrchnt0yx4cxothf41d6cxksgmyq8s2hjrt
=== STEP  testing login_domain_provider attribute: name_alias = wn6pmfc981rvnitogyxb98fmoewjbapse7tzj6mv63shh82wnepec7lf9f6cueju
=== STEP  testing login_domain_provider attribute: order = 91kg4
=== STEP  testing login_domain_provider attribute: order = -1
=== STEP  testing login_domain_provider attribute: order = 17
=== STEP  testing login_domain_provider attribute: omhcq = 91kg4
=== STEP  testing login_domain_provider creation with required arguments only
=== PAUSE TestAccAciProviderGroupMember_Negative
=== RUN   TestAccAciProviderGroupMember_MultipleCreateDelete
=== STEP  testing multiple login_domain_provider creation with required arguments only
=== PAUSE TestAccAciProviderGroupMember_MultipleCreateDelete
=== CONT  TestAccAciProviderGroupMemberDataSource_Basic
=== CONT  TestAccAciProviderGroupMember_Negative
=== CONT  TestAccAciProviderGroupMember_Update
=== CONT  TestAccAciProviderGroupMember_Basic
=== CONT  TestAccAciProviderGroupMember_MultipleCreateDelete
=== STEP  testing login_domain_provider destroy
--- PASS: TestAccAciProviderGroupMember_MultipleCreateDelete (21.35s)
=== STEP  testing login_domain_provider destroy
--- PASS: TestAccAciProviderGroupMemberDataSource_Basic (47.64s)
=== STEP  testing login_domain_provider destroy
--- PASS: TestAccAciProviderGroupMember_Update (86.92s)
=== STEP  testing login_domain_provider destroy
--- PASS: TestAccAciProviderGroupMember_Negative (103.12s)
=== STEP  testing login_domain_provider destroy
--- PASS: TestAccAciProviderGroupMember_Basic (123.40s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   124.867s
=== RUN   TestAccAciTACACSMonitoringDestinationGroupDataSource_Basic
=== STEP  Basic: testing tacacs_accounting Data Source without  name
=== STEP  testing tacacs_accounting Data Source with required arguments only
=== STEP  testing tacacs_accounting Data Source with random attribute
=== STEP  testing tacacs_accounting Data Source with invalid name
=== STEP  testing tacacs_accounting Data Source with updated resource
=== PAUSE TestAccAciTACACSMonitoringDestinationGroupDataSource_Basic
=== RUN   TestAccAciTACACSMonitoringDestinationGroup_Basic
=== STEP  Basic: testing tacacs_accounting creation without  name
=== STEP  testing tacacs_accounting creation with required arguments only
=== STEP  Basic: testing tacacs_accounting creation with optional parameters
=== STEP  testing tacacs_accounting creation with invalid name =  wq7myxaugfcajzixt8k9v62hclkfly0y9g6suuzn2bz0rvciej73w1198dyinbhwl
=== STEP  Basic: testing tacacs_accounting updation without required parameters
=== STEP  testing tacacs_accounting creation with updated naming arguments
=== PAUSE TestAccAciTACACSMonitoringDestinationGroup_Basic
=== RUN   TestAccAciTACACSMonitoringDestinationGroup_Negative
=== STEP  testing tacacs_accounting creation with required arguments only
=== STEP  testing tacacs_accounting attribute: description = 7n0r2baizs8gm7o6ni2foch1jun4o7k1lj4xqq9jeukdwvlievaosmwghs9d8270m4x4l6oibntdmpc0gr8acrivk7kesvd3q6bzv86sx7f3w29nyz8ouxfwrtn2xk9ri
=== STEP  testing tacacs_accounting attribute: annotation = 0vaj2pa9brhahddn2dxf7raz4ckei7osq04c1tjoqibcvgauxk64g6s4pb81bblqx49o4i83suqhdo3ulbdtjm9fcwz4fv2v2xa9wt37gkad2rhmt8yorfwadgclxprjk
=== STEP  testing tacacs_accounting attribute: name_alias = nrluj3vhxiy2ot26g8lbqkxtyr0krual9kuwqyn4thgs0tjof7jnalms29fdxb1h
=== STEP  testing tacacs_accounting attribute: ssbwn = 87fno
=== STEP  testing tacacs_accounting creation with required arguments only
=== PAUSE TestAccAciTACACSMonitoringDestinationGroup_Negative
=== RUN   TestAccAciTACACSMonitoringDestinationGroup_MultipleCreateDelete
=== STEP  testing multiple tacacs_accounting creation with required arguments only
=== PAUSE TestAccAciTACACSMonitoringDestinationGroup_MultipleCreateDelete
=== CONT  TestAccAciTACACSMonitoringDestinationGroupDataSource_Basic
=== CONT  TestAccAciTACACSMonitoringDestinationGroup_Basic
=== CONT  TestAccAciTACACSMonitoringDestinationGroup_MultipleCreateDelete
=== CONT  TestAccAciTACACSMonitoringDestinationGroup_Negative
=== STEP  testing tacacs_accounting destroy
--- PASS: TestAccAciTACACSMonitoringDestinationGroup_MultipleCreateDelete (19.42s)
=== STEP  testing tacacs_accounting destroy
--- PASS: TestAccAciTACACSMonitoringDestinationGroupDataSource_Basic (31.13s)
=== STEP  testing tacacs_accounting destroy
--- PASS: TestAccAciTACACSMonitoringDestinationGroup_Negative (40.64s)
=== STEP  testing tacacs_accounting destroy
--- PASS: TestAccAciTACACSMonitoringDestinationGroup_Basic (52.16s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   53.634s
=== RUN   TestAccAciTACACSDestinationDataSource_Basic
=== STEP  Basic: testing tacacs_accounting_destination Data Source without  tacacs_accounting_dn
=== STEP  Basic: testing tacacs_accounting_destination Data Source without  host
=== STEP  testing tacacs_accounting_destination Data Source with required arguments only
=== STEP  testing tacacs_accounting_destination Data Source with random attribute
=== STEP  testing tacacs_accounting_destination Data Source with Invalid Parent Dn
=== STEP  testing tacacs_accounting_destination Data Source with updated resource
=== PAUSE TestAccAciTACACSDestinationDataSource_Basic
=== RUN   TestAccAciTACACSDestination_Basic
=== STEP  Basic: testing tacacs_accounting_destination creation without  tacacs_accounting_dn
=== STEP  Basic: testing tacacs_accounting_destination creation without  host
=== STEP  testing tacacs_accounting_destination creation with required arguments only
=== STEP  Basic: testing tacacs_accounting_destination creation with optional parameters
=== STEP  Basic: testing tacacs_accounting_destination updation without required parameters
=== STEP  testing tacacs_accounting_destination creation with parent resource name exyzz, host 0d4ij.com and port 0
=== STEP  testing tacacs_accounting_destination creation with parent resource name exyzz, host 0d4ij.com and port 65536
=== STEP  testing tacacs_accounting_destination creation with parent resource name exyzz, host 0d4ij.com and port 49
=== STEP  testing tacacs_accounting_destination creation with required arguments only
=== STEP  testing tacacs_accounting_destination creation with parent resource name acctest_7jyr2, host 3br9e.com and port 49
=== STEP  testing tacacs_accounting_destination creation with required arguments only
=== STEP  testing tacacs_accounting_destination creation with parent resource name acctest_7jyr2, host 0d4ij.com and port 50
=== PAUSE TestAccAciTACACSDestination_Basic
=== RUN   TestAccAciTACACSDestination_Update
=== STEP  testing tacacs_accounting_destination creation with required arguments only
=== STEP  testing tacacs_accounting_destination attribute: auth_protocol = mschap
=== STEP  testing tacacs_accounting_destination creation with parent resource name acctest_dqiek, host zh7kt.com and port 1
=== STEP  testing tacacs_accounting_destination creation with parent resource name acctest_dqiek, host zh7kt.com and port 32000
=== PAUSE TestAccAciTACACSDestination_Update
=== RUN   TestAccAciTACACSDestination_Negative
=== STEP  testing tacacs_accounting_destination creation with required arguments only
=== STEP  Negative Case: testing tacacs_accounting_destination creation with invalid parent Dn
=== STEP  testing tacacs_accounting_destination attribute: description = h3zgohlhtwadpeatgg1ko3uuelw1930kvpty7qvjm22v9kemlak3xbo28ch74iylv2mhafdb0rksivnaauv6cqo9bged9j71p0uy9hbqknuokagwrj4q3zi9g09g06wkg
=== STEP  testing tacacs_accounting_destination attribute: annotation = 4f1lcevjpgekj89fd4ofullhuas9ncbx2qcktj1utwxmxxrg2sqh8g2fnel2pi27tqvzng0zept942mnjrq1soihlni3ymrv3nm74w6w1yc7lknpbbxxh8aipvx2h4djh
=== STEP  testing tacacs_accounting_destination attribute: name_alias = w3yr4mixg8ms706pwms4nkjkymkt66bt1dl9hhqsdcummrjt2fp44q8by9gl0lvx
=== STEP  testing tacacs_accounting_destination attribute: auth_protocol = gn7lb
=== STEP  testing tacacs_accounting_destination attribute: kshxi = gn7lb
=== STEP  testing tacacs_accounting_destination creation with required arguments only
=== PAUSE TestAccAciTACACSDestination_Negative
=== RUN   TestAccAciTACACSDestination_MultipleCreateDelete
=== STEP  testing multiple tacacs_accounting_destination creation with required arguments only
=== PAUSE TestAccAciTACACSDestination_MultipleCreateDelete
=== CONT  TestAccAciTACACSDestinationDataSource_Basic
=== CONT  TestAccAciTACACSDestination_Negative
=== CONT  TestAccAciTACACSDestination_Update
=== CONT  TestAccAciTACACSDestination_MultipleCreateDelete
=== CONT  TestAccAciTACACSDestination_Basic
=== STEP  testing tacacs_accounting_destination destroy
--- PASS: TestAccAciTACACSDestination_MultipleCreateDelete (43.03s)
=== STEP  testing tacacs_accounting_destination destroy
--- PASS: TestAccAciTACACSDestinationDataSource_Basic (86.19s)
=== STEP  testing tacacs_accounting_destination destroy
--- PASS: TestAccAciTACACSDestination_Update (100.71s)
=== STEP  testing tacacs_accounting_destination destroy
--- PASS: TestAccAciTACACSDestination_Negative (105.03s)
=== STEP  testing tacacs_accounting_destination destroy
--- PASS: TestAccAciTACACSDestination_Basic (150.94s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   153.802s
