### PR TITLE
Aci span source group

### DIFF
--- a/aci/data_source_aci_aaarsaprovider.go
+++ b/aci/data_source_aci_aaarsaprovider.go
@@ -29,17 +29,7 @@ func dataSourceAciRSAProvider() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			"key": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
 			"monitor_server": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"monitoring_password": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,

--- a/testacc/data_source_aci_aaaldapprovider_test.go
+++ b/testacc/data_source_aci_aaaldapprovider_test.go
@@ -1,0 +1,187 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciLDAPProviderDataSource_Basic(t *testing.T) {
+	resourceName := "aci_ldap_provider.test"
+	dataSourceName := "data.aci_ldap_provider.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLDAPProviderDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateLDAPProviderDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateLDAPProviderDSWithoutRequired(rName, "type"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLDAPProviderConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "type", resourceName, "type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ssl_validation_level", resourceName, "ssl_validation_level"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "attribute", resourceName, "attribute"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "basedn", resourceName, "basedn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "enable_ssl", resourceName, "enable_ssl"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "filter", resourceName, "filter"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "monitor_server", resourceName, "monitor_server"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "monitoring_user", resourceName, "monitoring_user"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "port", resourceName, "port"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "retries", resourceName, "retries"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "rootdn", resourceName, "rootdn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "timeout", resourceName, "timeout"),
+				),
+			},
+			{
+				Config:      CreateAccLDAPProviderDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccLDAPProviderDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccLDAPProviderDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccLDAPProviderConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing ldap_provider Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_provider" "test" {
+	
+		name  = "%s"
+		type = "duo"
+	}
+
+	data "aci_ldap_provider" "test" {
+	
+		name  = aci_ldap_provider.test.name
+		type = aci_ldap_provider.test.type
+		depends_on = [ aci_ldap_provider.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateLDAPProviderDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing ldap_provider Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_ldap_provider" "test" {
+	
+		name  = "%s"
+		type = "duo"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_ldap_provider" "test" {
+	
+	#	name  = aci_ldap_provider.test.name
+		type = aci_ldap_provider.test.type
+		depends_on = [ aci_ldap_provider.test ]
+	}
+		`
+	case "type":
+		rBlock += `
+	data "aci_ldap_provider" "test" {
+	
+		name  = aci_ldap_provider.test.name
+	#	type = aci_ldap_provider.test.type
+		depends_on = [ aci_ldap_provider.test ]
+	}
+	`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccLDAPProviderDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing ldap_provider Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_provider" "test" {
+	
+		name  = "%s"
+		type = "duo"
+	}
+
+	data "aci_ldap_provider" "test" {
+	
+		name  = "${aci_ldap_provider.test.name}_invalid"
+		type = aci_ldap_provider.test.type
+		depends_on = [ aci_ldap_provider.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLDAPProviderDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing ldap_provider Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_provider" "test" {
+	
+		name  = "%s"
+		type = "duo"
+	}
+
+	data "aci_ldap_provider" "test" {
+	
+		name  = aci_ldap_provider.test.name
+		type = aci_ldap_provider.test.type
+		%s = "%s"
+		depends_on = [ aci_ldap_provider.test ]
+	}
+	`, rName, key, value)
+	return resource
+}
+
+func CreateAccLDAPProviderDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing ldap_provider Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_provider" "test" {
+	
+		name  = "%s"
+		type = "duo"
+		%s = "%s"
+	}
+
+	data "aci_ldap_provider" "test" {
+	
+		name  = aci_ldap_provider.test.name
+		type = aci_ldap_provider.test.type
+		depends_on = [ aci_ldap_provider.test ]
+	}
+	`, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_aaarsaprovider_test.go
+++ b/testacc/data_source_aci_aaarsaprovider_test.go
@@ -1,0 +1,161 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciRSAProviderDataSource_Basic(t *testing.T) {
+	resourceName := "aci_rsa_provider.test"
+	dataSourceName := "data.aci_rsa_provider.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciRSAProviderDestroy,
+		Steps: []resource.TestStep{
+			
+			{
+				Config:      CreateRSAProviderDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccRSAProviderConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "auth_port", resourceName, "auth_port"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "auth_protocol", resourceName, "auth_protocol"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "monitor_server", resourceName, "monitor_server"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "monitoring_user", resourceName, "monitoring_user"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "retries", resourceName, "retries"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "timeout", resourceName, "timeout"),
+					
+				),
+			},
+			{
+				Config:      CreateAccRSAProviderDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			
+			{
+				Config:      CreateAccRSAProviderDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccRSAProviderDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+
+func CreateAccRSAProviderConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing rsa_provider Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_rsa_provider" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_rsa_provider" "test" {
+	
+		name  = aci_rsa_provider.test.name
+		depends_on = [ aci_rsa_provider.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateRSAProviderDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing rsa_provider Data Source without ",attrName)
+	rBlock := `
+	
+	resource "aci_rsa_provider" "test" {
+	
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_rsa_provider" "test" {
+	
+	#	name  = aci_rsa_provider.test.name
+		depends_on = [ aci_rsa_provider.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock,rName)
+}
+
+
+func CreateAccRSAProviderDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing rsa_provider Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_rsa_provider" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_rsa_provider" "test" {
+	
+		name  = "${aci_rsa_provider.test.name}_invalid"
+		depends_on = [ aci_rsa_provider.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccRSAProviderDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing rsa_provider Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_rsa_provider" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_rsa_provider" "test" {
+	
+		name  = aci_rsa_provider.test.name
+		%s = "%s"
+		depends_on = [ aci_rsa_provider.test ]
+	}
+	`, rName,key,value)
+	return resource
+}
+
+func CreateAccRSAProviderDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing rsa_provider Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_rsa_provider" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_rsa_provider" "test" {
+	
+		name  = aci_rsa_provider.test.name
+		depends_on = [ aci_rsa_provider.test ]
+	}
+	`, rName,key,value)
+	return resource
+}

