### PR TITLE
Aci saml provider

### DIFF
--- a/aci/data_source_aci_aaauserep.go
+++ b/aci/data_source_aci_aaauserep.go
@@ -99,7 +99,7 @@ func dataSourceAciUserManagementRead(d *schema.ResourceData, m interface{}) erro
 
 	rn := fmt.Sprintf("userext")
 	dn := fmt.Sprintf("uni/%s", rn)
-	aaaUserEp, err := getRemoteUserManagement(aciClient, dn)
+	aaaUserEp, err := GetRemoteUserManagement(aciClient, dn)
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func dataSourceAciUserManagementRead(d *schema.ResourceData, m interface{}) erro
 	_, err = aciClient.Get(dn + "/pwdprofile")
 	if err == nil {
 		aaaPwdProfileDn := dn + "/pwdprofile"
-		aaaPwdProfile, err := getRemotePasswordChangeExpirationPolicy(aciClient, aaaPwdProfileDn)
+		aaaPwdProfile, err := GetRemotePasswordChangeExpirationPolicy(aciClient, aaaPwdProfileDn)
 		if err != nil {
 			return err
 		}
@@ -120,7 +120,7 @@ func dataSourceAciUserManagementRead(d *schema.ResourceData, m interface{}) erro
 	_, err = aciClient.Get(dn + "/blockloginp")
 	if err == nil {
 		aaaBlockLoginProfileDn := dn + "/blockloginp"
-		aaaBlockLoginProfile, err := getRemoteBlockUserLoginsPolicy(aciClient, aaaBlockLoginProfileDn)
+		aaaBlockLoginProfile, err := GetRemoteBlockUserLoginsPolicy(aciClient, aaaBlockLoginProfileDn)
 		if err != nil {
 			return err
 		}
@@ -133,7 +133,7 @@ func dataSourceAciUserManagementRead(d *schema.ResourceData, m interface{}) erro
 	_, err = aciClient.Get(dn + "/pkiext/webtokendata")
 	if err == nil {
 		pkiWebTokenDn := dn + "/pkiext/webtokendata"
-		pkiWebTokenData, err := getRemoteWebTokenData(aciClient, pkiWebTokenDn)
+		pkiWebTokenData, err := GetRemoteWebTokenData(aciClient, pkiWebTokenDn)
 		if err != nil {
 			return err
 		}

--- a/aci/resource_aci_aaaldapgroupmap.go
+++ b/aci/resource_aci_aaaldapgroupmap.go
@@ -65,6 +65,7 @@ func setLDAPGroupMapAttributes(aaaLdapGroupMap *models.LDAPGroupMap, d *schema.R
 	}
 	d.Set("name", aaaLdapGroupMapMap["name"])
 	d.Set("name_alias", aaaLdapGroupMapMap["nameAlias"])
+	d.Set("annotation", aaaLdapGroupMapMap["annotation"])
 	return d, nil
 }
 

--- a/aci/resource_aci_aaauserep.go
+++ b/aci/resource_aci_aaauserep.go
@@ -134,7 +134,7 @@ func resourceAciUserManagement() *schema.Resource {
 	}
 }
 
-func getRemoteUserManagement(client *client.Client, dn string) (*models.UserManagement, error) {
+func GetRemoteUserManagement(client *client.Client, dn string) (*models.UserManagement, error) {
 	aaaUserEpCont, err := client.Get(dn)
 	if err != nil {
 		return nil, err
@@ -159,7 +159,7 @@ func setUserManagementAttributes(aaaUserEp *models.UserManagement, d *schema.Res
 	return d, nil
 }
 
-func getRemotePasswordChangeExpirationPolicy(client *client.Client, dn string) (*models.PasswordChangeExpirationPolicy, error) {
+func GetRemotePasswordChangeExpirationPolicy(client *client.Client, dn string) (*models.PasswordChangeExpirationPolicy, error) {
 	aaaPwdProfileCont, err := client.Get(dn)
 	if err != nil {
 		return nil, err
@@ -185,7 +185,7 @@ func setPasswordChangeExpirationPolicyAttributes(aaaPwdProfile *models.PasswordC
 	return d, nil
 }
 
-func getRemoteBlockUserLoginsPolicy(client *client.Client, dn string) (*models.BlockUserLoginsPolicy, error) {
+func GetRemoteBlockUserLoginsPolicy(client *client.Client, dn string) (*models.BlockUserLoginsPolicy, error) {
 	aaaBlockLoginProfileCont, err := client.Get(dn)
 	if err != nil {
 		return nil, err
@@ -210,7 +210,7 @@ func setBlockUserLoginsPolicyAttributes(aaaBlockLoginProfile *models.BlockUserLo
 	return d, nil
 }
 
-func getRemoteWebTokenData(client *client.Client, dn string) (*models.WebTokenData, error) {
+func GetRemoteWebTokenData(client *client.Client, dn string) (*models.WebTokenData, error) {
 	pkiWebTokenDataCont, err := client.Get(dn)
 	if err != nil {
 		return nil, err
@@ -257,7 +257,7 @@ func resourceAciUserManagementImport(d *schema.ResourceData, m interface{}) ([]*
 	log.Printf("[DEBUG] %s: Beginning Import", d.Id())
 	aciClient := m.(*client.Client)
 	dn := d.Id()
-	aaaUserEp, err := getRemoteUserManagement(aciClient, dn)
+	aaaUserEp, err := GetRemoteUserManagement(aciClient, dn)
 	if err != nil {
 		return nil, err
 	}
@@ -387,6 +387,10 @@ func resourceAciUserManagementCreate(ctx context.Context, d *schema.ResourceData
 		sessionRecordFlagsList := make([]string, 0, 1)
 		for _, val := range SessionRecordFlags.([]interface{}) {
 			sessionRecordFlagsList = append(sessionRecordFlagsList, val.(string))
+		}
+		err := checkDuplicate(sessionRecordFlagsList)
+		if err != nil {
+			return diag.FromErr(err)
 		}
 		SessionRecordFlags := strings.Join(sessionRecordFlagsList, ",")
 		pkiWebTokenDataAttr.SessionRecordFlags = SessionRecordFlags
@@ -559,6 +563,10 @@ func resourceAciUserManagementUpdate(ctx context.Context, d *schema.ResourceData
 		for _, val := range SessionRecordFlags.([]interface{}) {
 			sessionRecordFlagsList = append(sessionRecordFlagsList, val.(string))
 		}
+		err := checkDuplicate(sessionRecordFlagsList)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 		SessionRecordFlags := strings.Join(sessionRecordFlagsList, ",")
 		pkiWebTokenDataAttr.SessionRecordFlags = SessionRecordFlags
 	}
@@ -618,7 +626,7 @@ func resourceAciUserManagementRead(ctx context.Context, d *schema.ResourceData, 
 	log.Printf("[DEBUG] %s: Beginning Read", d.Id())
 	aciClient := m.(*client.Client)
 	dn := d.Id()
-	aaaUserEp, err := getRemoteUserManagement(aciClient, dn)
+	aaaUserEp, err := GetRemoteUserManagement(aciClient, dn)
 	if err != nil {
 		d.SetId("")
 		return diag.FromErr(err)
@@ -632,7 +640,7 @@ func resourceAciUserManagementRead(ctx context.Context, d *schema.ResourceData, 
 	_, err = aciClient.Get(dn + "/pwdprofile")
 	if err == nil {
 		aaaPwdProfileDn := dn + "/pwdprofile"
-		aaaPwdProfile, err := getRemotePasswordChangeExpirationPolicy(aciClient, aaaPwdProfileDn)
+		aaaPwdProfile, err := GetRemotePasswordChangeExpirationPolicy(aciClient, aaaPwdProfileDn)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -645,7 +653,7 @@ func resourceAciUserManagementRead(ctx context.Context, d *schema.ResourceData, 
 	_, err = aciClient.Get(dn + "/blockloginp")
 	if err == nil {
 		aaaBlockLoginProfileDn := dn + "/blockloginp"
-		aaaBlockLoginProfile, err := getRemoteBlockUserLoginsPolicy(aciClient, aaaBlockLoginProfileDn)
+		aaaBlockLoginProfile, err := GetRemoteBlockUserLoginsPolicy(aciClient, aaaBlockLoginProfileDn)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -658,7 +666,7 @@ func resourceAciUserManagementRead(ctx context.Context, d *schema.ResourceData, 
 	_, err = aciClient.Get(dn + "/pkiext/webtokendata")
 	if err == nil {
 		pkiWebTokenDn := dn + "/pkiext/webtokendata"
-		pkiWebTokenData, err := getRemoteWebTokenData(aciClient, pkiWebTokenDn)
+		pkiWebTokenData, err := GetRemoteWebTokenData(aciClient, pkiWebTokenDn)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/testacc/data_source_aci_aaaldapgroupmap_test.go
+++ b/testacc/data_source_aci_aaaldapgroupmap_test.go
@@ -1,0 +1,176 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciLDAPGroupMapDataSource_Basic(t *testing.T) {
+	resourceName := "aci_ldap_group_map.test"
+	dataSourceName := "data.aci_ldap_group_map.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLDAPGroupMapDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateLDAPGroupMapDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateLDAPGroupMapDSWithoutRequired(rName, "type"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLDAPGroupMapConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "type", resourceName, "type"),
+				),
+			},
+			{
+				Config:      CreateAccLDAPGroupMapDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccLDAPGroupMapDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccLDAPGroupMapDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccLDAPGroupMapConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing ldap_group_map Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+	
+		name  = "%s"
+		type = "duo"
+	}
+
+	data "aci_ldap_group_map" "test" {
+	
+		name  = aci_ldap_group_map.test.name
+		type = aci_ldap_group_map.test.type
+		depends_on = [ aci_ldap_group_map.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateLDAPGroupMapDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing ldap_group_map Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_ldap_group_map" "test" {
+	
+		name  = "%s"
+		type = "duo"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_ldap_group_map" "test" {
+	
+	#	name  = aci_ldap_group_map.test.name
+		type = aci_ldap_group_map.test.type
+		depends_on = [ aci_ldap_group_map.test ]
+	}
+		`
+	case "type":
+		rBlock += `
+	data "aci_ldap_group_map" "test" {
+	
+		name  = aci_ldap_group_map.test.name
+	#	type = aci_ldap_group_map.test.type
+		depends_on = [ aci_ldap_group_map.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccLDAPGroupMapDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing ldap_group_map Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+	
+		name  = "%s"
+		type = "duo"
+	}
+
+	data "aci_ldap_group_map" "test" {
+	
+		name  = "${aci_ldap_group_map.test.name}_invalid"
+		type = aci_ldap_group_map.test.type
+		depends_on = [ aci_ldap_group_map.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLDAPGroupMapDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing ldap_group_map Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+	
+		name  = "%s"
+		type = "duo"
+	}
+
+	data "aci_ldap_group_map" "test" {
+	
+		name  = aci_ldap_group_map.test.name
+		type = aci_ldap_group_map.test.type
+		%s = "%s"
+		depends_on = [ aci_ldap_group_map.test ]
+	}
+	`, rName, key, value)
+	return resource
+}
+
+func CreateAccLDAPGroupMapDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing ldap_group_map Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+	
+		name  = "%s"
+		type = "duo"
+		%s = "%s"
+	}
+
+	data "aci_ldap_group_map" "test" {
+	
+		name  = aci_ldap_group_map.test.name
+		type = aci_ldap_group_map.test.type
+		depends_on = [ aci_ldap_group_map.test ]
+	}
+	`, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_aaasamlprovider_test.go
+++ b/testacc/data_source_aci_aaasamlprovider_test.go
@@ -1,0 +1,167 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciSAMLProviderDataSource_Basic(t *testing.T) {
+	resourceName := "aci_saml_provider.test"
+	dataSourceName := "data.aci_saml_provider.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSAMLProviderDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateSAMLProviderDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccSAMLProviderConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "entity_id", resourceName, "entity_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "gui_banner_message", resourceName, "gui_banner_message"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "https_proxy", resourceName, "https_proxy"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "id_p", resourceName, "id_p"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "metadata_url", resourceName, "metadata_url"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "monitor_server", resourceName, "monitor_server"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "monitoring_user", resourceName, "monitoring_user"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "retries", resourceName, "retries"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "sig_alg", resourceName, "sig_alg"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "timeout", resourceName, "timeout"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tp", resourceName, "tp"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "want_assertions_encrypted", resourceName, "want_assertions_encrypted"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "want_assertions_signed", resourceName, "want_assertions_signed"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "want_requests_signed", resourceName, "want_requests_signed"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "want_response_signed", resourceName, "want_response_signed"),
+				),
+			},
+			{
+				Config:      CreateAccSAMLProviderDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccSAMLProviderDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccSAMLProviderConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing saml_provider Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_saml_provider" "test" {
+	
+		name  = aci_saml_provider.test.name
+		depends_on = [ aci_saml_provider.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateSAMLProviderDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing saml_provider Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_saml_provider" "test" {
+	
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_saml_provider" "test" {
+	
+	#	name  = aci_saml_provider.test.name
+		depends_on = [ aci_saml_provider.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccSAMLProviderDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing saml_provider Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_saml_provider" "test" {
+	
+		name  = "${aci_saml_provider.test.name}_invalid"
+		depends_on = [ aci_saml_provider.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccSAMLProviderDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing saml_provider Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_saml_provider" "test" {
+	
+		name  = aci_saml_provider.test.name
+		%s = "%s"
+		depends_on = [ aci_saml_provider.test ]
+	}
+	`, rName, key, value)
+	return resource
+}
+
+func CreateAccSAMLProviderDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing saml_provider Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_saml_provider" "test" {
+	
+		name  = aci_saml_provider.test.name
+		depends_on = [ aci_saml_provider.test ]
+	}
+	`, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_aaasamlprovidergroup_test.go
+++ b/testacc/data_source_aci_aaasamlprovidergroup_test.go
@@ -1,0 +1,151 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciSAMLProviderGroupDataSource_Basic(t *testing.T) {
+	resourceName := "aci_saml_provider_group.test"
+	dataSourceName := "data.aci_saml_provider_group.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSAMLProviderGroupDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateSAMLProviderGroupDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccSAMLProviderGroupConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+				),
+			},
+			{
+				Config:      CreateAccSAMLProviderGroupDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderGroupDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccSAMLProviderGroupDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccSAMLProviderGroupConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing saml_provider_group Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider_group" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_saml_provider_group" "test" {
+	
+		name  = aci_saml_provider_group.test.name
+		depends_on = [ aci_saml_provider_group.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateSAMLProviderGroupDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing saml_provider_group Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_saml_provider_group" "test" {
+	
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_saml_provider_group" "test" {
+	
+	#	name  = aci_saml_provider_group.test.name
+		depends_on = [ aci_saml_provider_group.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccSAMLProviderGroupDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing saml_provider_group Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider_group" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_saml_provider_group" "test" {
+	
+		name  = "${aci_saml_provider_group.test.name}_invalid"
+		depends_on = [ aci_saml_provider_group.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccSAMLProviderGroupDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing saml_provider_group Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider_group" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_saml_provider_group" "test" {
+	
+		name  = aci_saml_provider_group.test.name
+		%s = "%s"
+		depends_on = [ aci_saml_provider_group.test ]
+	}
+	`, rName, key, value)
+	return resource
+}
+
+func CreateAccSAMLProviderGroupDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing saml_provider_group Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider_group" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_saml_provider_group" "test" {
+	
+		name  = aci_saml_provider_group.test.name
+		depends_on = [ aci_saml_provider_group.test ]
+	}
+	`, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_aaauserep_test.go
+++ b/testacc/data_source_aci_aaauserep_test.go
@@ -1,0 +1,127 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aci/aci"
+)
+
+func TestAccAciWebTokenDataDataSource_Basic(t *testing.T) {
+	resourceName := "aci_global_security.test"
+	dataSourceName := "data.aci_global_security.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	aaaUserEp, err := aci.GetRemoteUserManagement(sharedAciClient(), "uni/userext")
+	if err != nil {
+		t.Errorf("reading initial config of aaaUserEp")
+	}
+	aaaPwdProfile, err := aci.GetRemotePasswordChangeExpirationPolicy(sharedAciClient(), "uni/userext/pwdprofile")
+	if err != nil {
+		t.Errorf("reading initial config of aaaPwdProfile")
+	}
+	aaaBlockLoginProfile, err := aci.GetRemoteBlockUserLoginsPolicy(sharedAciClient(), "uni/userext/blockloginp")
+	if err != nil {
+		t.Errorf("reading initial config of aaaBlockLoginProfile")
+	}
+	pkiWebTokenData, err := aci.GetRemoteWebTokenData(sharedAciClient(), "uni/userext/pkiext/webtokendata")
+	if err != nil {
+		t.Errorf("reading initial config of pkiWebTokenData")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccWebTokenDataConfigDataSource(),
+				Check: resource.ComposeTestCheckFunc(
+
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "pwd_strength_check", resourceName, "pwd_strength_check"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "change_count", resourceName, "change_count"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "change_during_interval", resourceName, "change_during_interval"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "change_interval", resourceName, "change_interval"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "expiration_warn_time", resourceName, "expiration_warn_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "history_count", resourceName, "history_count"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "no_change_interval", resourceName, "no_change_interval"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "block_duration", resourceName, "block_duration"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "enable_login_block", resourceName, "enable_login_block"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "max_failed_attempts", resourceName, "max_failed_attempts"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "max_failed_attempts_window", resourceName, "max_failed_attempts_window"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "maximum_validity_period", resourceName, "maximum_validity_period"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "session_record_flags", resourceName, "session_record_flags"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ui_idle_timeout_seconds", resourceName, "ui_idle_timeout_seconds"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "webtoken_timeout_seconds", resourceName, "webtoken_timeout_seconds"),
+				),
+			},
+			{
+				Config:      CreateAccWebTokenDataDataSourceUpdate(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccWebTokenDataDataSourceUpdatedResource("annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+			{
+				Config: restoreGlobalUser(aaaUserEp, aaaPwdProfile, aaaBlockLoginProfile, pkiWebTokenData),
+			},
+		},
+	})
+}
+
+func CreateAccWebTokenDataConfigDataSource() string {
+	fmt.Println("=== STEP  testing global_security Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_global_security" "test" {
+
+	}
+
+	data "aci_global_security" "test" {
+
+		depends_on = [ aci_global_security.test ]
+	}
+	`)
+	return resource
+}
+
+func CreateAccWebTokenDataDataSourceUpdate(key, value string) string {
+	fmt.Println("=== STEP  testing global_security Data Source with random attribute")
+	resource := fmt.Sprintf(`
+
+	resource "aci_global_security" "test" {
+
+	}
+
+	data "aci_global_security" "test" {
+
+		%s = "%s"
+		depends_on = [ aci_global_security.test ]
+	}
+	`, key, value)
+	return resource
+}
+
+func CreateAccWebTokenDataDataSourceUpdatedResource(key, value string) string {
+	fmt.Println("=== STEP  testing global_security Data Source with updated resource")
+	resource := fmt.Sprintf(`
+
+	resource "aci_global_security" "test" {
+
+		%s = "%s"
+	}
+
+	data "aci_global_security" "test" {
+
+		depends_on = [ aci_global_security.test ]
+	}
+	`, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_tacacstacacsdest_test.go
+++ b/testacc/data_source_aci_tacacstacacsdest_test.go
@@ -39,7 +39,7 @@ func TestAccAciTACACSDestinationDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "auth_protocol", resourceName, "auth_protocol"),
-					resource.TestCheckResourceAttrPair(dataSourceName, "key", resourceName, "key"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 				),
 			},
 			{

--- a/testacc/resource_aci_aaaldapgroupmap_test.go
+++ b/testacc/resource_aci_aaaldapgroupmap_test.go
@@ -1,0 +1,343 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciLDAPGroupMap_Basic(t *testing.T) {
+	var ldap_group_map_default models.LDAPGroupMap
+	var ldap_group_map_updated models.LDAPGroupMap
+	resourceName := "aci_ldap_group_map.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLDAPGroupMapDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateLDAPGroupMapWithoutRequired(rName, "duo", "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateLDAPGroupMapWithoutRequired(rName, "duo", "type"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLDAPGroupMapConfig(rName, "duo"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPGroupMapExists(resourceName, &ldap_group_map_default),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "type", "duo"),
+				),
+			},
+			{
+				Config: CreateAccLDAPGroupMapConfigWithOptionalValues(rName, "duo"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPGroupMapExists(resourceName, &ldap_group_map_updated),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_ldap_group_map"),
+					resource.TestCheckResourceAttr(resourceName, "type", "duo"),
+					testAccCheckAciLDAPGroupMapIdEqual(&ldap_group_map_default, &ldap_group_map_updated),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"type"},
+			},
+			{
+				Config:      CreateAccLDAPGroupMapConfigUpdatedName(acctest.RandString(65), "duo"),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccLDAPGroupMapRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateAccLDAPGroupMapConfigWithRequiredParams(rName, rName),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config: CreateAccLDAPGroupMapConfigWithRequiredParams(rNameUpdated, "duo"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPGroupMapExists(resourceName, &ldap_group_map_updated),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "type", "duo"),
+					testAccCheckAciLDAPGroupMapIdNotEqual(&ldap_group_map_default, &ldap_group_map_updated),
+				),
+			},
+			{
+				Config: CreateAccLDAPGroupMapConfig(rName, "duo"),
+			},
+			{
+				Config: CreateAccLDAPGroupMapConfigWithRequiredParams(rName, "ldap"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPGroupMapExists(resourceName, &ldap_group_map_updated),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "ldap"),
+					testAccCheckAciLDAPGroupMapIdNotEqual(&ldap_group_map_default, &ldap_group_map_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciLDAPGroupMap_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLDAPGroupMapDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLDAPGroupMapConfig(rName, "duo"),
+			},
+
+			{
+				Config:      CreateAccLDAPGroupMapUpdatedAttr(rName, "duo", "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLDAPGroupMapUpdatedAttr(rName, "duo", "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLDAPGroupMapUpdatedAttr(rName, "duo", "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLDAPGroupMapUpdatedAttr(rName, "duo", randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccLDAPGroupMapConfig(rName, "duo"),
+			},
+		},
+	})
+}
+
+func TestAccAciLDAPGroupMap_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLDAPGroupMapDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLDAPGroupMapConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciLDAPGroupMapExists(name string, ldap_group_map *models.LDAPGroupMap) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("LDAP Group Map %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No LDAP Group Map dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		ldap_group_mapFound := models.LDAPGroupMapFromContainer(cont)
+		if ldap_group_mapFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("LDAP Group Map %s not found", rs.Primary.ID)
+		}
+		*ldap_group_map = *ldap_group_mapFound
+		return nil
+	}
+}
+
+func testAccCheckAciLDAPGroupMapDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing ldap_group_map destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_ldap_group_map" {
+			cont, err := client.Get(rs.Primary.ID)
+			ldap_group_map := models.LDAPGroupMapFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("LDAP Group Map %s Still exists", ldap_group_map.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciLDAPGroupMapIdEqual(m1, m2 *models.LDAPGroupMap) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("ldap_group_map DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciLDAPGroupMapIdNotEqual(m1, m2 *models.LDAPGroupMap) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("ldap_group_map DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateLDAPGroupMapWithoutRequired(rName, groupType, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing ldap_group_map creation without ", attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_ldap_group_map" "test" {
+	#	name  = "%s"
+		type = "%s"
+	}
+		`
+	case "type":
+		rBlock += `
+	resource "aci_ldap_group_map" "test" {
+		name  = "%s"
+	#	type = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName, groupType)
+}
+
+func CreateAccLDAPGroupMapConfigWithRequiredParams(rName, groupType string) string {
+	fmt.Printf("=== STEP  testing ldap_group_map creation with type %s and name %s\n", groupType, rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+	
+		name  = "%s"
+		type = "%s"
+	}
+	`, rName, groupType)
+	return resource
+}
+func CreateAccLDAPGroupMapConfigUpdatedName(rName, groupType string) string {
+	fmt.Println("=== STEP  testing ldap_group_map creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+	
+		name  = "%s"
+		type = "%s"
+	}
+	`, rName, groupType)
+	return resource
+}
+
+func CreateAccLDAPGroupMapConfig(rName, groupType string) string {
+	fmt.Println("=== STEP  testing ldap_group_map creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+	
+		name  = "%s"
+		type = "%s"
+	}
+	`, rName, groupType)
+	return resource
+}
+
+func CreateAccLDAPGroupMapConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple ldap_group_map creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+	
+		name  = "%s_${count.index}"
+		type = "duo"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLDAPGroupMapConfigWithOptionalValues(rName, groupType string) string {
+	fmt.Println("=== STEP  Basic: testing ldap_group_map creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+	
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_ldap_group_map"
+		type = "%s"
+	}
+	`, rName, groupType)
+
+	return resource
+}
+
+func CreateAccLDAPGroupMapRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing ldap_group_map updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_ldap_group_map" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_ldap_group_map"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccLDAPGroupMapUpdatedAttr(rName, groupType, attribute, value string) string {
+	fmt.Printf("=== STEP  testing ldap_group_map attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_group_map" "test" {
+	
+		name  = "%s"
+		type = "%s"
+		%s = "%s"
+	}
+	`, rName, groupType, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_aaasamlprovider_test.go
+++ b/testacc/resource_aci_aaasamlprovider_test.go
@@ -1,0 +1,517 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciSAMLProvider_Basic(t *testing.T) {
+	var saml_provider_default models.SAMLProvider
+	var saml_provider_updated models.SAMLProvider
+	resourceName := "aci_saml_provider.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSAMLProviderDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateSAMLProviderWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccSAMLProviderConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSAMLProviderExists(resourceName, &saml_provider_default),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "entity_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "gui_banner_message", ""),
+					resource.TestCheckResourceAttr(resourceName, "https_proxy", ""),
+					resource.TestCheckResourceAttr(resourceName, "id_p", "adfs"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_url", ""),
+					resource.TestCheckResourceAttr(resourceName, "monitor_server", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_user", "default"),
+					resource.TestCheckResourceAttr(resourceName, "retries", "1"),
+					resource.TestCheckResourceAttr(resourceName, "sig_alg", "SIG_RSA_SHA256"),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "5"),
+					resource.TestCheckResourceAttr(resourceName, "tp", ""),
+					resource.TestCheckResourceAttr(resourceName, "want_assertions_encrypted", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "want_assertions_signed", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "want_requests_signed", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "want_response_signed", "yes"),
+				),
+			},
+			{
+				Config: CreateAccSAMLProviderConfigWithOptionalValues(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSAMLProviderExists(resourceName, &saml_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_saml_provider"),
+					resource.TestCheckResourceAttr(resourceName, "entity_id", "entity_id_test"),
+					resource.TestCheckResourceAttr(resourceName, "gui_banner_message", "gui_banner_message_test"),
+					resource.TestCheckResourceAttr(resourceName, "https_proxy", "https_proxy_test"),
+					resource.TestCheckResourceAttr(resourceName, "id_p", "okta"),
+					resource.TestCheckResourceAttr(resourceName, "key", "key_test"),
+					resource.TestCheckResourceAttr(resourceName, "metadata_url", "metadata_url_test"),
+					resource.TestCheckResourceAttr(resourceName, "monitor_server", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_password", "monitoring_password_test"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_user", "monitoring_user_test"),
+					resource.TestCheckResourceAttr(resourceName, "retries", "5"),
+					resource.TestCheckResourceAttr(resourceName, "sig_alg", "SIG_RSA_SHA1"),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "60"),
+					resource.TestCheckResourceAttr(resourceName, "tp", "tp_test"),
+					resource.TestCheckResourceAttr(resourceName, "want_assertions_encrypted", "no"),
+					resource.TestCheckResourceAttr(resourceName, "want_assertions_signed", "no"),
+					resource.TestCheckResourceAttr(resourceName, "want_requests_signed", "no"),
+					resource.TestCheckResourceAttr(resourceName, "want_response_signed", "no"),
+					testAccCheckAciSAMLProviderIdEqual(&saml_provider_default, &saml_provider_updated),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"key", "monitoring_password"},
+			},
+			{
+				Config:      CreateAccSAMLProviderConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccSAMLProviderConfigWithRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSAMLProviderExists(resourceName, &saml_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciSAMLProviderIdNotEqual(&saml_provider_default, &saml_provider_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciSAMLProvider_Update(t *testing.T) {
+	var saml_provider_default models.SAMLProvider
+	var saml_provider_updated models.SAMLProvider
+	resourceName := "aci_saml_provider.test"
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSAMLProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccSAMLProviderConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSAMLProviderExists(resourceName, &saml_provider_default),
+				),
+			},
+			{
+				Config: CreateAccSAMLProviderUpdatedAttr(rName, "retries", "2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSAMLProviderExists(resourceName, &saml_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "retries", "2"),
+					testAccCheckAciSAMLProviderIdEqual(&saml_provider_default, &saml_provider_updated),
+				),
+			},
+
+			{
+				Config: CreateAccSAMLProviderUpdatedAttr(rName, "sig_alg", "SIG_RSA_SHA224"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSAMLProviderExists(resourceName, &saml_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "sig_alg", "SIG_RSA_SHA224"),
+					testAccCheckAciSAMLProviderIdEqual(&saml_provider_default, &saml_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccSAMLProviderUpdatedAttr(rName, "sig_alg", "SIG_RSA_SHA384"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSAMLProviderExists(resourceName, &saml_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "sig_alg", "SIG_RSA_SHA384"),
+					testAccCheckAciSAMLProviderIdEqual(&saml_provider_default, &saml_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccSAMLProviderUpdatedAttr(rName, "sig_alg", "SIG_RSA_SHA512"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSAMLProviderExists(resourceName, &saml_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "sig_alg", "SIG_RSA_SHA512"),
+					testAccCheckAciSAMLProviderIdEqual(&saml_provider_default, &saml_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccSAMLProviderUpdatedAttr(rName, "timeout", "27"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSAMLProviderExists(resourceName, &saml_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "27"),
+					testAccCheckAciSAMLProviderIdEqual(&saml_provider_default, &saml_provider_updated),
+				),
+			},
+
+			{
+				Config: CreateAccSAMLProviderConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciSAMLProvider_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSAMLProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccSAMLProviderConfig(rName),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "entity_id", acctest.RandString(513)),
+				ExpectError: regexp.MustCompile(`failed validation for value`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "https_proxy", acctest.RandString(257)),
+				ExpectError: regexp.MustCompile(`failed validation for value`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "id_p", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "monitor_server", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "monitoring_user", acctest.RandString(33)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "retries", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "retries", "0"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "retries", "6"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "sig_alg", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "timeout", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "timeout", "4"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "timeout", "61"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "tp", acctest.RandString(27)),
+				ExpectError: regexp.MustCompile(`failed validation for value`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "want_assertions_encrypted", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "want_assertions_signed", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "want_requests_signed", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, "want_response_signed", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccSAMLProviderConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciSAMLProvider_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSAMLProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccSAMLProviderConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciSAMLProviderExists(name string, saml_provider *models.SAMLProvider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("SAML Provider %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No SAML Provider dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		saml_providerFound := models.SAMLProviderFromContainer(cont)
+		if saml_providerFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("SAML Provider %s not found", rs.Primary.ID)
+		}
+		*saml_provider = *saml_providerFound
+		return nil
+	}
+}
+
+func testAccCheckAciSAMLProviderDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing saml_provider destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_saml_provider" {
+			cont, err := client.Get(rs.Primary.ID)
+			saml_provider := models.SAMLProviderFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("SAML Provider %s Still exists", saml_provider.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciSAMLProviderIdEqual(m1, m2 *models.SAMLProvider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("saml_provider DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciSAMLProviderIdNotEqual(m1, m2 *models.SAMLProvider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("saml_provider DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateSAMLProviderWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing saml_provider creation without ", attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_saml_provider" "test" {
+	
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccSAMLProviderConfigWithRequiredParams(rName string) string {
+	fmt.Printf("=== STEP  testing saml_provider creation with name %s\n", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+func CreateAccSAMLProviderConfigUpdatedName(rName string) string {
+	fmt.Println("=== STEP  testing saml_provider creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccSAMLProviderConfig(rName string) string {
+	fmt.Println("=== STEP  testing saml_provider creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccSAMLProviderConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple saml_provider creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider" "test" {
+	
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccSAMLProviderConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing saml_provider creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider" "test" {
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_saml_provider"
+		entity_id = "entity_id_test"
+		gui_banner_message = "gui_banner_message_test"
+		https_proxy = "https_proxy_test"
+		id_p = "okta"
+		key = "key_test"
+		metadata_url = "metadata_url_test"
+		monitor_server = "disabled"
+		monitoring_password = "monitoring_password_test"
+		monitoring_user = "monitoring_user_test"
+		retries = "5"
+		sig_alg = "SIG_RSA_SHA1"
+		timeout = "60"
+		tp = "tp_test"
+		want_assertions_encrypted = "no"
+		want_assertions_signed = "no"
+		want_requests_signed = "no"
+		want_response_signed = "no"
+		
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccSAMLProviderRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing saml_provider updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_saml_provider" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_saml_provider"
+		entity_id = ""
+		gui_banner_message = ""
+		https_proxy = ""
+		id_p = "okta"
+		key = ""
+		metadata_url = ""
+		monitor_server = "enabled"
+		monitoring_password = ""
+		monitoring_user = ""
+		retries = "1"
+		sig_alg = "SIG_RSA_SHA1"
+		timeout = "6"
+		tp = ""
+		want_assertions_encrypted = "no"
+		want_assertions_signed = "no"
+		want_requests_signed = "no"
+		want_response_signed = "no"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccSAMLProviderUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing saml_provider attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_aaasamlprovidergroup_test.go
+++ b/testacc/resource_aci_aaasamlprovidergroup_test.go
@@ -1,0 +1,308 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciSAMLProviderGroup_Basic(t *testing.T) {
+	var saml_provider_group_default models.SAMLProviderGroup
+	var saml_provider_group_updated models.SAMLProviderGroup
+	resourceName := "aci_saml_provider_group.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSAMLProviderGroupDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateSAMLProviderGroupWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccSAMLProviderGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSAMLProviderGroupExists(resourceName, &saml_provider_group_default),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+				),
+			},
+			{
+				Config: CreateAccSAMLProviderGroupConfigWithOptionalValues(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSAMLProviderGroupExists(resourceName, &saml_provider_group_updated),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_saml_provider_group"),
+
+					testAccCheckAciSAMLProviderGroupIdEqual(&saml_provider_group_default, &saml_provider_group_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccSAMLProviderGroupConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderGroupRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+
+			{
+				Config: CreateAccSAMLProviderGroupConfigWithRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSAMLProviderGroupExists(resourceName, &saml_provider_group_updated),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciSAMLProviderGroupIdNotEqual(&saml_provider_group_default, &saml_provider_group_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciSAMLProviderGroup_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSAMLProviderGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccSAMLProviderGroupConfig(rName),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderGroupUpdatedAttr(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccSAMLProviderGroupUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccSAMLProviderGroupUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccSAMLProviderGroupUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccSAMLProviderGroupConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciSAMLProviderGroup_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSAMLProviderGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccSAMLProviderGroupConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciSAMLProviderGroupExists(name string, saml_provider_group *models.SAMLProviderGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("SAML Provider Group %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No SAML Provider Group dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		saml_provider_groupFound := models.SAMLProviderGroupFromContainer(cont)
+		if saml_provider_groupFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("SAML Provider Group %s not found", rs.Primary.ID)
+		}
+		*saml_provider_group = *saml_provider_groupFound
+		return nil
+	}
+}
+
+func testAccCheckAciSAMLProviderGroupDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing saml_provider_group destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_saml_provider_group" {
+			cont, err := client.Get(rs.Primary.ID)
+			saml_provider_group := models.SAMLProviderGroupFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("SAML Provider Group %s Still exists", saml_provider_group.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciSAMLProviderGroupIdEqual(m1, m2 *models.SAMLProviderGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("saml_provider_group DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciSAMLProviderGroupIdNotEqual(m1, m2 *models.SAMLProviderGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("saml_provider_group DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateSAMLProviderGroupWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing saml_provider_group creation without ", attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_saml_provider_group" "test" {
+	
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccSAMLProviderGroupConfigWithRequiredParams(rName string) string {
+	fmt.Printf("=== STEP  testing saml_provider_group creation with name %s\n", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider_group" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+func CreateAccSAMLProviderGroupConfigUpdatedName(rName string) string {
+	fmt.Println("=== STEP  testing saml_provider_group creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider_group" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccSAMLProviderGroupConfig(rName string) string {
+	fmt.Println("=== STEP  testing saml_provider_group creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider_group" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccSAMLProviderGroupConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple saml_provider_group creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider_group" "test" {
+	
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccSAMLProviderGroupConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing saml_provider_group creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider_group" "test" {
+	
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_saml_provider_group"
+		
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccSAMLProviderGroupRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing saml_provider_group updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_saml_provider_group" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_saml_provider_group"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccSAMLProviderGroupUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing saml_provider_group attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_saml_provider_group" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_aaauserep_test.go
+++ b/testacc/resource_aci_aaauserep_test.go
@@ -79,7 +79,7 @@ func TestAccAciWebTokenData_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "maximum_validity_period", "4"),
 					resource.TestCheckResourceAttr(resourceName, "session_record_flags.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "session_record_flags.0", "login"),
-					resource.TestCheckResourceAttr(resourceName, "session_record_flags.0", "logout"),
+					resource.TestCheckResourceAttr(resourceName, "session_record_flags.1", "logout"),
 					resource.TestCheckResourceAttr(resourceName, "ui_idle_timeout_seconds", "60"),
 					resource.TestCheckResourceAttr(resourceName, "webtoken_timeout_seconds", "300"),
 					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
@@ -367,7 +367,7 @@ func TestAccAciWebTokenData_Negative(t *testing.T) {
 	if err != nil {
 		t.Errorf("reading initial config of pkiWebTokenData")
 	}
-	resource.ParallelTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: testAccProviders,
 
@@ -535,7 +535,7 @@ func TestAccAciWebTokenData_Negative(t *testing.T) {
 			},
 			{
 				Config:      CreateAccWebTokenDataUpdatedAttrList("session_record_flags", StringListtoString([]string{"login", "login"})),
-				ExpectError: regexp.MustCompile(`out of range`),
+				ExpectError: regexp.MustCompile(`duplication is not supported in list`),
 			},
 			{
 				Config:      CreateAccWebTokenDataUpdatedAttr(randomParameter, randomValue),

--- a/testacc/resource_aci_aaauserep_test.go
+++ b/testacc/resource_aci_aaauserep_test.go
@@ -1,0 +1,672 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/terraform-providers/terraform-provider-aci/aci"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciWebTokenData_Basic(t *testing.T) {
+	var global_security_default models.UserManagement
+	var global_security_updated models.UserManagement
+	resourceName := "aci_global_security.test"
+	aaaUserEp, err := aci.GetRemoteUserManagement(sharedAciClient(), "uni/userext")
+	if err != nil {
+		t.Errorf("reading initial config of aaaUserEp")
+	}
+	aaaPwdProfile, err := aci.GetRemotePasswordChangeExpirationPolicy(sharedAciClient(), "uni/userext/pwdprofile")
+	if err != nil {
+		t.Errorf("reading initial config of aaaPwdProfile")
+	}
+	aaaBlockLoginProfile, err := aci.GetRemoteBlockUserLoginsPolicy(sharedAciClient(), "uni/userext/blockloginp")
+	if err != nil {
+		t.Errorf("reading initial config of aaaBlockLoginProfile")
+	}
+	pkiWebTokenData, err := aci.GetRemoteWebTokenData(sharedAciClient(), "uni/userext/pkiext/webtokendata")
+	if err != nil {
+		t.Errorf("reading initial config of pkiWebTokenData")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccWebTokenDataConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_default),
+					resource.TestCheckResourceAttrSet(resourceName, "pwd_strength_check"),
+					resource.TestCheckResourceAttrSet(resourceName, "change_count"),
+					resource.TestCheckResourceAttrSet(resourceName, "change_during_interval"),
+					resource.TestCheckResourceAttrSet(resourceName, "change_interval"),
+					resource.TestCheckResourceAttrSet(resourceName, "expiration_warn_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "history_count"),
+					resource.TestCheckResourceAttrSet(resourceName, "no_change_interval"),
+					resource.TestCheckResourceAttrSet(resourceName, "block_duration"),
+					resource.TestCheckResourceAttrSet(resourceName, "enable_login_block"),
+					resource.TestCheckResourceAttrSet(resourceName, "max_failed_attempts"),
+					resource.TestCheckResourceAttrSet(resourceName, "max_failed_attempts_window"),
+					resource.TestCheckResourceAttrSet(resourceName, "maximum_validity_period"),
+					resource.TestCheckResourceAttrSet(resourceName, "ui_idle_timeout_seconds"),
+					resource.TestCheckResourceAttrSet(resourceName, "webtoken_timeout_seconds"),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataConfigWithOptionalValues(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_global_security"),
+					resource.TestCheckResourceAttr(resourceName, "pwd_strength_check", "no"),
+					resource.TestCheckResourceAttr(resourceName, "change_count", "0"),
+					resource.TestCheckResourceAttr(resourceName, "change_during_interval", "disable"),
+					resource.TestCheckResourceAttr(resourceName, "change_interval", "0"),
+					resource.TestCheckResourceAttr(resourceName, "expiration_warn_time", "0"),
+					resource.TestCheckResourceAttr(resourceName, "history_count", "0"),
+					resource.TestCheckResourceAttr(resourceName, "no_change_interval", "0"),
+					resource.TestCheckResourceAttr(resourceName, "block_duration", "1"),
+					resource.TestCheckResourceAttr(resourceName, "enable_login_block", "disable"),
+					resource.TestCheckResourceAttr(resourceName, "max_failed_attempts", "1"),
+					resource.TestCheckResourceAttr(resourceName, "max_failed_attempts_window", "1"),
+					resource.TestCheckResourceAttr(resourceName, "maximum_validity_period", "4"),
+					resource.TestCheckResourceAttr(resourceName, "session_record_flags.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "session_record_flags.0", "login"),
+					resource.TestCheckResourceAttr(resourceName, "session_record_flags.0", "logout"),
+					resource.TestCheckResourceAttr(resourceName, "ui_idle_timeout_seconds", "60"),
+					resource.TestCheckResourceAttr(resourceName, "webtoken_timeout_seconds", "300"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: restoreGlobalUser(aaaUserEp, aaaPwdProfile, aaaBlockLoginProfile, pkiWebTokenData),
+			},
+		},
+	})
+}
+
+func TestAccAciWebTokenData_Update(t *testing.T) {
+	var global_security_default models.UserManagement
+	var global_security_updated models.UserManagement
+	resourceName := "aci_global_security.test"
+	aaaUserEp, err := aci.GetRemoteUserManagement(sharedAciClient(), "uni/userext")
+	if err != nil {
+		t.Errorf("reading initial config of aaaUserEp")
+	}
+	aaaPwdProfile, err := aci.GetRemotePasswordChangeExpirationPolicy(sharedAciClient(), "uni/userext/pwdprofile")
+	if err != nil {
+		t.Errorf("reading initial config of aaaPwdProfile")
+	}
+	aaaBlockLoginProfile, err := aci.GetRemoteBlockUserLoginsPolicy(sharedAciClient(), "uni/userext/blockloginp")
+	if err != nil {
+		t.Errorf("reading initial config of aaaBlockLoginProfile")
+	}
+	pkiWebTokenData, err := aci.GetRemoteWebTokenData(sharedAciClient(), "uni/userext/pkiext/webtokendata")
+	if err != nil {
+		t.Errorf("reading initial config of pkiWebTokenData")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccWebTokenDataConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_default),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("pwd_strength_check", "no"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "pwd_strength_check", "no"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("change_count", "10"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "change_count", "10"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("change_count", "5"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "change_count", "5"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("change_during_interval", "enable"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "change_during_interval", "enable"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("change_interval", "745"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "change_interval", "745"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("change_interval", "372"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "change_interval", "372"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("expiration_warn_time", "15"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "expiration_warn_time", "15"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("history_count", "15"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "history_count", "15"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("history_count", "7"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "history_count", "7"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("no_change_interval", "745"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "no_change_interval", "745"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("no_change_interval", "372"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "no_change_interval", "372"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("block_duration", "1440"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "block_duration", "1440"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("block_duration", "720"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "block_duration", "720"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("enable_login_block", "enable"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "enable_login_block", "enable"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("max_failed_attempts", "15"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "max_failed_attempts", "15"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("max_failed_attempts", "7"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "max_failed_attempts", "7"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("max_failed_attempts_window", "720"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "max_failed_attempts_window", "720"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("max_failed_attempts_window", "360"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "max_failed_attempts_window", "360"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("maximum_validity_period", "24"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "maximum_validity_period", "24"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("maximum_validity_period", "14"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "maximum_validity_period", "14"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("ui_idle_timeout_seconds", "32000"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "ui_idle_timeout_seconds", "32000"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("ui_idle_timeout_seconds", "65525"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "ui_idle_timeout_seconds", "65525"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("webtoken_timeout_seconds", "4545"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "webtoken_timeout_seconds", "4545"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("webtoken_timeout_seconds", "9600"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "webtoken_timeout_seconds", "9600"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttrList("session_record_flags", StringListtoString([]string{"refresh", "logout", "login"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "session_record_flags.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "session_record_flags.0", "refresh"),
+					resource.TestCheckResourceAttr(resourceName, "session_record_flags.1", "logout"),
+					resource.TestCheckResourceAttr(resourceName, "session_record_flags.2", "login"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttrList("session_record_flags", StringListtoString([]string{"login", "logout", "refresh"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "session_record_flags.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "session_record_flags.0", "login"),
+					resource.TestCheckResourceAttr(resourceName, "session_record_flags.1", "logout"),
+					resource.TestCheckResourceAttr(resourceName, "session_record_flags.2", "refresh"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: restoreGlobalUser(aaaUserEp, aaaPwdProfile, aaaBlockLoginProfile, pkiWebTokenData),
+			},
+		},
+	})
+}
+
+func TestAccAciWebTokenData_Negative(t *testing.T) {
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	aaaUserEp, err := aci.GetRemoteUserManagement(sharedAciClient(), "uni/userext")
+	if err != nil {
+		t.Errorf("reading initial config of aaaUserEp")
+	}
+	aaaPwdProfile, err := aci.GetRemotePasswordChangeExpirationPolicy(sharedAciClient(), "uni/userext/pwdprofile")
+	if err != nil {
+		t.Errorf("reading initial config of aaaPwdProfile")
+	}
+	aaaBlockLoginProfile, err := aci.GetRemoteBlockUserLoginsPolicy(sharedAciClient(), "uni/userext/blockloginp")
+	if err != nil {
+		t.Errorf("reading initial config of aaaBlockLoginProfile")
+	}
+	pkiWebTokenData, err := aci.GetRemoteWebTokenData(sharedAciClient(), "uni/userext/pkiext/webtokendata")
+	if err != nil {
+		t.Errorf("reading initial config of pkiWebTokenData")
+	}
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccWebTokenDataConfig(),
+			},
+
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("pwd_strength_check", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("change_count", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("change_count", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("change_count", "11"),
+				ExpectError: regexp.MustCompile(`is out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("change_during_interval", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("change_interval", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("change_interval", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("change_interval", "746"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("expiration_warn_time", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("expiration_warn_time", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("expiration_warn_time", "31"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("history_count", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("history_count", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("history_count", "16"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("no_change_interval", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("no_change_interval", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("no_change_interval", "746"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("block_duration", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("block_duration", "0"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("block_duration", "1441"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("enable_login_block", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("max_failed_attempts", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("max_failed_attempts", "0"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("max_failed_attempts", "16"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("max_failed_attempts_window", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("max_failed_attempts_window", "0"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("max_failed_attempts_window", "721"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("maximum_validity_period", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("maximum_validity_period", "0"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("maximum_validity_period", "721"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("ui_idle_timeout_seconds", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("ui_idle_timeout_seconds", "59"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("ui_idle_timeout_seconds", "65526"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("webtoken_timeout_seconds", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("webtoken_timeout_seconds", "299"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr("webtoken_timeout_seconds", "9601"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttrList("session_record_flags", StringListtoString([]string{"login", "login"})),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccWebTokenDataUpdatedAttr(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: restoreGlobalUser(aaaUserEp, aaaPwdProfile, aaaBlockLoginProfile, pkiWebTokenData),
+			},
+		},
+	})
+}
+
+func restoreGlobalUser(aaaUserEp *models.UserManagement, aaaPwdProfile *models.PasswordChangeExpirationPolicy, aaaBlockLoginProfile *models.BlockUserLoginsPolicy, pkiWebTokenData *models.WebTokenData) string {
+	resource := fmt.Sprintf(`
+	resource "aci_global_security" "test" {
+		annotation = "%s"
+		description = "%s"
+		name_alias = "%s"
+		pwd_strength_check = "%s"
+		change_count = "%s"
+		change_during_interval = "%s"
+		change_interval = "%s"
+		expiration_warn_time = "%s"
+		history_count = "%s"
+		no_change_interval = "%s"
+		block_duration = "%s"
+		enable_login_block = "%s"
+		max_failed_attempts = "%s"
+		max_failed_attempts_window = "%s"
+		maximum_validity_period = "%s"
+		session_record_flags = %s
+	}
+	`, aaaUserEp.Annotation, aaaUserEp.Description, aaaUserEp.NameAlias, aaaUserEp.PwdStrengthCheck, aaaPwdProfile.ChangeCount, aaaPwdProfile.ChangeDuringInterval, aaaPwdProfile.ChangeInterval, aaaPwdProfile.ExpirationWarnTime, aaaPwdProfile.HistoryCount, aaaPwdProfile.NoChangeInterval, aaaBlockLoginProfile.BlockDuration, aaaBlockLoginProfile.EnableLoginBlock, aaaBlockLoginProfile.MaxFailedAttempts, aaaBlockLoginProfile.MaxFailedAttemptsWindow, pkiWebTokenData.MaximumValidityPeriod, StringListtoString(convertToStringArray(pkiWebTokenData.SessionRecordFlags)))
+	return resource
+}
+
+func testAccCheckAciWebTokenDataExists(name string, global_security *models.UserManagement) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Web Token Data %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Web Token Data dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		global_securityFound := models.UserManagementFromContainer(cont)
+		if global_securityFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Web Token Data %s not found", rs.Primary.ID)
+		}
+		*global_security = *global_securityFound
+		return nil
+	}
+}
+
+func testAccCheckAciWebTokenDataIdEqual(m1, m2 *models.UserManagement) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("global_security DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func CreateAccWebTokenDataConfig() string {
+	fmt.Println("=== STEP  testing global_security creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_global_security" "test" {}
+	`)
+	return resource
+}
+
+func CreateAccWebTokenDataConfigWithOptionalValues() string {
+	fmt.Println("=== STEP  Basic: testing global_security creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_global_security" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_global_security"
+		pwd_strength_check = "no"
+		change_count = "0"
+		change_during_interval = "disable"
+		change_interval = "0"
+		expiration_warn_time = "0"
+		history_count = "0"
+		no_change_interval = "0"
+		block_duration = "1"
+		enable_login_block = "disable"
+		max_failed_attempts = "1"
+		max_failed_attempts_window = "1"
+		maximum_validity_period = "4"
+		session_record_flags = ["login" , "logout"]
+		ui_idle_timeout_seconds = "60"
+		webtoken_timeout_seconds = "300"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccWebTokenDataUpdatedAttr(attribute, value string) string {
+	fmt.Printf("=== STEP  testing global_security attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_global_security" "test" {
+	
+		%s = "%s"
+	}
+	`, attribute, value)
+	return resource
+}
+
+func CreateAccWebTokenDataUpdatedAttrList(attribute, value string) string {
+	fmt.Printf("=== STEP  testing global_security attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_global_security" "test" {
+	
+		%s = %s
+	}
+	`, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_tacacstacacsdest_test.go
+++ b/testacc/resource_aci_tacacstacacsdest_test.go
@@ -43,6 +43,7 @@ func TestAccAciTACACSDestination_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
 					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", ""),
 					resource.TestCheckResourceAttr(resourceName, "auth_protocol", "pap"),
 				),
 			},
@@ -58,6 +59,7 @@ func TestAccAciTACACSDestination_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_tacacs_accounting_destination"),
 					resource.TestCheckResourceAttr(resourceName, "auth_protocol", "chap"),
 					resource.TestCheckResourceAttr(resourceName, "key", "test_key"),
+					resource.TestCheckResourceAttr(resourceName, "name", "test_name"),
 					testAccCheckAciTACACSDestinationIdEqual(&tacacs_accounting_destination_default, &tacacs_accounting_destination_updated),
 				),
 			},
@@ -197,7 +199,10 @@ func TestAccAciTACACSDestination_Negative(t *testing.T) {
 				Config:      CreateAccTACACSDestinationUpdatedAttr(tacacsGroupName, host, "name_alias", acctest.RandString(64)),
 				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
 			},
-
+			{
+				Config:      CreateAccTACACSDestinationUpdatedAttr(tacacsGroupName, host, "name", acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
 			{
 				Config:      CreateAccTACACSDestinationUpdatedAttr(tacacsGroupName, host, "auth_protocol", randomValue),
 				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
@@ -406,7 +411,7 @@ func CreateAccTACACSDestinationConfigWithOptionalValues(tacacsGroupName, host st
 		name_alias = "test_tacacs_accounting_destination"
 		auth_protocol = "chap"
 		key = "test_key"
-		
+		name = "test_name"
 	}
 	`, tacacsGroupName, host)
 

--- a/website/docs/r/global_security.html.markdown
+++ b/website/docs/r/global_security.html.markdown
@@ -52,22 +52,22 @@ resource "aci_global_security" "example" {
 * `annotation` - (Optional) Annotation of object Global Security.
 * `description` - (Optional) Description of object Global Security.
 * `name_alias` - (Optional) Name alias of object Global Security.
-* `pwd_strength_check` - (Optional) Password Strength Check.The password strength check specifies if the system enforces the strength of the user password. Allowed values are "no", "yes", and default value is "yes". Type: String.
-* `change_count` - (Optional) Number of Password Changes in Interval.The number of password changes allowed within the change interval. Allowed range is 0-10 and default value is "2".
-* `change_during_interval` - (Optional) Password Policy.The change count/change interval policy selector. This property enables you to select an option for enforcing password change. Allowed values are "disable", "enable", and default value is "enable". Type: String.
-* `change_interval` - (Optional) Change Interval in Hours.A time interval for limiting the number of password changes. Allowed range is 0-745 and default value is "48".
+* `pwd_strength_check` - (Optional) Password Strength Check.The password strength check specifies if the system enforces the strength of the user password. Allowed values are "no" and "yes". Type: String.
+* `change_count` - (Optional) Number of Password Changes in Interval.The number of password changes allowed within the change interval. Allowed range is 0-10.
+* `change_during_interval` - (Optional) Password Policy.The change count/change interval policy selector. This property enables you to select an option for enforcing password change. Allowed values are "disable" and "enable". Type: String.
+* `change_interval` - (Optional) Change Interval in Hours.A time interval for limiting the number of password changes. Allowed range is 0-745.
 * `expiration_warn_time` - (Optional) Password Expiration Warn Time in Days.A warning period before password expiration.
-A warning will be displayed when a user logs in within this number of days of an impending password expiration. Allowed range is 0-30 and default value is "15".
-* `history_count` - (Optional) Password History Count.How many retired passwords are stored in a user's password history. Allowed range is 0-15 and default value is "5".
-* `no_change_interval` - (Optional) No Password Change Interval in Hours.A minimum period after a password change before the user can change the password again. Allowed range is 0-745 and default value is "24".
-* `block_duration` - (Optional) Duration in minutes for which login should be blocked.Duration in minutes for which future logins should be blocked Allowed range is 1-1440 and default value is "60".
-* `enable_login_block` - (Optional) Enable blocking of user logins after failed attempts. Allowed values are "disable", "enable", and default value is "disable". Type: String.
-* `max_failed_attempts` - (Optional) Maximum continuous failed logins before blocking user.max failed login attempts before blocking user login Allowed range is 1-15 and default value is "5".
-* `max_failed_attempts_window` - (Optional) Time period for maximum continuous failed logins.times in minutes for max login failures to occur before blocking the user Allowed range is 1-720 and default value is "5".
-* `maximum_validity_period` - (Optional) Maximum Validity Period in hours.The maximum validity period for a webt oken. Allowed range is 4-24 and default value is "24".
-* `session_record_flags` - (Optional) Session Recording Options.Enables or disables a refresh in the session records. Allowed values are "login", "logout", "refresh" and default value is ["login", "logout", "refresh"]. Type: List.
-* `ui_idle_timeout_seconds` - (Optional) GUI Idle Timeout in Seconds.The maximum interval time the GUI remains idle before login needs to be refreshed. Allowed range is 60-65525 and default value is "1200".
-* `webtoken_timeout_seconds` - (Optional) Timeout in Seconds.The web token timeout interval. Allowed range is 300-9600 and default value is "600".
+A warning will be displayed when a user logs in within this number of days of an impending password expiration. Allowed range is 0-30.
+* `history_count` - (Optional) Password History Count.How many retired passwords are stored in a user's password history. Allowed range is 0-15.
+* `no_change_interval` - (Optional) No Password Change Interval in Hours.A minimum period after a password change before the user can change the password again. Allowed range is 0-745.
+* `block_duration` - (Optional) Duration in minutes for which login should be blocked.Duration in minutes for which future logins should be blocked Allowed range is 1-1440.
+* `enable_login_block` - (Optional) Enable blocking of user logins after failed attempts. Allowed values are "disable" and "enable". Type: String.
+* `max_failed_attempts` - (Optional) Maximum continuous failed logins before blocking user.max failed login attempts before blocking user login Allowed range is 1-15.
+* `max_failed_attempts_window` - (Optional) Time period for maximum continuous failed logins.times in minutes for max login failures to occur before blocking the user Allowed range is 1-720.
+* `maximum_validity_period` - (Optional) Maximum Validity Period in hours.The maximum validity period for a webt oken. Allowed range is 4-24.
+* `session_record_flags` - (Optional) Session Recording Options.Enables or disables a refresh in the session records. Allowed values are "login", "logout", "refresh". Type: List.
+* `ui_idle_timeout_seconds` - (Optional) GUI Idle Timeout in Seconds.The maximum interval time the GUI remains idle before login needs to be refreshed. Allowed range is 60-65525.
+* `webtoken_timeout_seconds` - (Optional) Timeout in Seconds.The web token timeout interval. Allowed range is 300-9600.
 
 * `relation_aaa_rs_to_user_ep` - (Optional) Represents the relation to a Global Security (class aaaUserEp).  Type: String.
 

--- a/website/docs/r/match_route_destination_rule.html.markdown
+++ b/website/docs/r/match_route_destination_rule.html.markdown
@@ -38,7 +38,7 @@ resource "aci_match_route_destination_rule" "destination" {
 * `match_rule_dn` - (Required) Distinguished name of parent Match Rule object.
 * `ip` - (Required) Ip of object Match Route Destination Rule.
 * `annotation` - (Optional) Annotation of object Match Route Destination Rule.
-* `aggregate` - (Optional) Aggregated Route. Allowed values are "false", "true" and default value is "false". Type: String.
+* `aggregate` - (Optional) Aggregated Route. Allowed values are "yes", "no" and default value is "no". Type: String.
 * `greater_than_mask` - (Optional) Start of Prefix Length. Allowed range is 0-128 and default value is "0".
 * `less_than_mask` - (Optional) End of Prefix Length. Allowed range is 0-128 and default value is "0".
 * `description` - (Optional) Description of object Match Route Destination Rule.


### PR DESCRIPTION
=== RUN   TestAccAciWebTokenDataDataSource_Basic
=== STEP  testing global_security Data Source with required arguments only
=== STEP  testing global_security Data Source with random attribute
=== STEP  testing global_security Data Source with updated resource
--- PASS: TestAccAciWebTokenDataDataSource_Basic (31.31s)
=== RUN   TestAccAciWebTokenData_Basic
=== STEP  testing global_security creation with required arguments only
=== STEP  Basic: testing global_security creation with optional parameters
--- PASS: TestAccAciWebTokenData_Basic (29.65s)
=== RUN   TestAccAciWebTokenData_Update
=== STEP  testing global_security creation with required arguments only
=== STEP  testing global_security attribute: pwd_strength_check = no
=== STEP  testing global_security attribute: change_count = 10
=== STEP  testing global_security attribute: change_count = 5
=== STEP  testing global_security attribute: change_during_interval = enable
=== STEP  testing global_security attribute: change_interval = 745
=== STEP  testing global_security attribute: change_interval = 372
=== STEP  testing global_security attribute: expiration_warn_time = 15
=== STEP  testing global_security attribute: history_count = 15
=== STEP  testing global_security attribute: history_count = 7
=== STEP  testing global_security attribute: no_change_interval = 745
=== STEP  testing global_security attribute: no_change_interval = 372
=== STEP  testing global_security attribute: block_duration = 1440
=== STEP  testing global_security attribute: block_duration = 720
=== STEP  testing global_security attribute: enable_login_block = enable
=== STEP  testing global_security attribute: max_failed_attempts = 15
=== STEP  testing global_security attribute: max_failed_attempts = 7
=== STEP  testing global_security attribute: max_failed_attempts_window = 720
=== STEP  testing global_security attribute: max_failed_attempts_window = 360
=== STEP  testing global_security attribute: maximum_validity_period = 24
=== STEP  testing global_security attribute: maximum_validity_period = 14
=== STEP  testing global_security attribute: ui_idle_timeout_seconds = 32000
=== STEP  testing global_security attribute: ui_idle_timeout_seconds = 65525
=== STEP  testing global_security attribute: webtoken_timeout_seconds = 4545
=== STEP  testing global_security attribute: webtoken_timeout_seconds = 9600
=== STEP  testing global_security attribute: session_record_flags = ["refresh","logout","login"]
=== STEP  testing global_security attribute: session_record_flags = ["login","logout","refresh"]
--- PASS: TestAccAciWebTokenData_Update (246.47s)
=== RUN   TestAccAciWebTokenData_Negative
=== STEP  testing global_security creation with required arguments only
=== STEP  testing global_security attribute: description = fsf4cwvhd6l8uxxpvmiocoupk2qznsxn0euqn498v49s9job1nvrt4m3lwoz22dy0bp96b3ndosumhqaa9obp9hrdfu710mefrckriciazqnvcztw3nmd3ei8hfz73qa1
=== STEP  testing global_security attribute: annotation = 7tiqspqz1aqb4pdck202vwv2jivxl4umog44xgvgginjmiv0un8vltnhfti3scf1zsw7qsetkqbj9gox4soqyagqmdh1ix9fx8g98iwdeijvh32qcqrxpwgs2j60ubc0t
=== STEP  testing global_security attribute: name_alias = 01g3gmxd9erj6x4x3odv07k42pt0to0p76fx6ez4so0k3we2m8awzvq8abtgthrf
=== STEP  testing global_security attribute: pwd_strength_check = 7uxqs
=== STEP  testing global_security attribute: change_count = 7uxqs
=== STEP  testing global_security attribute: change_count = -1
=== STEP  testing global_security attribute: change_count = 11
=== STEP  testing global_security attribute: change_during_interval = 7uxqs
=== STEP  testing global_security attribute: change_interval = 7uxqs
=== STEP  testing global_security attribute: change_interval = -1
=== STEP  testing global_security attribute: change_interval = 746
=== STEP  testing global_security attribute: expiration_warn_time = 7uxqs
=== STEP  testing global_security attribute: expiration_warn_time = -1
=== STEP  testing global_security attribute: expiration_warn_time = 31
=== STEP  testing global_security attribute: history_count = 7uxqs
=== STEP  testing global_security attribute: history_count = -1
=== STEP  testing global_security attribute: history_count = 16
=== STEP  testing global_security attribute: no_change_interval = 7uxqs
=== STEP  testing global_security attribute: no_change_interval = -1
=== STEP  testing global_security attribute: no_change_interval = 746
=== STEP  testing global_security attribute: block_duration = 7uxqs
=== STEP  testing global_security attribute: block_duration = 0
=== STEP  testing global_security attribute: block_duration = 1441
=== STEP  testing global_security attribute: enable_login_block = 7uxqs
=== STEP  testing global_security attribute: max_failed_attempts = 7uxqs
=== STEP  testing global_security attribute: max_failed_attempts = 0
=== STEP  testing global_security attribute: max_failed_attempts = 16
=== STEP  testing global_security attribute: max_failed_attempts_window = 7uxqs
=== STEP  testing global_security attribute: max_failed_attempts_window = 0
=== STEP  testing global_security attribute: max_failed_attempts_window = 721
=== STEP  testing global_security attribute: maximum_validity_period = 7uxqs
=== STEP  testing global_security attribute: maximum_validity_period = 0
=== STEP  testing global_security attribute: maximum_validity_period = 721
=== STEP  testing global_security attribute: ui_idle_timeout_seconds = 7uxqs
=== STEP  testing global_security attribute: ui_idle_timeout_seconds = 59
=== STEP  testing global_security attribute: ui_idle_timeout_seconds = 65526
=== STEP  testing global_security attribute: webtoken_timeout_seconds = 7uxqs
=== STEP  testing global_security attribute: webtoken_timeout_seconds = 299
=== STEP  testing global_security attribute: webtoken_timeout_seconds = 9601
=== STEP  testing global_security attribute: session_record_flags = ["login","login"]
=== STEP  testing global_security attribute: zbdwp = 7uxqs
--- PASS: TestAccAciWebTokenData_Negative (169.26s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   477.904s
=== RUN   TestAccAciTACACSDestinationDataSource_Basic
=== STEP  Basic: testing tacacs_accounting_destination Data Source without  tacacs_accounting_dn
=== STEP  Basic: testing tacacs_accounting_destination Data Source without  host
=== STEP  testing tacacs_accounting_destination Data Source with required arguments only
=== STEP  testing tacacs_accounting_destination Data Source with random attribute
=== STEP  testing tacacs_accounting_destination Data Source with Invalid Parent Dn
=== STEP  testing tacacs_accounting_destination Data Source with updated resource
=== PAUSE TestAccAciTACACSDestinationDataSource_Basic
=== RUN   TestAccAciTACACSDestination_Basic
=== STEP  Basic: testing tacacs_accounting_destination creation without  tacacs_accounting_dn
=== STEP  Basic: testing tacacs_accounting_destination creation without  host
=== STEP  testing tacacs_accounting_destination creation with required arguments only
=== STEP  Basic: testing tacacs_accounting_destination creation with optional parameters
=== STEP  Basic: testing tacacs_accounting_destination updation without required parameters
=== STEP  testing tacacs_accounting_destination creation with parent resource name e2hih, host u1amv.com and port 0
=== STEP  testing tacacs_accounting_destination creation with parent resource name e2hih, host u1amv.com and port 65536
=== STEP  testing tacacs_accounting_destination creation with parent resource name e2hih, host u1amv.com and port 49
=== STEP  testing tacacs_accounting_destination creation with required arguments only
=== STEP  testing tacacs_accounting_destination creation with parent resource name acctest_11hkg, host bxdyx.com and port 49
=== STEP  testing tacacs_accounting_destination creation with required arguments only
=== STEP  testing tacacs_accounting_destination creation with parent resource name acctest_11hkg, host u1amv.com and port 50
=== PAUSE TestAccAciTACACSDestination_Basic
=== RUN   TestAccAciTACACSDestination_Update
=== STEP  testing tacacs_accounting_destination creation with required arguments only
=== STEP  testing tacacs_accounting_destination attribute: auth_protocol = mschap
=== STEP  testing tacacs_accounting_destination creation with parent resource name acctest_mrynp, host vxef9.com and port 1
=== STEP  testing tacacs_accounting_destination creation with parent resource name acctest_mrynp, host vxef9.com and port 32000
=== PAUSE TestAccAciTACACSDestination_Update
=== RUN   TestAccAciTACACSDestination_Negative
=== STEP  testing tacacs_accounting_destination creation with required arguments only
=== STEP  Negative Case: testing tacacs_accounting_destination creation with invalid parent Dn
=== STEP  testing tacacs_accounting_destination attribute: description = njguwuuyzxtpllzi1osby7upijo8nuapqwidbiimxnbfasvv646vurrtram9zmnqhwjdj49uoqsnjc9dejyzeekfvaciukzfoi7q6dwgsxhc4ohu0io67ir3hidzf1x8p
=== STEP  testing tacacs_accounting_destination attribute: annotation = qiazn0piocrq8ix8zho0t61zmx6f84sr14wbgja6au7daa04z1jbniil467ib78agswpkw0engsgwkxslztv777auieovr8uf1oqdievrrj044lakoxfamqfou6lgmbvb
=== STEP  testing tacacs_accounting_destination attribute: name_alias = 0amxsce192rbqd3z49b87m0ointxglnw9ivu1v8hgyu7qvidqwqi240fuo9xc0wc
=== STEP  testing tacacs_accounting_destination attribute: name = tcz2ohoqpeejp3ju37bfts7d4g1o4qhte7oo48fqyvhjbvqsxikupmktc2af8adv7
=== STEP  testing tacacs_accounting_destination attribute: auth_protocol = 3re2u
=== STEP  testing tacacs_accounting_destination attribute: gtvnp = 3re2u
=== STEP  testing tacacs_accounting_destination creation with required arguments only
=== PAUSE TestAccAciTACACSDestination_Negative
=== RUN   TestAccAciTACACSDestination_MultipleCreateDelete
=== STEP  testing multiple tacacs_accounting_destination creation with required arguments only
=== PAUSE TestAccAciTACACSDestination_MultipleCreateDelete
=== CONT  TestAccAciTACACSDestinationDataSource_Basic
=== CONT  TestAccAciTACACSDestination_Negative
=== CONT  TestAccAciTACACSDestination_Update
=== CONT  TestAccAciTACACSDestination_Basic
=== CONT  TestAccAciTACACSDestination_MultipleCreateDelete
=== STEP  testing tacacs_accounting_destination destroy
--- PASS: TestAccAciTACACSDestination_MultipleCreateDelete (23.39s)
=== STEP  testing tacacs_accounting_destination destroy
--- PASS: TestAccAciTACACSDestinationDataSource_Basic (47.19s)
=== STEP  testing tacacs_accounting_destination destroy
--- PASS: TestAccAciTACACSDestination_Update (61.56s)
=== STEP  testing tacacs_accounting_destination destroy
--- PASS: TestAccAciTACACSDestination_Negative (66.29s)
=== STEP  testing tacacs_accounting_destination destroy
--- PASS: TestAccAciTACACSDestination_Basic (101.48s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   102.826s
=== RUN   TestAccAciLDAPGroupMap_Basic
=== STEP  Basic: testing ldap_group_map creation without  name
=== STEP  Basic: testing ldap_group_map creation without  type
=== STEP  testing ldap_group_map creation with required arguments only
=== STEP  Basic: testing ldap_group_map creation with optional parameters
=== STEP  testing ldap_group_map creation with invalid name =  zhmyfta7tnrogi2ds1rahmttscnim2bixxbew3qaca4fe0ataaex1pd2rcegjygb7
=== STEP  Basic: testing ldap_group_map updation without required parameters
=== STEP  testing ldap_group_map creation with type acctest_obl9y and name acctest_obl9y
=== STEP  testing ldap_group_map creation with type duo and name acctest_k977m
=== STEP  testing ldap_group_map creation with required arguments only
=== STEP  testing ldap_group_map creation with type ldap and name acctest_obl9y
=== PAUSE TestAccAciLDAPGroupMap_Basic
=== RUN   TestAccAciLDAPGroupMap_Negative
=== STEP  testing ldap_group_map creation with required arguments only
=== STEP  testing ldap_group_map attribute: description = ep6wfg9aygwnpuvwngztk8yjwwoibvjoz3o383svxw0dtjfsrdw2q9dnhn9wgh81u3vk0kibuuiitjtqy8ckrntlg8v49046tfl08fgz0fjmwaom7wh7ewwt668jg9cef
=== STEP  testing ldap_group_map attribute: annotation = ab8joe9myixne86ghoqlxzlddhmic0k3thhcn9jq0ljqv9nyiobs0on6rbopq4ac21apovx6kaqunklud6st6ez4u4m9vlyrytlnlwwaas3gr0c8fs7y3ekzjzzg7b3ar
=== STEP  testing ldap_group_map attribute: name_alias = nw0n2b8ob1ykkuu6i6xs48qa4noqboqwyymwsuqz2v1qmtqvseq3t1lxwqcty2fu
=== STEP  testing ldap_group_map attribute: ciake = exq0y
=== STEP  testing ldap_group_map creation with required arguments only
=== PAUSE TestAccAciLDAPGroupMap_Negative
=== RUN   TestAccAciLDAPGroupMap_MultipleCreateDelete
=== STEP  testing multiple ldap_group_map creation with required arguments only
=== PAUSE TestAccAciLDAPGroupMap_MultipleCreateDelete
=== CONT  TestAccAciLDAPGroupMap_Basic
=== CONT  TestAccAciLDAPGroupMap_MultipleCreateDelete
=== CONT  TestAccAciLDAPGroupMap_Negative
=== STEP  testing ldap_group_map destroy
--- PASS: TestAccAciLDAPGroupMap_MultipleCreateDelete (16.94s)
=== STEP  testing ldap_group_map destroy
--- PASS: TestAccAciLDAPGroupMap_Negative (37.70s)
=== STEP  testing ldap_group_map destroy
--- PASS: TestAccAciLDAPGroupMap_Basic (60.58s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   62.372s
=== RUN   TestAccAciLDAPGroupMapDataSource_Basic
=== STEP  Basic: testing ldap_group_map Data Source without  name
=== STEP  Basic: testing ldap_group_map Data Source without  type
=== STEP  testing ldap_group_map Data Source with required arguments only
=== STEP  testing ldap_group_map Data Source with random attribute
=== STEP  testing ldap_group_map Data Source with invalid name
=== STEP  testing ldap_group_map Data Source with updated resource
=== PAUSE TestAccAciLDAPGroupMapDataSource_Basic
=== CONT  TestAccAciLDAPGroupMapDataSource_Basic
=== STEP  testing ldap_group_map destroy
--- PASS: TestAccAciLDAPGroupMapDataSource_Basic (29.19s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   31.044s
=== RUN   TestAccAciSAMLProviderDataSource_Basic
=== STEP  Basic: testing saml_provider Data Source without  name
=== STEP  testing saml_provider Data Source with required arguments only
=== STEP  testing saml_provider Data Source with random attribute
=== STEP  testing saml_provider Data Source with invalid name
=== STEP  testing saml_provider Data Source with updated resource
=== PAUSE TestAccAciSAMLProviderDataSource_Basic
=== RUN   TestAccAciSAMLProviderGroupDataSource_Basic
=== STEP  Basic: testing saml_provider_group Data Source without  name
=== STEP  testing saml_provider_group Data Source with required arguments only
=== STEP  testing saml_provider_group Data Source with random attribute
=== STEP  testing saml_provider_group Data Source with invalid name
=== STEP  testing saml_provider_group Data Source with updated resource
=== PAUSE TestAccAciSAMLProviderGroupDataSource_Basic
=== RUN   TestAccAciSAMLProvider_Basic
=== STEP  Basic: testing saml_provider creation without  name
=== STEP  testing saml_provider creation with required arguments only
=== STEP  Basic: testing saml_provider creation with optional parameters
=== STEP  testing saml_provider creation with invalid name =  k0qkgbwhcmokrpbsdhbgnx4x4talkj0vtajjsgqcua10lcmlclmze8m4qwpfd0os7
=== STEP  Basic: testing saml_provider updation without required parameters
=== STEP  testing saml_provider creation with name acctest_d6ohn
=== PAUSE TestAccAciSAMLProvider_Basic
=== RUN   TestAccAciSAMLProvider_Update
=== STEP  testing saml_provider creation with required arguments only
=== STEP  testing saml_provider attribute: retries = 2
=== STEP  testing saml_provider attribute: sig_alg = SIG_RSA_SHA224
=== STEP  testing saml_provider attribute: sig_alg = SIG_RSA_SHA384
=== STEP  testing saml_provider attribute: sig_alg = SIG_RSA_SHA512
=== STEP  testing saml_provider attribute: timeout = 27
=== STEP  testing saml_provider creation with required arguments only
=== PAUSE TestAccAciSAMLProvider_Update
=== RUN   TestAccAciSAMLProvider_Negative
=== STEP  testing saml_provider creation with required arguments only
=== STEP  testing saml_provider attribute: description = yq0e40jpp2uf1ohuvp0z4j7nhk2f0j8gy3bhl4flm38l4gqzvmjjmq1cjz26l4aayjaoe33d9cvgze0nm6ss6dxnmv3okf4vofky9hmc3i8evn33ostwj6yqegr26p2q9
=== STEP  testing saml_provider attribute: annotation = pu4uoz0do67hewqqm9jlcwz7xza78r4t0vjdynp9o2eqz3xyfbbgsf7ngz63inrqrbrhyx2iuqr2so3y7tzek8zgx6dx3720pgtmklsczwgls0q2ck3sg9rsm49gld67v
=== STEP  testing saml_provider attribute: name_alias = dj7gsbml4p2ambjj3a2d77v7dnjckc3b3rwcqrrujlxe3h63anbcmogap0ou6149
=== STEP  testing saml_provider attribute: entity_id = yewnoi2ysg8tnd3kbkpsfuqdcfwbah96g0a4lhypvdgr7qsdwc464g77c0lu0phjbpl8mkhm9wlnyusnrrw8a4mo9nv3i0aelsv84sfm3f3jjnymic07jd4xiqe6l6tlzhrlg1jutw92r06sludji3te3eub7dup9ci1xx4ld360ibmo47vtav48rdsnt2aw3zvvdoyjaw13rf4rx1auykphpd39najjqomezgbiqpw4824j8gkzotg2wuboieudw92ggqfzjs4fmg6dnod2anaaun6y2ct8p6cc97zni4tg99xd8nb8v43runyfx8x6x8kbiha6i8k1wmeqtoiqb8majl4lnngt29mqol897yszi8wswtvwxte91qxc6asanuwq9dlg143l0cpd8lqs1lkd02p2vqsqo69falj1oovis0q7ckfhs7x7la1o92f8x999lanxck2nbu8babi042u1f34gllxj9hryn8h7buwu3d8g97zx46h7lqjtbzjc3
=== STEP  testing saml_provider attribute: https_proxy = xr8j3v3lle14bhikfg2ac2byq39ov19yxv9hyz62nnjdomo8il9l84203khv3m3vups1pqe3jr6z62xvyn91ot2aw6gu4y38t2wc396hthiouyh3us4ohobe7d48t3fwx1j4m9dok8u40qsojqrxjnokp18e9l26wkfg9aw0chfzfhb9ngmnycugbj3m44epyumzak3cswnfyrnn1iiotxvqthqj87avsyp6f0r1razjtg9gprztkoocw96x168ii
=== STEP  testing saml_provider attribute: id_p = 6rmoj
=== STEP  testing saml_provider attribute: monitor_server = 6rmoj
=== STEP  testing saml_provider attribute: monitoring_user = cnlchk0ius8nqfmqts7q1d7hya7iab86e
=== STEP  testing saml_provider attribute: retries = 6rmoj
=== STEP  testing saml_provider attribute: retries = 0
=== STEP  testing saml_provider attribute: retries = 6
=== STEP  testing saml_provider attribute: sig_alg = 6rmoj
=== STEP  testing saml_provider attribute: timeout = 6rmoj
=== STEP  testing saml_provider attribute: timeout = 4
=== STEP  testing saml_provider attribute: timeout = 61
=== STEP  testing saml_provider attribute: tp = vtcm3xrkyfvdp1zixwx7rawzejn
=== STEP  testing saml_provider attribute: want_assertions_encrypted = 6rmoj
=== STEP  testing saml_provider attribute: want_assertions_signed = 6rmoj
=== STEP  testing saml_provider attribute: want_requests_signed = 6rmoj
=== STEP  testing saml_provider attribute: want_response_signed = 6rmoj
=== STEP  testing saml_provider attribute: jsxzc = 6rmoj
=== STEP  testing saml_provider creation with required arguments only
=== PAUSE TestAccAciSAMLProvider_Negative
=== RUN   TestAccAciSAMLProvider_MultipleCreateDelete
=== STEP  testing multiple saml_provider creation with required arguments only
=== PAUSE TestAccAciSAMLProvider_MultipleCreateDelete
=== RUN   TestAccAciSAMLProviderGroup_Basic
=== STEP  Basic: testing saml_provider_group creation without  name
=== STEP  testing saml_provider_group creation with required arguments only
=== STEP  Basic: testing saml_provider_group creation with optional parameters
=== STEP  testing saml_provider_group creation with invalid name =  qdlailho9vqc4acmw92w1hup8f3l6fun39ounyfnchuvqvall4rpiw32evaibpc48
=== STEP  Basic: testing saml_provider_group updation without required parameters
=== STEP  testing saml_provider_group creation with name acctest_v0zia
=== PAUSE TestAccAciSAMLProviderGroup_Basic
=== RUN   TestAccAciSAMLProviderGroup_Negative
=== STEP  testing saml_provider_group creation with required arguments only
=== STEP  testing saml_provider_group attribute: description = sxerzwzcbgwyuipli1iiedxqsmw8vo8t6bmayhvxyymkb1r1m0saolj6hlold740ab6kbjix0z12l68sbbhmooqesvrlilwt2nu6g84nfd33ai3xqb8uzq7xma6x4atxd
=== STEP  testing saml_provider_group attribute: annotation = yfql164kfh0dudvivbohxapf3sb6x9mf6pav09v4uld9h7hu6xd6k8kcwhf6k0kk6km4g7bng8esaiqt4jlg8hxv93wf4uhr3xdtn64p9almzz0adg0eu91aky44ibii1
=== STEP  testing saml_provider_group attribute: name_alias = vzxsdf8gygxzg4ysvf4y1r93gw71glmpz2nersq06gr4g4vq686tv2pcfjz7co93
=== STEP  testing saml_provider_group attribute: cyfcv = 2qq8t
=== STEP  testing saml_provider_group creation with required arguments only
=== PAUSE TestAccAciSAMLProviderGroup_Negative
=== RUN   TestAccAciSAMLProviderGroup_MultipleCreateDelete
=== STEP  testing multiple saml_provider_group creation with required arguments only
=== PAUSE TestAccAciSAMLProviderGroup_MultipleCreateDelete
=== CONT  TestAccAciSAMLProviderDataSource_Basic
=== CONT  TestAccAciSAMLProvider_MultipleCreateDelete
=== CONT  TestAccAciSAMLProvider_Update
=== CONT  TestAccAciSAMLProvider_Negative
=== CONT  TestAccAciSAMLProvider_Basic
=== CONT  TestAccAciSAMLProviderGroup_Negative
=== CONT  TestAccAciSAMLProviderGroupDataSource_Basic
=== CONT  TestAccAciSAMLProviderGroup_Basic
=== STEP  testing saml_provider destroy
--- PASS: TestAccAciSAMLProvider_MultipleCreateDelete (27.14s)
=== CONT  TestAccAciSAMLProviderGroup_MultipleCreateDelete
=== STEP  testing saml_provider_group destroy
=== STEP  testing saml_provider destroy
--- PASS: TestAccAciSAMLProviderDataSource_Basic (44.16s)
=== STEP  testing saml_provider_group destroy
--- PASS: TestAccAciSAMLProviderGroupDataSource_Basic (44.64s)
--- PASS: TestAccAciSAMLProviderGroup_MultipleCreateDelete (19.67s)
=== STEP  testing saml_provider_group destroy
--- PASS: TestAccAciSAMLProviderGroup_Negative (52.19s)
=== STEP  testing saml_provider_group destroy
--- PASS: TestAccAciSAMLProviderGroup_Basic (58.44s)
=== STEP  testing saml_provider destroy
--- PASS: TestAccAciSAMLProvider_Basic (63.56s)
=== STEP  testing saml_provider destroy
--- PASS: TestAccAciSAMLProvider_Update (93.72s)
=== STEP  testing saml_provider destroy
--- PASS: TestAccAciSAMLProvider_Negative (103.51s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   104.839s
=== RUN   TestAccAciSAMLProviderDataSource_Basic
=== STEP  Basic: testing saml_provider Data Source without  name
=== STEP  testing saml_provider Data Source with required arguments only
=== STEP  testing saml_provider Data Source with random attribute
=== STEP  testing saml_provider Data Source with invalid name
=== STEP  testing saml_provider Data Source with updated resource
=== PAUSE TestAccAciSAMLProviderDataSource_Basic
=== RUN   TestAccAciSAMLProviderGroupDataSource_Basic
=== STEP  Basic: testing saml_provider_group Data Source without  name
=== STEP  testing saml_provider_group Data Source with required arguments only
=== STEP  testing saml_provider_group Data Source with random attribute
=== STEP  testing saml_provider_group Data Source with invalid name
=== STEP  testing saml_provider_group Data Source with updated resource
=== PAUSE TestAccAciSAMLProviderGroupDataSource_Basic
=== RUN   TestAccAciSAMLProvider_Basic
=== STEP  Basic: testing saml_provider creation without  name
=== STEP  testing saml_provider creation with required arguments only
=== STEP  Basic: testing saml_provider creation with optional parameters
=== STEP  testing saml_provider creation with invalid name =  k0qkgbwhcmokrpbsdhbgnx4x4talkj0vtajjsgqcua10lcmlclmze8m4qwpfd0os7
=== STEP  Basic: testing saml_provider updation without required parameters
=== STEP  testing saml_provider creation with name acctest_d6ohn
=== PAUSE TestAccAciSAMLProvider_Basic
=== RUN   TestAccAciSAMLProvider_Update
=== STEP  testing saml_provider creation with required arguments only
=== STEP  testing saml_provider attribute: retries = 2
=== STEP  testing saml_provider attribute: sig_alg = SIG_RSA_SHA224
=== STEP  testing saml_provider attribute: sig_alg = SIG_RSA_SHA384
=== STEP  testing saml_provider attribute: sig_alg = SIG_RSA_SHA512
=== STEP  testing saml_provider attribute: timeout = 27
=== STEP  testing saml_provider creation with required arguments only
=== PAUSE TestAccAciSAMLProvider_Update
=== RUN   TestAccAciSAMLProvider_Negative
=== STEP  testing saml_provider creation with required arguments only
=== STEP  testing saml_provider attribute: description = yq0e40jpp2uf1ohuvp0z4j7nhk2f0j8gy3bhl4flm38l4gqzvmjjmq1cjz26l4aayjaoe33d9cvgze0nm6ss6dxnmv3okf4vofky9hmc3i8evn33ostwj6yqegr26p2q9
=== STEP  testing saml_provider attribute: annotation = pu4uoz0do67hewqqm9jlcwz7xza78r4t0vjdynp9o2eqz3xyfbbgsf7ngz63inrqrbrhyx2iuqr2so3y7tzek8zgx6dx3720pgtmklsczwgls0q2ck3sg9rsm49gld67v
=== STEP  testing saml_provider attribute: name_alias = dj7gsbml4p2ambjj3a2d77v7dnjckc3b3rwcqrrujlxe3h63anbcmogap0ou6149
=== STEP  testing saml_provider attribute: entity_id = yewnoi2ysg8tnd3kbkpsfuqdcfwbah96g0a4lhypvdgr7qsdwc464g77c0lu0phjbpl8mkhm9wlnyusnrrw8a4mo9nv3i0aelsv84sfm3f3jjnymic07jd4xiqe6l6tlzhrlg1jutw92r06sludji3te3eub7dup9ci1xx4ld360ibmo47vtav48rdsnt2aw3zvvdoyjaw13rf4rx1auykphpd39najjqomezgbiqpw4824j8gkzotg2wuboieudw92ggqfzjs4fmg6dnod2anaaun6y2ct8p6cc97zni4tg99xd8nb8v43runyfx8x6x8kbiha6i8k1wmeqtoiqb8majl4lnngt29mqol897yszi8wswtvwxte91qxc6asanuwq9dlg143l0cpd8lqs1lkd02p2vqsqo69falj1oovis0q7ckfhs7x7la1o92f8x999lanxck2nbu8babi042u1f34gllxj9hryn8h7buwu3d8g97zx46h7lqjtbzjc3
=== STEP  testing saml_provider attribute: https_proxy = xr8j3v3lle14bhikfg2ac2byq39ov19yxv9hyz62nnjdomo8il9l84203khv3m3vups1pqe3jr6z62xvyn91ot2aw6gu4y38t2wc396hthiouyh3us4ohobe7d48t3fwx1j4m9dok8u40qsojqrxjnokp18e9l26wkfg9aw0chfzfhb9ngmnycugbj3m44epyumzak3cswnfyrnn1iiotxvqthqj87avsyp6f0r1razjtg9gprztkoocw96x168ii
=== STEP  testing saml_provider attribute: id_p = 6rmoj
=== STEP  testing saml_provider attribute: monitor_server = 6rmoj
=== STEP  testing saml_provider attribute: monitoring_user = cnlchk0ius8nqfmqts7q1d7hya7iab86e
=== STEP  testing saml_provider attribute: retries = 6rmoj
=== STEP  testing saml_provider attribute: retries = 0
=== STEP  testing saml_provider attribute: retries = 6
=== STEP  testing saml_provider attribute: sig_alg = 6rmoj
=== STEP  testing saml_provider attribute: timeout = 6rmoj
=== STEP  testing saml_provider attribute: timeout = 4
=== STEP  testing saml_provider attribute: timeout = 61
=== STEP  testing saml_provider attribute: tp = vtcm3xrkyfvdp1zixwx7rawzejn
=== STEP  testing saml_provider attribute: want_assertions_encrypted = 6rmoj
=== STEP  testing saml_provider attribute: want_assertions_signed = 6rmoj
=== STEP  testing saml_provider attribute: want_requests_signed = 6rmoj
=== STEP  testing saml_provider attribute: want_response_signed = 6rmoj
=== STEP  testing saml_provider attribute: jsxzc = 6rmoj
=== STEP  testing saml_provider creation with required arguments only
=== PAUSE TestAccAciSAMLProvider_Negative
=== RUN   TestAccAciSAMLProvider_MultipleCreateDelete
=== STEP  testing multiple saml_provider creation with required arguments only
=== PAUSE TestAccAciSAMLProvider_MultipleCreateDelete
=== RUN   TestAccAciSAMLProviderGroup_Basic
=== STEP  Basic: testing saml_provider_group creation without  name
=== STEP  testing saml_provider_group creation with required arguments only
=== STEP  Basic: testing saml_provider_group creation with optional parameters
=== STEP  testing saml_provider_group creation with invalid name =  qdlailho9vqc4acmw92w1hup8f3l6fun39ounyfnchuvqvall4rpiw32evaibpc48
=== STEP  Basic: testing saml_provider_group updation without required parameters
=== STEP  testing saml_provider_group creation with name acctest_v0zia
=== PAUSE TestAccAciSAMLProviderGroup_Basic
=== RUN   TestAccAciSAMLProviderGroup_Negative
=== STEP  testing saml_provider_group creation with required arguments only
=== STEP  testing saml_provider_group attribute: description = sxerzwzcbgwyuipli1iiedxqsmw8vo8t6bmayhvxyymkb1r1m0saolj6hlold740ab6kbjix0z12l68sbbhmooqesvrlilwt2nu6g84nfd33ai3xqb8uzq7xma6x4atxd
=== STEP  testing saml_provider_group attribute: annotation = yfql164kfh0dudvivbohxapf3sb6x9mf6pav09v4uld9h7hu6xd6k8kcwhf6k0kk6km4g7bng8esaiqt4jlg8hxv93wf4uhr3xdtn64p9almzz0adg0eu91aky44ibii1
=== STEP  testing saml_provider_group attribute: name_alias = vzxsdf8gygxzg4ysvf4y1r93gw71glmpz2nersq06gr4g4vq686tv2pcfjz7co93
=== STEP  testing saml_provider_group attribute: cyfcv = 2qq8t
=== STEP  testing saml_provider_group creation with required arguments only
=== PAUSE TestAccAciSAMLProviderGroup_Negative
=== RUN   TestAccAciSAMLProviderGroup_MultipleCreateDelete
=== STEP  testing multiple saml_provider_group creation with required arguments only
=== PAUSE TestAccAciSAMLProviderGroup_MultipleCreateDelete
=== CONT  TestAccAciSAMLProviderDataSource_Basic
=== CONT  TestAccAciSAMLProvider_MultipleCreateDelete
=== CONT  TestAccAciSAMLProvider_Update
=== CONT  TestAccAciSAMLProvider_Negative
=== CONT  TestAccAciSAMLProvider_Basic
=== CONT  TestAccAciSAMLProviderGroup_Negative
=== CONT  TestAccAciSAMLProviderGroupDataSource_Basic
=== CONT  TestAccAciSAMLProviderGroup_Basic
=== STEP  testing saml_provider destroy
--- PASS: TestAccAciSAMLProvider_MultipleCreateDelete (27.14s)
=== CONT  TestAccAciSAMLProviderGroup_MultipleCreateDelete
=== STEP  testing saml_provider_group destroy
=== STEP  testing saml_provider destroy
--- PASS: TestAccAciSAMLProviderDataSource_Basic (44.16s)
=== STEP  testing saml_provider_group destroy
--- PASS: TestAccAciSAMLProviderGroupDataSource_Basic (44.64s)
--- PASS: TestAccAciSAMLProviderGroup_MultipleCreateDelete (19.67s)
=== STEP  testing saml_provider_group destroy
--- PASS: TestAccAciSAMLProviderGroup_Negative (52.19s)
=== STEP  testing saml_provider_group destroy
--- PASS: TestAccAciSAMLProviderGroup_Basic (58.44s)
=== STEP  testing saml_provider destroy
--- PASS: TestAccAciSAMLProvider_Basic (63.56s)
=== STEP  testing saml_provider destroy
--- PASS: TestAccAciSAMLProvider_Update (93.72s)
=== STEP  testing saml_provider destroy
--- PASS: TestAccAciSAMLProvider_Negative (103.51s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   104.839s
