### PR TITLE
updated dhcp_option_pol

### DIFF
--- a/testacc/resource_aci_dhcpoptionpol_test.go
+++ b/testacc/resource_aci_dhcpoptionpol_test.go
@@ -98,8 +98,13 @@ func TestAccAciDHCPOptionPolicy_Basic(t *testing.T) {
 					testAccCheckAciDHCPOptionPolicyIdEqual(&dhcp_option_policy_default, &dhcp_option_policy_updated),
 				),
 			},
+
 			{
 				Config:      CreateAccDHCPOptionPolicyConfigUpdatedName(fvTenantName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			{
+				Config:      CreateAccDHCPOptionPolicyConfigWithInvalidOptionName(fvTenantName, rName, acctest.RandString(65)),
 				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
 			},
 
@@ -323,6 +328,27 @@ func CreateAccDHCPOptionPolicyConfigWithRequiredParams(fvTenantName, rName strin
 	`, fvTenantName, rName)
 	return resource
 }
+
+func CreateAccDHCPOptionPolicyConfigWithInvalidOptionName(fvTenantName, rName, longName string) string {
+	fmt.Println("=== STEP  testing dhcp_option creation with invalid name = ", longName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_dhcp_option_policy" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		dhcp_option {
+			name = "%s"
+		}
+	}
+	`, fvTenantName, rName, longName)
+	return resource
+}
+
 func CreateAccDHCPOptionPolicyConfigUpdatedName(fvTenantName, rName string) string {
 	fmt.Println("=== STEP  testing dhcp_option_policy creation with invalid name = ", rName)
 	resource := fmt.Sprintf(`

--- a/testacc/resource_aci_pkiexportencryptionkey_test.go
+++ b/testacc/resource_aci_pkiexportencryptionkey_test.go
@@ -173,11 +173,11 @@ func testAccCheckAciAESEncryptionPassphraseandKeysforConfigExportImportExists(na
 		rs, ok := s.RootModule().Resources[name]
 
 		if !ok {
-			return fmt.Errorf("AES Encryption Passphraseand KeysforConfig Export Import %s not found", name)
+			return fmt.Errorf("AES Encryption Passphrase and Keys for Config Export Import %s not found", name)
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("No AES Encryption Passphraseand KeysforConfig Export Import dn was set")
+			return fmt.Errorf("No AES Encryption Passphrase and Keys for Config Export Import dn was set")
 		}
 
 		client := testAccProvider.Meta().(*client.Client)
@@ -189,7 +189,7 @@ func testAccCheckAciAESEncryptionPassphraseandKeysforConfigExportImportExists(na
 
 		encryption_keyFound := models.AESEncryptionPassphraseandKeysforConfigExportImportFromContainer(cont)
 		if encryption_keyFound.DistinguishedName != rs.Primary.ID {
-			return fmt.Errorf("AES Encryption Passphraseand KeysforConfig Export Import %s not found", rs.Primary.ID)
+			return fmt.Errorf("AES Encryption Passphrase and KeysforConfig Export Import %s not found", rs.Primary.ID)
 		}
 		*encryption_key = *encryption_keyFound
 		return nil


### PR DESCRIPTION
$ go test -v -run TestAccAciDHCPOptionPolicy_Basic -timeout=60m
=== RUN   TestAccAciDHCPOptionPolicy_Basic
=== STEP  Basic: testing dhcp_option_policy creation without  tenant_dn
=== STEP  Basic: testing dhcp_option_policy creation without  name
=== STEP  testing dhcp_option_policy creation with required arguments only
=== STEP  Basic: testing dhcp_option_policy creation with optional parameters of dhcp_option_policy
=== STEP  Basic: testing dhcp_option_policy creation with optional parameters
=== STEP  Basic: testing dhcp_option_policy creation with optional parameters of dhcp_option_policy and dhcp_option
=== STEP  testing dhcp_option_policy creation with invalid name =  cuylq8v3s2b0vy4r8znjibz18il7qt19rn1qxzpjjs69jgfwgu6wi6yhnbs8hr1ph
=== STEP  testing dhcp_option creation with invalid name =  y7ca88opx7k0q2p4ac7ton8aeed0lcyaq0n3ip7bkp96idxke08cv92r3z1jyhkd7
=== STEP  Basic: testing dhcp_option_policy updation without required parameters
=== STEP  testing dhcp_option creation without name
=== STEP  testing dhcp_option_policy creation with parent resource name acctest_wuqj6 and resource name acctest_zrmvg
=== STEP  testing dhcp_option_policy creation with required arguments only
=== STEP  testing dhcp_option_policy creation with parent resource name acctest_zrmvg and resource name acctest_wuqj6
=== PAUSE TestAccAciDHCPOptionPolicy_Basic
=== CONT  TestAccAciDHCPOptionPolicy_Basic
=== STEP  testing dhcp_option_policy destroy
--- PASS: TestAccAciDHCPOptionPolicy_Basic (117.21s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   118.958s