--- a/testacc/data_source_aci_firmwarefwp_test.go
+++ b/testacc/data_source_aci_firmwarefwp_test.go
@@ -1,0 +1,160 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciFirmwarePolicyDataSource_Basic(t *testing.T) {
+	resourceName := "aci_firmware_policy.test"
+	dataSourceName := "data.aci_firmware_policy.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciFirmwarePolicyDestroy,
+		Steps: []resource.TestStep{
+			
+			{
+				Config:      CreateFirmwarePolicyDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccFirmwarePolicyConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "effective_on_reboot", resourceName, "effective_on_reboot"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ignore_compat", resourceName, "ignore_compat"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "internal_label", resourceName, "internal_label"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "version", resourceName, "version"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "version_check_override", resourceName, "version_check_override"),
+					
+				),
+			},
+			{
+				Config:      CreateAccFirmwarePolicyDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			
+			{
+				Config:      CreateAccFirmwarePolicyDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccFirmwarePolicyDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+
+func CreateAccFirmwarePolicyConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing firmware_policy Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_firmware_policy" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_firmware_policy" "test" {
+	
+		name  = aci_firmware_policy.test.name
+		depends_on = [ aci_firmware_policy.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateFirmwarePolicyDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing firmware_policy Data Source without ",attrName)
+	rBlock := `
+	
+	resource "aci_firmware_policy" "test" {
+	
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_firmware_policy" "test" {
+	
+	#	name  = aci_firmware_policy.test.name
+		depends_on = [ aci_firmware_policy.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock,rName)
+}
+
+
+func CreateAccFirmwarePolicyDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing firmware_policy Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_firmware_policy" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_firmware_policy" "test" {
+	
+		name  = "${aci_firmware_policy.test.name}_invalid"
+		depends_on = [ aci_firmware_policy.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccFirmwarePolicyDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing firmware_policy Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_firmware_policy" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_firmware_policy" "test" {
+	
+		name  = aci_firmware_policy.test.name
+		%s = "%s"
+		depends_on = [ aci_firmware_policy.test ]
+	}
+	`, rName,key,value)
+	return resource
+}
+
+func CreateAccFirmwarePolicyDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing firmware_policy Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_firmware_policy" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_firmware_policy" "test" {
+	
+		name  = aci_firmware_policy.test.name
+		depends_on = [ aci_firmware_policy.test ]
+	}
+	`, rName,key,value)
+	return resource
+}

--- a/testacc/data_source_aci_spansrcgrp_test.go
+++ b/testacc/data_source_aci_spansrcgrp_test.go
@@ -1,0 +1,193 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciSPANSourceGroupDataSource_Basic(t *testing.T) {
+	resourceName := "aci_span_source_group.test"
+	dataSourceName := "data.aci_span_source_group.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciSPANSourceGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateSPANSourceGroupDSWithoutRequired(fvTenantName, rName,"tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateSPANSourceGroupDSWithoutRequired(fvTenantName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccSPANSourceGroupConfigDataSource(fvTenantName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "tenant_dn", resourceName, "tenant_dn",),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "admin_st", resourceName, "admin_st"),
+					
+				),
+			},
+			{
+				Config:      CreateAccSPANSourceGroupDataSourceUpdate(fvTenantName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			
+			{
+				Config:      CreateAccSPANSourceGroupDSWithInvalidName(fvTenantName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			
+			{
+				Config: CreateAccSPANSourceGroupDataSourceUpdatedResource(fvTenantName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+
+func CreateAccSPANSourceGroupConfigDataSource(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing span_source_group Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_span_source_group" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_span_source_group.test.name
+		depends_on = [ aci_span_source_group.test ]
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateSPANSourceGroupDSWithoutRequired(fvTenantName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing span_source_group Data Source without ",attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	data "aci_span_source_group" "test" {
+	#	tenant_dn  = aci_tenant.test.id
+		name  = aci_span_source_group.test.name
+		depends_on = [ aci_span_source_group.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_span_source_group" "test" {
+		tenant_dn  = aci_tenant.test.id
+	#	name  = aci_span_source_group.test.name
+		depends_on = [ aci_span_source_group.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock,fvTenantName, rName)
+}
+
+func CreateAccSPANSourceGroupDSWithInvalidName(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing span_source_group Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_span_source_group" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "${aci_span_source_group.test.name}_invalid"
+		depends_on = [ aci_span_source_group.test ]
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccSPANSourceGroupDataSourceUpdate(fvTenantName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing span_source_group Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+
+	data "aci_span_source_group" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_span_source_group.test.name
+		%s = "%s"
+		depends_on = [ aci_span_source_group.test ]
+	}
+	`, fvTenantName, rName,key,value)
+	return resource
+}
+
+func CreateAccSPANSourceGroupDataSourceUpdatedResource(fvTenantName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing span_source_group Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_span_source_group" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = aci_span_source_group.test.name
+		depends_on = [ aci_span_source_group.test ]
+	}
+	`, fvTenantName, rName,key,value)
+	return resource
+}

--- a/testacc/resource_aci_aaaldapprovider_test.go
+++ b/testacc/resource_aci_aaaldapprovider_test.go
@@ -1,0 +1,499 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciLDAPProvider_Basic(t *testing.T) {
+	var ldap_provider_default models.LDAPProvider
+	var ldap_provider_updated models.LDAPProvider
+	resourceName := "aci_ldap_provider.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLDAPProviderDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateLDAPProviderWithoutRequired(rName, "duo", "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateLDAPProviderWithoutRequired(rName, "duo", "type"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLDAPProviderConfig(rName, "duo"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPProviderExists(resourceName, &ldap_provider_default),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "duo"),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "attribute", "CiscoAVPair"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "ssl_validation_level", "strict"),
+					resource.TestCheckResourceAttr(resourceName, "basedn", ""),
+					resource.TestCheckResourceAttr(resourceName, "enable_ssl", "no"),
+					resource.TestCheckResourceAttr(resourceName, "filter", "sAMAccountName=$userid"),
+					resource.TestCheckResourceAttr(resourceName, "monitor_server", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_user", "default"),
+					resource.TestCheckResourceAttr(resourceName, "port", "389"),
+					resource.TestCheckResourceAttr(resourceName, "retries", "1"),
+					resource.TestCheckResourceAttr(resourceName, "rootdn", ""),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "30"),
+				),
+			},
+			{
+				Config: CreateAccLDAPProviderConfigWithOptionalValues(rName, "duo"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPProviderExists(resourceName, &ldap_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_ldap_provider"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_validation_level", "permissive"),
+					resource.TestCheckResourceAttr(resourceName, "type", "duo"),
+					resource.TestCheckResourceAttr(resourceName, "attribute", "memberOf"),
+					resource.TestCheckResourceAttr(resourceName, "basedn", "CN=Users,DC=host,DC=com"),
+					resource.TestCheckResourceAttr(resourceName, "enable_ssl", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "filter", "cn=$userid"),
+					resource.TestCheckResourceAttr(resourceName, "key", "test_key"),
+					resource.TestCheckResourceAttr(resourceName, "monitor_server", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_password", "test_password"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_user", "test_user"),
+					resource.TestCheckResourceAttr(resourceName, "port", "1"),
+					resource.TestCheckResourceAttr(resourceName, "retries", "5"),
+					resource.TestCheckResourceAttr(resourceName, "rootdn", "CN=admin,CN=Users,DC=host,DC=com"),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "60"),
+					testAccCheckAciLDAPProviderIdEqual(&ldap_provider_default, &ldap_provider_updated),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"key", "monitoring_password"},
+			},
+			{
+				Config:      CreateAccLDAPProviderConfigUpdatedName(acctest.RandString(65), "duo"),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			{
+				Config:      CreateAccLDAPProviderConfigWithRequiredParams(rName, rName),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccLDAPProviderRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+
+			{
+				Config: CreateAccLDAPProviderConfigWithRequiredParams(rNameUpdated, "duo"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPProviderExists(resourceName, &ldap_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "type", "duo"),
+					testAccCheckAciLDAPProviderIdNotEqual(&ldap_provider_default, &ldap_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccLDAPProviderConfig(rName, "duo"),
+			},
+			{
+				Config: CreateAccLDAPProviderConfigWithRequiredParams(rName, "ldap"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPProviderExists(resourceName, &ldap_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "ldap"),
+					testAccCheckAciLDAPProviderIdNotEqual(&ldap_provider_default, &ldap_provider_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciLDAPProvider_Update(t *testing.T) {
+	var ldap_provider_default models.LDAPProvider
+	var ldap_provider_updated models.LDAPProvider
+	resourceName := "aci_ldap_provider.test"
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLDAPProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLDAPProviderConfig(rName, "ldap"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPProviderExists(resourceName, &ldap_provider_default),
+				),
+			},
+			{
+				Config: CreateAccLDAPProviderUpdatedAttr(rName, "ldap", "port", "65535"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPProviderExists(resourceName, &ldap_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "port", "65535"),
+					testAccCheckAciLDAPProviderIdEqual(&ldap_provider_default, &ldap_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccLDAPProviderUpdatedAttr(rName, "ldap", "port", "32767"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPProviderExists(resourceName, &ldap_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "port", "32767"),
+					testAccCheckAciLDAPProviderIdEqual(&ldap_provider_default, &ldap_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccLDAPProviderUpdatedAttr(rName, "ldap", "retries", "2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPProviderExists(resourceName, &ldap_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "retries", "2"),
+					testAccCheckAciLDAPProviderIdEqual(&ldap_provider_default, &ldap_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccLDAPProviderUpdatedAttr(rName, "ldap", "timeout", "5"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPProviderExists(resourceName, &ldap_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "5"),
+					testAccCheckAciLDAPProviderIdEqual(&ldap_provider_default, &ldap_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccLDAPProviderConfig(rName, "ldap"),
+			},
+		},
+	})
+}
+
+func TestAccAciLDAPProvider_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLDAPProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLDAPProviderConfig(rName, "duo"),
+			},
+
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "ssl_validation_level", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "attribute", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "basedn", acctest.RandString(128)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "enable_ssl", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "filter", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "monitor_server", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "monitoring_user", acctest.RandString(33)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "port", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "port", "0"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "port", "65536"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "retries", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "retries", "0"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "retries", "6"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "rootdn", acctest.RandString(128)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "timeout", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "timeout", "4"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", "timeout", "61"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccLDAPProviderUpdatedAttr(rName, "duo", randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccLDAPProviderConfig(rName, "duo"),
+			},
+		},
+	})
+}
+
+func testAccCheckAciLDAPProviderExists(name string, ldap_provider *models.LDAPProvider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("LDAP Provider %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No LDAP Provider dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		ldap_providerFound := models.LDAPProviderFromContainer(cont)
+		if ldap_providerFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("LDAP Provider %s not found", rs.Primary.ID)
+		}
+		*ldap_provider = *ldap_providerFound
+		return nil
+	}
+}
+
+func testAccCheckAciLDAPProviderDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing ldap_provider destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_ldap_provider" {
+			cont, err := client.Get(rs.Primary.ID)
+			ldap_provider := models.LDAPProviderFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("LDAP Provider %s Still exists", ldap_provider.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciLDAPProviderIdEqual(m1, m2 *models.LDAPProvider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("ldap_provider DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciLDAPProviderIdNotEqual(m1, m2 *models.LDAPProvider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("ldap_provider DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateLDAPProviderWithoutRequired(rName, proType, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing ldap_provider creation without ", attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_ldap_provider" "test" {
+	
+	#	name  = "%s"
+		type = "%s"
+	}
+		`
+	case "type":
+		rBlock += `
+	resource "aci_ldap_provider" "test" {
+	
+		name  = "%s"
+	#	type = "%s"
+	}
+	`
+	}
+	return fmt.Sprintf(rBlock, rName, proType)
+}
+
+func CreateAccLDAPProviderConfigWithRequiredParams(rName, proType string) string {
+	fmt.Printf("=== STEP  testing ldap_provider creation with name %s and type %s\n", rName, proType)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_provider" "test" {
+	
+		name  = "%s"
+		type = "%s"
+	}
+	`, rName, proType)
+	return resource
+}
+func CreateAccLDAPProviderConfigUpdatedName(rName, proType string) string {
+	fmt.Println("=== STEP  testing ldap_provider creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_provider" "test" {
+	
+		name  = "%s"
+		type = "%s"
+	}
+	`, rName, proType)
+	return resource
+}
+
+func CreateAccLDAPProviderConfig(rName, proType string) string {
+	fmt.Println("=== STEP  testing ldap_provider creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_provider" "test" {
+	
+		name  = "%s"
+		type = "%s"
+	}
+	`, rName, proType)
+	return resource
+}
+
+func CreateAccLDAPProviderConfigWithOptionalValues(rName, proType string) string {
+	fmt.Println("=== STEP  Basic: testing ldap_provider creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_provider" "test" {
+	
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_ldap_provider"
+		ssl_validation_level = "permissive"
+		attribute = "memberOf"
+		basedn = "CN=Users,DC=host,DC=com"
+		enable_ssl = "yes"
+		filter = "cn=$userid"
+		key = "test_key"
+		monitor_server = "enabled"
+		monitoring_password = "test_password"
+		monitoring_user = "test_user"
+		port = "1"
+		retries = "5"
+		rootdn = "CN=admin,CN=Users,DC=host,DC=com"
+		timeout = "60"
+		type = "%s"
+	}
+	`, rName, proType)
+
+	return resource
+}
+
+func CreateAccLDAPProviderRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing ldap_provider updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_ldap_provider" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_ldap_provider"
+		ssl_validation_level = "permissive"
+		attribute = ""
+		basedn = ""
+		enable_ssl = "yes"
+		filter = ""
+		key = ""
+		monitor_server = "enabled"
+		monitoring_password = ""
+		monitoring_user = ""
+		port = "2"
+		retries = "1"
+		rootdn = ""
+		timeout = "6"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccLDAPProviderUpdatedAttr(rName, proType, attribute, value string) string {
+	fmt.Printf("=== STEP  testing ldap_provider attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_ldap_provider" "test" {
+	
+		name  = "%s"
+		type = "%s"
+		%s = "%s"
+	}
+	`, rName, proType, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_aaarsaprovider_test.go
+++ b/testacc/resource_aci_aaarsaprovider_test.go
@@ -1,0 +1,477 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciRSAProvider_Basic(t *testing.T) {
+	var rsa_provider_default models.RSAProvider
+	var rsa_provider_updated models.RSAProvider
+	resourceName := "aci_rsa_provider.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciRSAProviderDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateRSAProviderWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccRSAProviderConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRSAProviderExists(resourceName, &rsa_provider_default),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "auth_port", "1812"),
+					resource.TestCheckResourceAttr(resourceName, "auth_protocol", "pap"),
+					resource.TestCheckResourceAttr(resourceName, "monitor_server", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_user", "default"),
+					resource.TestCheckResourceAttr(resourceName, "retries", "1"),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "5"),
+				),
+			},
+			{
+				Config: CreateAccRSAProviderConfigWithOptionalValues(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRSAProviderExists(resourceName, &rsa_provider_updated),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_rsa_provider"),
+					resource.TestCheckResourceAttr(resourceName, "auth_port", "1"),
+					resource.TestCheckResourceAttr(resourceName, "auth_protocol", "chap"),
+					resource.TestCheckResourceAttr(resourceName, "key", "test_key"),
+					resource.TestCheckResourceAttr(resourceName, "monitor_server", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_password", "test_password"),
+					resource.TestCheckResourceAttr(resourceName, "monitoring_user", "test_user"),
+					resource.TestCheckResourceAttr(resourceName, "retries", "5"),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "1"),
+					testAccCheckAciRSAProviderIdEqual(&rsa_provider_default, &rsa_provider_updated),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"key", "monitoring_password"},
+			},
+			{
+				Config:      CreateAccRSAProviderConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccRSAProviderRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+
+			{
+				Config: CreateAccRSAProviderConfigWithRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRSAProviderExists(resourceName, &rsa_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciRSAProviderIdNotEqual(&rsa_provider_default, &rsa_provider_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciRSAProvider_Update(t *testing.T) {
+	var rsa_provider_default models.RSAProvider
+	var rsa_provider_updated models.RSAProvider
+	resourceName := "aci_rsa_provider.test"
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciRSAProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccRSAProviderConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRSAProviderExists(resourceName, &rsa_provider_default),
+				),
+			},
+			{
+				Config: CreateAccRSAProviderUpdatedAttr(rName, "auth_port", "65535"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRSAProviderExists(resourceName, &rsa_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "auth_port", "65535"),
+					testAccCheckAciRSAProviderIdEqual(&rsa_provider_default, &rsa_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccRSAProviderUpdatedAttr(rName, "auth_port", "32767"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRSAProviderExists(resourceName, &rsa_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "auth_port", "32767"),
+					testAccCheckAciRSAProviderIdEqual(&rsa_provider_default, &rsa_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccRSAProviderUpdatedAttr(rName, "auth_protocol", "mschap"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRSAProviderExists(resourceName, &rsa_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "auth_protocol", "mschap"),
+					testAccCheckAciRSAProviderIdEqual(&rsa_provider_default, &rsa_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccRSAProviderUpdatedAttr(rName, "retries", "2"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRSAProviderExists(resourceName, &rsa_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "retries", "2"),
+					testAccCheckAciRSAProviderIdEqual(&rsa_provider_default, &rsa_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccRSAProviderUpdatedAttr(rName, "timeout", "60"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRSAProviderExists(resourceName, &rsa_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "60"),
+					testAccCheckAciRSAProviderIdEqual(&rsa_provider_default, &rsa_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccRSAProviderUpdatedAttr(rName, "timeout", "30"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciRSAProviderExists(resourceName, &rsa_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "30"),
+					testAccCheckAciRSAProviderIdEqual(&rsa_provider_default, &rsa_provider_updated),
+				),
+			},
+
+			{
+				Config: CreateAccRSAProviderConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciRSAProvider_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciRSAProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccRSAProviderConfig(rName),
+			},
+
+			{
+				Config:      CreateAccRSAProviderUpdatedAttr(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccRSAProviderUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccRSAProviderUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccRSAProviderUpdatedAttr(rName, "auth_port", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccRSAProviderUpdatedAttr(rName, "auth_port", "0"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccRSAProviderUpdatedAttr(rName, "auth_port", "65536"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccRSAProviderUpdatedAttr(rName, "auth_protocol", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccRSAProviderUpdatedAttr(rName, "monitor_server", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccRSAProviderUpdatedAttr(rName, "monitoring_user", acctest.RandString(33)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccRSAProviderUpdatedAttr(rName, "retries", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccRSAProviderUpdatedAttr(rName, "retries", "0"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccRSAProviderUpdatedAttr(rName, "retries", "6"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccRSAProviderUpdatedAttr(rName, "timeout", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccRSAProviderUpdatedAttr(rName, "timeout", "0"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccRSAProviderUpdatedAttr(rName, "timeout", "61"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccRSAProviderUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccRSAProviderConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciRSAProvider_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciRSAProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccRSAProviderConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciRSAProviderExists(name string, rsa_provider *models.RSAProvider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("RSA Provider %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No RSA Provider dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		rsa_providerFound := models.RSAProviderFromContainer(cont)
+		if rsa_providerFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("RSA Provider %s not found", rs.Primary.ID)
+		}
+		*rsa_provider = *rsa_providerFound
+		return nil
+	}
+}
+
+func testAccCheckAciRSAProviderDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing rsa_provider destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_rsa_provider" {
+			cont, err := client.Get(rs.Primary.ID)
+			rsa_provider := models.RSAProviderFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("RSA Provider %s Still exists", rsa_provider.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciRSAProviderIdEqual(m1, m2 *models.RSAProvider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("rsa_provider DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciRSAProviderIdNotEqual(m1, m2 *models.RSAProvider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("rsa_provider DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateRSAProviderWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing rsa_provider creation without ", attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_rsa_provider" "test" {
+	
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccRSAProviderConfigWithRequiredParams(rName string) string {
+	fmt.Println("=== STEP  testing rsa_provider creation with name =", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_rsa_provider" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+func CreateAccRSAProviderConfigUpdatedName(rName string) string {
+	fmt.Println("=== STEP  testing rsa_provider creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_rsa_provider" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccRSAProviderConfig(rName string) string {
+	fmt.Println("=== STEP  testing rsa_provider creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_rsa_provider" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccRSAProviderConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple rsa_provider creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_rsa_provider" "test" {
+	
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccRSAProviderConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing rsa_provider creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_rsa_provider" "test" {
+	
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_rsa_provider"
+		auth_port = "1"
+		auth_protocol = "chap"
+		key = "test_key"
+		monitor_server = "enabled"
+		monitoring_password = "test_password"
+		monitoring_user = "test_user"
+		retries = "5"
+		timeout = "1"
+		
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccRSAProviderRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing rsa_provider updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_rsa_provider" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_rsa_provider"
+		auth_port = "2"
+		auth_protocol = "chap"
+		key = ""
+		monitor_server = "enabled"
+		monitoring_password = ""
+		monitoring_user = ""
+		retries = "1"
+		timeout = "1"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccRSAProviderUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing rsa_provider attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_rsa_provider" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName, attribute, value)
+	return resource
+}
+
+func CreateAccRSAProviderUpdatedAttrList(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing rsa_provider attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_rsa_provider" "test" {
+	
+		name  = "%s"
+		%s = %s
+	}
+	`, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_aaasamlprovider_test.go
+++ b/testacc/resource_aci_aaasamlprovider_test.go
@@ -168,7 +168,14 @@ func TestAccAciSAMLProvider_Update(t *testing.T) {
 					testAccCheckAciSAMLProviderIdEqual(&saml_provider_default, &saml_provider_updated),
 				),
 			},
-
+			{
+				Config: CreateAccSAMLProviderUpdatedAttr(rName, "id_p", "ping identity"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSAMLProviderExists(resourceName, &saml_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "id_p", "ping identity"),
+					testAccCheckAciSAMLProviderIdEqual(&saml_provider_default, &saml_provider_updated),
+				),
+			},
 			{
 				Config: CreateAccSAMLProviderConfig(rName),
 			},

--- a/testacc/resource_aci_aaauserep_test.go
+++ b/testacc/resource_aci_aaauserep_test.go
@@ -128,10 +128,10 @@ func TestAccAciWebTokenData_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: CreateAccWebTokenDataUpdatedAttr("pwd_strength_check", "no"),
+				Config: CreateAccWebTokenDataUpdatedAttr("pwd_strength_check", "yes"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
-					resource.TestCheckResourceAttr(resourceName, "pwd_strength_check", "no"),
+					resource.TestCheckResourceAttr(resourceName, "pwd_strength_check", "yes"),
 					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
 				),
 			},
@@ -180,6 +180,14 @@ func TestAccAciWebTokenData_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
 					resource.TestCheckResourceAttr(resourceName, "expiration_warn_time", "15"),
+					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
+				),
+			},
+			{
+				Config: CreateAccWebTokenDataUpdatedAttr("expiration_warn_time", "30"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciWebTokenDataExists(resourceName, &global_security_updated),
+					resource.TestCheckResourceAttr(resourceName, "expiration_warn_time", "30"),
 					testAccCheckAciWebTokenDataIdEqual(&global_security_default, &global_security_updated),
 				),
 			},
@@ -538,6 +546,10 @@ func TestAccAciWebTokenData_Negative(t *testing.T) {
 				ExpectError: regexp.MustCompile(`duplication is not supported in list`),
 			},
 			{
+				Config:      CreateAccWebTokenDataUpdatedAttrList("session_record_flags", StringListtoString([]string{randomValue})),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
 				Config:      CreateAccWebTokenDataUpdatedAttr(randomParameter, randomValue),
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
 			},
@@ -566,9 +578,11 @@ func restoreGlobalUser(aaaUserEp *models.UserManagement, aaaPwdProfile *models.P
 		max_failed_attempts = "%s"
 		max_failed_attempts_window = "%s"
 		maximum_validity_period = "%s"
+		ui_idle_timeout_seconds = "%s"
+		webtoken_timeout_seconds = "%s"
 		session_record_flags = %s
 	}
-	`, aaaUserEp.Annotation, aaaUserEp.Description, aaaUserEp.NameAlias, aaaUserEp.PwdStrengthCheck, aaaPwdProfile.ChangeCount, aaaPwdProfile.ChangeDuringInterval, aaaPwdProfile.ChangeInterval, aaaPwdProfile.ExpirationWarnTime, aaaPwdProfile.HistoryCount, aaaPwdProfile.NoChangeInterval, aaaBlockLoginProfile.BlockDuration, aaaBlockLoginProfile.EnableLoginBlock, aaaBlockLoginProfile.MaxFailedAttempts, aaaBlockLoginProfile.MaxFailedAttemptsWindow, pkiWebTokenData.MaximumValidityPeriod, StringListtoString(convertToStringArray(pkiWebTokenData.SessionRecordFlags)))
+	`, aaaUserEp.Annotation, aaaUserEp.Description, aaaUserEp.NameAlias, aaaUserEp.PwdStrengthCheck, aaaPwdProfile.ChangeCount, aaaPwdProfile.ChangeDuringInterval, aaaPwdProfile.ChangeInterval, aaaPwdProfile.ExpirationWarnTime, aaaPwdProfile.HistoryCount, aaaPwdProfile.NoChangeInterval, aaaBlockLoginProfile.BlockDuration, aaaBlockLoginProfile.EnableLoginBlock, aaaBlockLoginProfile.MaxFailedAttempts, aaaBlockLoginProfile.MaxFailedAttemptsWindow, pkiWebTokenData.MaximumValidityPeriod, pkiWebTokenData.UiIdleTimeoutSeconds, pkiWebTokenData.WebtokenTimeoutSeconds, StringListtoString(convertToStringArray(pkiWebTokenData.SessionRecordFlags)))
 	return resource
 }
 

--- a/testacc/resource_aci_firmwarefwp_test.go
+++ b/testacc/resource_aci_firmwarefwp_test.go
@@ -1,0 +1,408 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciFirmwarePolicy_Basic(t *testing.T) {
+	var firmware_policy_default models.FirmwarePolicy
+	var firmware_policy_updated models.FirmwarePolicy
+	resourceName := "aci_firmware_policy.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciFirmwarePolicyDestroy,
+		Steps: []resource.TestStep{
+			
+			{
+				Config:      CreateFirmwarePolicyWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccFirmwarePolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFirmwarePolicyExists(resourceName, &firmware_policy_default),
+					
+					resource.TestCheckResourceAttr(resourceName, "name",rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation","orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description",""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias",""),
+					resource.TestCheckResourceAttr(resourceName, "effective_on_reboot", "no"),
+					resource.TestCheckResourceAttr(resourceName, "ignore_compat", "no"),
+					resource.TestCheckResourceAttr(resourceName, "internal_label", ""),
+					resource.TestCheckResourceAttr(resourceName, "version", ""),
+					resource.TestCheckResourceAttr(resourceName, "version_check_override", "untriggered"),
+					
+				),
+			},
+			{
+				Config: CreateAccFirmwarePolicyConfigWithOptionalValues(rName), 
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFirmwarePolicyExists(resourceName, &firmware_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "name",rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_firmware_policy"),
+					resource.TestCheckResourceAttr(resourceName, "effective_on_reboot", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "ignore_compat", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "internal_label", "internal_label_test"),					
+					resource.TestCheckResourceAttr(resourceName, "version", "n9000-14.2(3q)"),
+					resource.TestCheckResourceAttr(resourceName, "version_check_override", "trigger"),
+					testAccCheckAciFirmwarePolicyIdEqual(&firmware_policy_default, &firmware_policy_updated),
+				),
+			},  
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccFirmwarePolicyConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			
+			{
+				Config:      CreateAccFirmwarePolicyRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			
+			{
+				Config: CreateAccFirmwarePolicyConfigWithRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFirmwarePolicyExists(resourceName, &firmware_policy_updated),
+					
+					resource.TestCheckResourceAttr(resourceName, "name",rNameUpdated),
+					testAccCheckAciFirmwarePolicyIdNotEqual(&firmware_policy_default, &firmware_policy_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciFirmwarePolicy_Update(t *testing.T) {
+	var firmware_policy_default models.FirmwarePolicy
+	var firmware_policy_updated models.FirmwarePolicy
+	resourceName := "aci_firmware_policy.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciFirmwarePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccFirmwarePolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFirmwarePolicyExists(resourceName, &firmware_policy_default),
+				),
+			},
+			
+			{
+				Config: CreateAccFirmwarePolicyUpdatedAttr(rName, "version_check_override", "trigger-immediate"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFirmwarePolicyExists(resourceName, &firmware_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "version_check_override", "trigger-immediate"),
+					testAccCheckAciFirmwarePolicyIdEqual(&firmware_policy_default, &firmware_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccFirmwarePolicyUpdatedAttr(rName, "version_check_override", "triggered"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFirmwarePolicyExists(resourceName, &firmware_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "version_check_override", "triggered"),
+					testAccCheckAciFirmwarePolicyIdEqual(&firmware_policy_default, &firmware_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccFirmwarePolicyConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciFirmwarePolicy_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciFirmwarePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccFirmwarePolicyConfig(rName),
+			},
+			
+			{
+				Config:      CreateAccFirmwarePolicyUpdatedAttr(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccFirmwarePolicyUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccFirmwarePolicyUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			
+			{
+				Config:      CreateAccFirmwarePolicyUpdatedAttr(rName, "effective_on_reboot", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			
+			{
+				Config:      CreateAccFirmwarePolicyUpdatedAttr(rName, "ignore_compat", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			
+			{
+				Config:      CreateAccFirmwarePolicyUpdatedAttr(rName, "internal_label", acctest.RandString(513)),
+				ExpectError: regexp.MustCompile(`failed validation for value`),
+			},
+			
+			{
+				Config:      CreateAccFirmwarePolicyUpdatedAttr(rName, "version", acctest.RandString(513)),
+				ExpectError: regexp.MustCompile(`failed validation for value`),
+			},
+			
+			{
+				Config:      CreateAccFirmwarePolicyUpdatedAttr(rName, "version_check_override", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			
+			{
+				Config:      CreateAccFirmwarePolicyUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccFirmwarePolicyConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciFirmwarePolicy_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciFirmwarePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccFirmwarePolicyConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciFirmwarePolicyExists(name string, firmware_policy *models.FirmwarePolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Firmware Policy %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Firmware Policy dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		firmware_policyFound := models.FirmwarePolicyFromContainer(cont)
+		if firmware_policyFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Firmware Policy %s not found", rs.Primary.ID)
+		}
+		*firmware_policy = *firmware_policyFound
+		return nil
+	}
+}
+
+func testAccCheckAciFirmwarePolicyDestroy(s *terraform.State) error {	
+	fmt.Println("=== STEP  testing firmware_policy destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		 if rs.Type == "aci_firmware_policy" {
+			cont,err := client.Get(rs.Primary.ID)
+			firmware_policy := models.FirmwarePolicyFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Firmware Policy %s Still exists",firmware_policy.DistinguishedName)
+			}
+		}else{
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciFirmwarePolicyIdEqual(m1, m2 *models.FirmwarePolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("firmware_policy DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciFirmwarePolicyIdNotEqual(m1, m2 *models.FirmwarePolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("firmware_policy DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateFirmwarePolicyWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing firmware_policy creation without ",attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_firmware_policy" "test" {
+	
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock,rName)
+}
+
+func CreateAccFirmwarePolicyConfigWithRequiredParams(rName string) string {
+	fmt.Println("=== STEP  testing firmware_policy creation with name =",rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_firmware_policy" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+func CreateAccFirmwarePolicyConfigUpdatedName(rName string) string {
+	fmt.Println("=== STEP  testing firmware_policy creation with invalid name = ",rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_firmware_policy" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccFirmwarePolicyConfig(rName string) string {
+	fmt.Println("=== STEP  testing firmware_policy creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_firmware_policy" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccFirmwarePolicyConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple firmware_policy creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_firmware_policy" "test" {
+	
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+
+
+func CreateAccFirmwarePolicyConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing firmware_policy creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_firmware_policy" "test" {
+	
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_firmware_policy"
+		effective_on_reboot = "yes"
+		ignore_compat = "yes"
+		internal_label = "internal_label_test"
+		version = "n9000-14.2(3q)"
+		version_check_override = "trigger"
+		
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccFirmwarePolicyRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing firmware_policy updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_firmware_policy" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_firmware_policy"
+		effective_on_reboot = "yes"
+		ignore_compat = "yes"
+		internal_label = ""
+		version = ""
+		version_check_override = "trigger"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccFirmwarePolicyUpdatedAttr(rName,attribute,value string) string {
+	fmt.Printf("=== STEP  testing firmware_policy attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_firmware_policy" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName,attribute,value)
+	return resource
+}
+
+func CreateAccFirmwarePolicyUpdatedAttrList(rName,attribute,value string) string {
+	fmt.Printf("=== STEP  testing firmware_policy attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_firmware_policy" "test" {
+	
+		name  = "%s"
+		%s = %s
+	}
+	`, rName,attribute,value)
+	return resource
+}

--- a/testacc/resource_aci_spansrcgrp_test.go
+++ b/testacc/resource_aci_spansrcgrp_test.go
@@ -1,0 +1,396 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciSPANSourceGroup_Basic(t *testing.T) {
+	var span_source_group_default models.SPANSourceGroup
+	var span_source_group_updated models.SPANSourceGroup
+	resourceName := "aci_span_source_group.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSPANSourceGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateSPANSourceGroupWithoutRequired(fvTenantName, rName, "tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateSPANSourceGroupWithoutRequired(fvTenantName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccSPANSourceGroupConfig(fvTenantName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSPANSourceGroupExists(resourceName, &span_source_group_default),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", fvTenantName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "admin_st", "enabled"),
+				),
+			},
+			{
+				Config: CreateAccSPANSourceGroupConfigWithOptionalValues(fvTenantName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSPANSourceGroupExists(resourceName, &span_source_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", fvTenantName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_span_source_group"),
+					resource.TestCheckResourceAttr(resourceName, "admin_st", "disabled"),
+					testAccCheckAciSPANSourceGroupIdEqual(&span_source_group_default, &span_source_group_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccSPANSourceGroupConfigUpdatedName(fvTenantName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccSPANSourceGroupRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccSPANSourceGroupConfigWithRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSPANSourceGroupExists(resourceName, &span_source_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciSPANSourceGroupIdNotEqual(&span_source_group_default, &span_source_group_updated),
+				),
+			},
+			{
+				Config: CreateAccSPANSourceGroupConfig(fvTenantName, rName),
+			},
+			{
+				Config: CreateAccSPANSourceGroupConfigWithRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSPANSourceGroupExists(resourceName, &span_source_group_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciSPANSourceGroupIdNotEqual(&span_source_group_default, &span_source_group_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciSPANSourceGroup_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSPANSourceGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccSPANSourceGroupConfig(fvTenantName, rName),
+			},
+			{
+				Config:      CreateAccSPANSourceGroupWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccSPANSourceGroupUpdatedAttr(fvTenantName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccSPANSourceGroupUpdatedAttr(fvTenantName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccSPANSourceGroupUpdatedAttr(fvTenantName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccSPANSourceGroupUpdatedAttr(fvTenantName, rName, "admin_st", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccSPANSourceGroupUpdatedAttr(fvTenantName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccSPANSourceGroupConfig(fvTenantName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciSPANSourceGroup_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSPANSourceGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccSPANSourceGroupConfigMultiple(fvTenantName, rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciSPANSourceGroupExists(name string, span_source_group *models.SPANSourceGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("SPAN Source Group %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No SPAN Source Group dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		span_source_groupFound := models.SPANSourceGroupFromContainer(cont)
+		if span_source_groupFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("SPAN Source Group %s not found", rs.Primary.ID)
+		}
+		*span_source_group = *span_source_groupFound
+		return nil
+	}
+}
+
+func testAccCheckAciSPANSourceGroupDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing span_source_group destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_span_source_group" {
+			cont, err := client.Get(rs.Primary.ID)
+			span_source_group := models.SPANSourceGroupFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("SPAN Source Group %s Still exists", span_source_group.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciSPANSourceGroupIdEqual(m1, m2 *models.SPANSourceGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("span_source_group DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciSPANSourceGroupIdNotEqual(m1, m2 *models.SPANSourceGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("span_source_group DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateSPANSourceGroupWithoutRequired(fvTenantName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing span_source_group creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		
+	}
+	
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	resource "aci_span_source_group" "test" {
+	#	tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_span_source_group" "test" {
+		tenant_dn  = aci_tenant.test.id
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, rName)
+}
+
+func CreateAccSPANSourceGroupConfigWithRequiredParams(prName, rName string) string {
+	fmt.Printf("=== STEP  testing span_source_group creation with parent resource name %s and resource name %s\n", prName, rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, prName, rName)
+	return resource
+}
+func CreateAccSPANSourceGroupConfigUpdatedName(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing span_source_group creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccSPANSourceGroupConfig(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing span_source_group creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccSPANSourceGroupConfigMultiple(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  testing multiple span_source_group creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, fvTenantName, rName)
+	return resource
+}
+
+func CreateAccSPANSourceGroupWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing span_source_group creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_application_profile" "test" {
+		tenant_dn = aci_tenant.test.id
+		name = "%s"
+	}
+	resource "aci_span_source_group" "test" {
+		tenant_dn  = aci_application_profile.test.id
+		name  = "%s"	
+	}
+	`, rName, rName, rName)
+	return resource
+}
+
+func CreateAccSPANSourceGroupConfigWithOptionalValues(fvTenantName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing span_source_group creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		tenant_dn  = "${aci_tenant.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_span_source_group"
+		admin_st = "disabled"
+		
+	}
+	`, fvTenantName, rName)
+
+	return resource
+}
+
+func CreateAccSPANSourceGroupRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing span_source_group updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_span_source_group" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_span_source_group"
+		admin_st = "disabled"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccSPANSourceGroupUpdatedAttr(fvTenantName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing span_source_group attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		tenant_dn  = aci_tenant.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, fvTenantName, rName, attribute, value)
+	return resource
+}

--- a/website/docs/d/rsa_provider.html.markdown
+++ b/website/docs/d/rsa_provider.html.markdown
@@ -42,9 +42,7 @@ data "aci_rsa_provider" "example" {
 * `description` - (Optional) Description of object RSA Provider.
 * `auth_port` - (Optional) Port. 
 * `auth_protocol` - (Optional) Authentication Protocol. 
-* `key` - (Optional) Key. A password for the AAA provider database.
 * `monitor_server` - (Optional) Periodic Server Monitoring. 
-* `monitoring_password` - (Optional) Periodic Server Monitoring Password. 
 * `monitoring_user` - (Optional) Periodic Server Monitoring Username. 
 * `retries` - (Optional) Retries. null
 * `timeout` - (Optional) Timeout in Seconds. The amount of time between authentication attempts.


### PR DESCRIPTION
=== RUN   TestAccAciWebTokenDataDataSource_Basic
=== STEP  testing global_security Data Source with required arguments only
=== STEP  testing global_security Data Source with random attribute
=== STEP  testing global_security Data Source with updated resource
--- PASS: TestAccAciWebTokenDataDataSource_Basic (36.89s)
=== RUN   TestAccAciWebTokenData_Basic
=== STEP  testing global_security creation with required arguments only
=== STEP  Basic: testing global_security creation with optional parameters
--- PASS: TestAccAciWebTokenData_Basic (41.43s)
=== RUN   TestAccAciWebTokenData_Update
=== STEP  testing global_security creation with required arguments only
=== STEP  testing global_security attribute: pwd_strength_check = yes
=== STEP  testing global_security attribute: change_count = 10
=== STEP  testing global_security attribute: change_count = 5
=== STEP  testing global_security attribute: change_during_interval = enable
=== STEP  testing global_security attribute: change_interval = 745
=== STEP  testing global_security attribute: change_interval = 372
=== STEP  testing global_security attribute: expiration_warn_time = 15
=== STEP  testing global_security attribute: expiration_warn_time = 30
=== STEP  testing global_security attribute: history_count = 15
=== STEP  testing global_security attribute: history_count = 7
=== STEP  testing global_security attribute: no_change_interval = 745
=== STEP  testing global_security attribute: no_change_interval = 372
=== STEP  testing global_security attribute: block_duration = 1440
=== STEP  testing global_security attribute: block_duration = 720
=== STEP  testing global_security attribute: enable_login_block = enable
=== STEP  testing global_security attribute: max_failed_attempts = 15
=== STEP  testing global_security attribute: max_failed_attempts = 7
=== STEP  testing global_security attribute: max_failed_attempts_window = 720
=== STEP  testing global_security attribute: max_failed_attempts_window = 360
=== STEP  testing global_security attribute: maximum_validity_period = 24
=== STEP  testing global_security attribute: maximum_validity_period = 14
=== STEP  testing global_security attribute: ui_idle_timeout_seconds = 32000
=== STEP  testing global_security attribute: ui_idle_timeout_seconds = 65525
=== STEP  testing global_security attribute: webtoken_timeout_seconds = 4545
=== STEP  testing global_security attribute: webtoken_timeout_seconds = 9600
=== STEP  testing global_security attribute: session_record_flags = ["refresh","logout","login"]
=== STEP  testing global_security attribute: session_record_flags = ["login","logout","refresh"]
--- PASS: TestAccAciWebTokenData_Update (323.62s)
=== RUN   TestAccAciWebTokenData_Negative
=== STEP  testing global_security creation with required arguments only
=== STEP  testing global_security attribute: description = s7opcpzkckgmvg9a3pfkp3e7yh9dg6i8zkcqbuiw48fccjoslxvtuli78vtoylhidlvks24v3hngjpyze17v78v34t70poll2lmnhb6ftd323n8kwkd6lrl2t67ba3snd
=== STEP  testing global_security attribute: annotation = 78zrv2y7vdeyukdoff4hk6y99snnutspvw1ji1ytnezfafop09jjma62kr70d0aiism7qbn3z4p69i1gcu3undcik734jpzq0vyfzo3hjgfbkcgf189whw8ij64sgcl9d
=== STEP  testing global_security attribute: name_alias = okafe7ic1cb3o1tyaacdwhar8fbuul84mbo7892ypizzqd6ai1om1m9pz6e860mi
=== STEP  testing global_security attribute: pwd_strength_check = q7syp
=== STEP  testing global_security attribute: change_count = q7syp
=== STEP  testing global_security attribute: change_count = -1
=== STEP  testing global_security attribute: change_count = 11
=== STEP  testing global_security attribute: change_during_interval = q7syp
=== STEP  testing global_security attribute: change_interval = q7syp
=== STEP  testing global_security attribute: change_interval = -1
=== STEP  testing global_security attribute: change_interval = 746
=== STEP  testing global_security attribute: expiration_warn_time = q7syp
=== STEP  testing global_security attribute: expiration_warn_time = -1
=== STEP  testing global_security attribute: expiration_warn_time = 31
=== STEP  testing global_security attribute: history_count = q7syp
=== STEP  testing global_security attribute: history_count = -1
=== STEP  testing global_security attribute: history_count = 16
=== STEP  testing global_security attribute: no_change_interval = q7syp
=== STEP  testing global_security attribute: no_change_interval = -1
=== STEP  testing global_security attribute: no_change_interval = 746
=== STEP  testing global_security attribute: block_duration = q7syp
=== STEP  testing global_security attribute: block_duration = 0
=== STEP  testing global_security attribute: block_duration = 1441
=== STEP  testing global_security attribute: enable_login_block = q7syp
=== STEP  testing global_security attribute: max_failed_attempts = q7syp
=== STEP  testing global_security attribute: max_failed_attempts = 0
=== STEP  testing global_security attribute: max_failed_attempts = 16
=== STEP  testing global_security attribute: max_failed_attempts_window = q7syp
=== STEP  testing global_security attribute: max_failed_attempts_window = 0
=== STEP  testing global_security attribute: max_failed_attempts_window = 721
=== STEP  testing global_security attribute: maximum_validity_period = q7syp
=== STEP  testing global_security attribute: maximum_validity_period = 0
=== STEP  testing global_security attribute: maximum_validity_period = 721
=== STEP  testing global_security attribute: ui_idle_timeout_seconds = q7syp
=== STEP  testing global_security attribute: ui_idle_timeout_seconds = 59
=== STEP  testing global_security attribute: ui_idle_timeout_seconds = 65526
=== STEP  testing global_security attribute: webtoken_timeout_seconds = q7syp
=== STEP  testing global_security attribute: webtoken_timeout_seconds = 299
=== STEP  testing global_security attribute: webtoken_timeout_seconds = 9601
=== STEP  testing global_security attribute: session_record_flags = ["login","login"]
=== STEP  testing global_security attribute: session_record_flags = ["q7syp"]
=== STEP  testing global_security attribute: gnxsi = q7syp
--- PASS: TestAccAciWebTokenData_Negative (211.31s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   614.647s
=== RUN   TestAccAciSAMLProvider_Update
=== STEP  testing saml_provider creation with required arguments only
=== STEP  testing saml_provider attribute: retries = 2
=== STEP  testing saml_provider attribute: sig_alg = SIG_RSA_SHA224
=== STEP  testing saml_provider attribute: sig_alg = SIG_RSA_SHA384
=== STEP  testing saml_provider attribute: sig_alg = SIG_RSA_SHA512
=== STEP  testing saml_provider attribute: timeout = 27
=== STEP  testing saml_provider attribute: id_p = ping identity
=== STEP  testing saml_provider creation with required arguments only
=== PAUSE TestAccAciSAMLProvider_Update
=== CONT  TestAccAciSAMLProvider_Update
=== STEP  testing saml_provider destroy
--- PASS: TestAccAciSAMLProvider_Update (89.50s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   91.038s
=== RUN   TestAccAciSPANSourceGroupDataSource_Basic
=== STEP  Basic: testing span_source_group Data Source without  tenant_dn
=== STEP  Basic: testing span_source_group Data Source without  name
=== STEP  testing span_source_group Data Source with required arguments only
=== STEP  testing span_source_group Data Source with random attribute
=== STEP  testing span_source_group Data Source with invalid name
=== STEP  testing span_source_group Data Source with updated resource
=== PAUSE TestAccAciSPANSourceGroupDataSource_Basic
=== RUN   TestAccAciSPANSourceGroup_Basic
=== STEP  Basic: testing span_source_group creation without  tenant_dn
=== STEP  Basic: testing span_source_group creation without  name
=== STEP  testing span_source_group creation with required arguments only
=== STEP  Basic: testing span_source_group creation with optional parameters
=== STEP  testing span_source_group creation with invalid name =  tdxjp7wlpgehq2708h071poamtkl2jyjds842fp3ca8qj3lauqlp2yykw4elq4dhx
=== STEP  Basic: testing span_source_group updation without required parameters
=== STEP  testing span_source_group creation with parent resource name acctest_dkyuq and resource name acctest_aag9a
=== STEP  testing span_source_group creation with required arguments only
=== STEP  testing span_source_group creation with parent resource name acctest_aag9a and resource name acctest_dkyuq
=== PAUSE TestAccAciSPANSourceGroup_Basic
=== RUN   TestAccAciSPANSourceGroup_Negative
=== STEP  testing span_source_group creation with required arguments only
=== STEP  Negative Case: testing span_source_group creation with invalid parent Dn
=== STEP  testing span_source_group attribute: description = nuxo7a7k0yo1wrnobr0f23lasd1szsskea9474b74g4x4uo4uzzuby2q8yyooy6dzxc3d8g9n27w2r8t3xua7zv0jd0n0aehkjmj96nva37tlhcahfv4t06vn3fxma860
=== STEP  testing span_source_group attribute: annotation = pul6s1h9v3s34ddgy0rp0tfwui4w618ov79yhojhtalswgc4hd214ixzd6gcnqpby4xrax0lc2byiw8btldks8rpbnrzb4t4fxuivv7c0huwqzv1qcvlmwz32q9t7pxfy
=== STEP  testing span_source_group attribute: name_alias = vrrafiowyugb9xml87l9ul323xbd2yxp8x7fcrkq7t83zgyhof87vgnir0p2ugk8
=== STEP  testing span_source_group attribute: admin_st = 9jy3a
=== STEP  testing span_source_group attribute: delvw = 9jy3a
=== STEP  testing span_source_group creation with required arguments only
=== PAUSE TestAccAciSPANSourceGroup_Negative
=== RUN   TestAccAciSPANSourceGroup_MultipleCreateDelete
=== STEP  testing multiple span_source_group creation with required arguments only
=== PAUSE TestAccAciSPANSourceGroup_MultipleCreateDelete
=== CONT  TestAccAciSPANSourceGroupDataSource_Basic
=== CONT  TestAccAciSPANSourceGroup_Negative
=== CONT  TestAccAciSPANSourceGroup_Basic
=== CONT  TestAccAciSPANSourceGroup_MultipleCreateDelete
=== STEP  testing span_source_group destroy
--- PASS: TestAccAciSPANSourceGroup_MultipleCreateDelete (30.62s)
=== STEP  testing span_source_group destroy
--- PASS: TestAccAciSPANSourceGroupDataSource_Basic (49.43s)
=== STEP  testing span_source_group destroy
--- PASS: TestAccAciSPANSourceGroup_Negative (68.18s)
=== STEP  testing span_source_group destroy
--- PASS: TestAccAciSPANSourceGroup_Basic (92.57s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   94.057s
=== RUN   TestAccAciFirmwarePolicyDataSource_Basic
=== STEP  Basic: testing firmware_policy Data Source without  name
=== STEP  testing firmware_policy Data Source with required arguments only
=== STEP  testing firmware_policy Data Source with random attribute
=== STEP  testing firmware_policy Data Source with invalid name
=== STEP  testing firmware_policy Data Source with updated resource
=== PAUSE TestAccAciFirmwarePolicyDataSource_Basic
=== RUN   TestAccAciFirmwarePolicy_Basic
=== STEP  Basic: testing firmware_policy creation without  name
=== STEP  testing firmware_policy creation with required arguments only
=== STEP  Basic: testing firmware_policy creation with optional parameters
=== STEP  testing firmware_policy creation with invalid name =  gbysv0vfaz1yzx4us9283pt7n3codnxu31pgl08ecmo2yyr1yjjmpb8d9qfbaikt0
=== STEP  Basic: testing firmware_policy updation without required parameters
=== STEP  testing firmware_policy creation with name = acctest_717b0
=== PAUSE TestAccAciFirmwarePolicy_Basic
=== RUN   TestAccAciFirmwarePolicy_Update
=== STEP  testing firmware_policy creation with required arguments only
=== STEP  testing firmware_policy attribute: version_check_override = trigger-immediate
=== STEP  testing firmware_policy attribute: version_check_override = triggered
=== STEP  testing firmware_policy creation with required arguments only
=== PAUSE TestAccAciFirmwarePolicy_Update
=== RUN   TestAccAciFirmwarePolicy_Negative
=== STEP  testing firmware_policy creation with required arguments only
=== STEP  testing firmware_policy attribute: description = 2bq22t0jeo8vzg2gzz47wvdrpfa2kzqmlfz2hea2kg8kfwyrxx7k8aua3ajluz1o2t4s669so6o3qe3nahp827c0udywlf9yd86nib38uetrbz4g2sojthqdgxfvq3nyv
=== STEP  testing firmware_policy attribute: annotation = 6h0oitvu2zi74onojlnjk9nvn68ssmhtziioidt8y782ksbk3d8oqpd2rbrd77v49zkc4ug3nta12v94ig3v8xzk823n0381jucbuwbftdg3c6ilxu81oj9wrswkt0w2u
=== STEP  testing firmware_policy attribute: name_alias = wq1slolry7kaqmutdga0uk021333fw4iovtnuydsuog2zd3mbwvkknoh7m3e9xcb
=== STEP  testing firmware_policy attribute: effective_on_reboot = 4t8ft
=== STEP  testing firmware_policy attribute: ignore_compat = 4t8ft
=== STEP  testing firmware_policy attribute: internal_label = u79p726v38d0kzhbx93c90xq342y1sdr7mtqzz6bgd74dw7m6jjyfh29jepz9t32nfwuhfd0to1vhlhi1nspy43lioyet9wztlg36wgygwa19zjix62do6hnpqz1vrl41rtkot4rti4a1e08mdvebec0n0avtuzr71xl7eob6jfv0pjhiiux8uqhonsyr3bwn1scgsb0ytm2g4u97mu3uawinbzihjjs87j13klywtwbr6vmxdamojs4tgytidbkys1al4bk8v928kxxok9zdtvkqo7jke0a336uxprvdunv64vk168xlgij42fntpfasezkr10ewo1ehatedmghungzdrftbb6d0xvs8e0jfy4s36hpbziivrd6ls29robgwi7xomm04qh7l0b0fxcnzutnqaduyomkbdmfzvk19k8pakhchgc9btska12r2xgsqaryhjkosixc0eaq71jks9boueqw1ogkv9tga1ngur3lucsqm667rriftbxqlwsso
=== STEP  testing firmware_policy attribute: version = yyx0ug9oojuft0wu27oaknukvr0q0ikqsgkf0nlie10w6a4g4uq61ik1k1tvdea6xj6y0c2xbvhqo1hxfonbimx3rt0ewornp2qb39abtipwuo6pvcvk88vqkoxo70qevt9l3sjliz681e716koiimw6xst3st161ijtgye1iwx77xrbuscau7stb1r09n0zom99iickaueuo6howqjupwc4vmwuoafl3ox3z37xpejd4y4ohevwps0jvdn7l71int3ojtrobwo7v4e1anauh28m7ddpgsfpq6q8nooex1b8ncfabmek190mky9bi19fpx1dhr6h0xw2tp1q6nygiwvmn8hl4b2zqrdio6xv3w3o2l2fmfimae21l3t7zuvzls0c1tbt47lsaisnpv4std0pr9jle2wb4t1h9ylcae060wxrpmgwd62v7fay2n0rxdqsegpuouvok1oq99k2cq67emo4vv62yw4w8t44psyo8gr2nieu0dk80b3y2g08e
=== STEP  testing firmware_policy attribute: version_check_override = 4t8ft
=== STEP  testing firmware_policy attribute: yxkwg = 4t8ft
=== STEP  testing firmware_policy creation with required arguments only
=== PAUSE TestAccAciFirmwarePolicy_Negative
=== RUN   TestAccAciFirmwarePolicy_MultipleCreateDelete
=== STEP  testing multiple firmware_policy creation with required arguments only
=== PAUSE TestAccAciFirmwarePolicy_MultipleCreateDelete
=== CONT  TestAccAciFirmwarePolicyDataSource_Basic
=== CONT  TestAccAciFirmwarePolicy_Negative
=== CONT  TestAccAciFirmwarePolicy_MultipleCreateDelete
=== CONT  TestAccAciFirmwarePolicy_Update
=== CONT  TestAccAciFirmwarePolicy_Basic
=== STEP  testing firmware_policy destroy
--- PASS: TestAccAciFirmwarePolicy_MultipleCreateDelete (36.36s)
=== STEP  testing firmware_policy destroy
--- PASS: TestAccAciFirmwarePolicyDataSource_Basic (79.49s)
=== STEP  testing firmware_policy destroy
--- PASS: TestAccAciFirmwarePolicy_Update (124.87s)
=== STEP  testing firmware_policy destroy
--- PASS: TestAccAciFirmwarePolicy_Basic (130.48s)
=== STEP  testing firmware_policy destroy
--- PASS: TestAccAciFirmwarePolicy_Negative (158.69s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   160.641s
=== RUN   TestAccAciLDAPProviderDataSource_Basic
=== STEP  Basic: testing ldap_provider Data Source without  name
=== STEP  Basic: testing ldap_provider Data Source without  type
=== STEP  testing ldap_provider Data Source with required arguments only
=== STEP  testing ldap_provider Data Source with random attribute
=== STEP  testing ldap_provider Data Source with invalid name
=== STEP  testing ldap_provider Data Source with updated resource
=== PAUSE TestAccAciLDAPProviderDataSource_Basic
=== RUN   TestAccAciLDAPProvider_Basic
=== STEP  Basic: testing ldap_provider creation without  name
=== STEP  Basic: testing ldap_provider creation without  type
=== STEP  testing ldap_provider creation with required arguments only
=== STEP  Basic: testing ldap_provider creation with optional parameters
=== STEP  testing ldap_provider creation with invalid name =  bv8twvdo2ka8zth98laehrvyoue806s6qxlb9m2lq173ewt0ez1ns0zg19lab36lm
=== STEP  testing ldap_provider creation with name acctest_fgoy0 and type acctest_fgoy0
=== STEP  Basic: testing ldap_provider updation without required parameters
=== STEP  testing ldap_provider creation with name acctest_yh37i and type duo
=== STEP  testing ldap_provider creation with required arguments only
=== STEP  testing ldap_provider creation with name acctest_fgoy0 and type ldap
=== PAUSE TestAccAciLDAPProvider_Basic
=== RUN   TestAccAciLDAPProvider_Update
=== STEP  testing ldap_provider creation with required arguments only
=== STEP  testing ldap_provider attribute: port = 65535
=== STEP  testing ldap_provider attribute: port = 32767
=== STEP  testing ldap_provider attribute: retries = 2
=== STEP  testing ldap_provider attribute: timeout = 5
=== STEP  testing ldap_provider creation with required arguments only
=== PAUSE TestAccAciLDAPProvider_Update
=== RUN   TestAccAciLDAPProvider_Negative
=== STEP  testing ldap_provider creation with required arguments only
=== STEP  testing ldap_provider attribute: description = sc3p2qj0ye46ef8hrc2kcnwiovprfgufayz6twiscg44ieskd7edw9zck07l63spp9isqj99rla9izao4grbwxozyxv9sm0wlr2fi9na2ou801yovw3brnb8zsxzy7fbe
=== STEP  testing ldap_provider attribute: annotation = h78xi986qvamykivzr3bjbd69kxg1jkeolsuj7uhzsyoershibzpc7ki3e1uvoycjwgysn22iqzzz7w6lmrv0lr6hxifqi1raqfihqkonwiqyxjzw9avqoyqtxemj336f
=== STEP  testing ldap_provider attribute: name_alias = pds8a68wu4kcmwkelqr0no261fi2w1coniv477j9k8pqfzjaf1n74rb3pufeyn3z
=== STEP  testing ldap_provider attribute: ssl_validation_level = emj6w
=== STEP  testing ldap_provider attribute: attribute = 1z4sx6qz7pcqeu7hqu7dvtmyti8d4ctvmdty2cdyf6tiw8txt13bsmp7tgftb7hg
=== STEP  testing ldap_provider attribute: basedn = nvwahflv72ey8iogdnckw8gnk64uohfely7x0xft439yfm01tr3dbbq9ir1l4i0v8hhk6lp0mkfpxkpd9rcec3x6bgttf62y4h26viuonfzvo1jvofgdlk446bhplwo6
=== STEP  testing ldap_provider attribute: enable_ssl = emj6w
=== STEP  testing ldap_provider attribute: filter = nadkbv9y8jdj7pkkkdprb6ekvi61jhj96j8qrkjzz1qwflvz4gs2auqmdacfajpq
=== STEP  testing ldap_provider attribute: monitor_server = emj6w
=== STEP  testing ldap_provider attribute: monitoring_user = frpo8yzzt4ar39tms8r6q32l4wzlexa1x
=== STEP  testing ldap_provider attribute: port = emj6w
=== STEP  testing ldap_provider attribute: port = 0
=== STEP  testing ldap_provider attribute: port = 65536
=== STEP  testing ldap_provider attribute: retries = emj6w
=== STEP  testing ldap_provider attribute: retries = 0
=== STEP  testing ldap_provider attribute: retries = 6
=== STEP  testing ldap_provider attribute: rootdn = wbthkxi7bnjxmqyj1qs8hbshloqn9xw6e0cu74x22kygq3mwm7mp3jvk2aaent9y7ackrjhz6whakn9gkymnpxdtos0xr477fquphpb79j3c3i8wquviwhq3bhx22szc
=== STEP  testing ldap_provider attribute: timeout = emj6w
=== STEP  testing ldap_provider attribute: timeout = 4
=== STEP  testing ldap_provider attribute: timeout = 61
=== STEP  testing ldap_provider attribute: qpcbz = emj6w
=== STEP  testing ldap_provider creation with required arguments only
=== PAUSE TestAccAciLDAPProvider_Negative
=== CONT  TestAccAciLDAPProviderDataSource_Basic
=== CONT  TestAccAciLDAPProvider_Update
=== CONT  TestAccAciLDAPProvider_Basic
=== CONT  TestAccAciLDAPProvider_Negative
=== STEP  testing ldap_provider destroy
--- PASS: TestAccAciLDAPProviderDataSource_Basic (82.81s)
=== STEP  testing ldap_provider destroy
--- PASS: TestAccAciLDAPProvider_Update (152.01s)
=== STEP  testing ldap_provider destroy
--- PASS: TestAccAciLDAPProvider_Basic (182.52s)
=== STEP  testing ldap_provider destroy
--- PASS: TestAccAciLDAPProvider_Negative (296.18s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   298.416s
=== RUN   TestAccAciRSAProviderDataSource_Basic
=== STEP  Basic: testing rsa_provider Data Source without  name
=== STEP  testing rsa_provider Data Source with required arguments only
=== STEP  testing rsa_provider Data Source with random attribute
=== STEP  testing rsa_provider Data Source with invalid name
=== STEP  testing rsa_provider Data Source with updated resource
=== PAUSE TestAccAciRSAProviderDataSource_Basic
=== RUN   TestAccAciRSAProvider_Basic
=== STEP  Basic: testing rsa_provider creation without  name
=== STEP  testing rsa_provider creation with required arguments only
=== STEP  Basic: testing rsa_provider creation with optional parameters
=== STEP  testing rsa_provider creation with invalid name =  9icn6zxipqayh9ui8rkrrzn6yuodghb9yr16zlntjnewlq6xrfr8o6p74zxq4hktf
=== STEP  Basic: testing rsa_provider updation without required parameters
=== STEP  testing rsa_provider creation with name = acctest_viess
=== PAUSE TestAccAciRSAProvider_Basic
=== RUN   TestAccAciRSAProvider_Update
=== STEP  testing rsa_provider creation with required arguments only
=== STEP  testing rsa_provider attribute: auth_port = 65535
=== STEP  testing rsa_provider attribute: auth_port = 32767
=== STEP  testing rsa_provider attribute: auth_protocol = mschap
=== STEP  testing rsa_provider attribute: retries = 2
=== STEP  testing rsa_provider attribute: timeout = 60
=== STEP  testing rsa_provider attribute: timeout = 30
=== STEP  testing rsa_provider creation with required arguments only
=== PAUSE TestAccAciRSAProvider_Update
=== RUN   TestAccAciRSAProvider_Negative
=== STEP  testing rsa_provider creation with required arguments only
=== STEP  testing rsa_provider attribute: description = 3fda3spbcrbwhxw4ri3nw1pbtn32r2gu7pl6rx3yhmgl8txvjir02vs9vjyi807dxzttgbb2vyc9knehm7jp1uzbf1zkfsl8fy3wx6ky46ouu4ta2o7n0lavpa27sq4ae
=== STEP  testing rsa_provider attribute: annotation = jnkdptryhtnn98j2k174qjargpmym9fk6hdqwl3sdox9tsv89nqzbimda86833rkn8lm9nipl9tkkkx7b8zg7fg3wv0pikuvvo929up0dp3nb3ymth7hlbrioowvcpdm6
=== STEP  testing rsa_provider attribute: name_alias = 26s1wf22dmf2atxlf0hg9xtqkefsxtohvcti2o9ojbvssazvalzk2zo3pmj03pjz
=== STEP  testing rsa_provider attribute: auth_port = nzp1u
=== STEP  testing rsa_provider attribute: auth_port = 0
=== STEP  testing rsa_provider attribute: auth_port = 65536
=== STEP  testing rsa_provider attribute: auth_protocol = nzp1u
=== STEP  testing rsa_provider attribute: monitor_server = nzp1u
=== STEP  testing rsa_provider attribute: monitoring_user = 60ynkyollh3poqlh16cngqyf4hvf9lmgi
=== STEP  testing rsa_provider attribute: retries = nzp1u
=== STEP  testing rsa_provider attribute: retries = 0
=== STEP  testing rsa_provider attribute: retries = 6
=== STEP  testing rsa_provider attribute: timeout = nzp1u
=== STEP  testing rsa_provider attribute: timeout = 0
=== STEP  testing rsa_provider attribute: timeout = 61
=== STEP  testing rsa_provider attribute: kgwvc = nzp1u
=== STEP  testing rsa_provider creation with required arguments only
=== PAUSE TestAccAciRSAProvider_Negative
=== RUN   TestAccAciRSAProvider_MultipleCreateDelete
=== STEP  testing multiple rsa_provider creation with required arguments only
=== PAUSE TestAccAciRSAProvider_MultipleCreateDelete
=== CONT  TestAccAciRSAProviderDataSource_Basic
=== CONT  TestAccAciRSAProvider_Negative
=== CONT  TestAccAciRSAProvider_MultipleCreateDelete
=== CONT  TestAccAciRSAProvider_Update
=== CONT  TestAccAciRSAProvider_Basic
=== STEP  testing rsa_provider destroy
--- PASS: TestAccAciRSAProvider_MultipleCreateDelete (59.93s)
=== STEP  testing rsa_provider destroy
--- PASS: TestAccAciRSAProviderDataSource_Basic (117.04s)
=== STEP  testing rsa_provider destroy
--- PASS: TestAccAciRSAProvider_Basic (172.77s)
=== STEP  testing rsa_provider destroy
--- PASS: TestAccAciRSAProvider_Negative (252.19s)
=== STEP  testing rsa_provider destroy
--- PASS: TestAccAciRSAProvider_Update (280.99s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   283.837s
