### PR TITLE
Added Resources and Updated Test Cases

### DIFF
--- a/aci/data_source_aci_aaaconsoleauth.go
+++ b/aci/data_source_aci_aaaconsoleauth.go
@@ -43,7 +43,7 @@ func dataSourceAciConsoleAuthenticationMethodReadContext(ctx context.Context, d 
 
 	rn := fmt.Sprintf("userext/authrealm/consoleauth")
 	dn := fmt.Sprintf("uni/%s", rn)
-	aaaConsoleAuth, err := getRemoteConsoleAuthenticationMethod(aciClient, dn)
+	aaaConsoleAuth, err := GetRemoteConsoleAuthenticationMethod(aciClient, dn)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/aci/data_source_aci_edrerrdisrecoverpol.go
+++ b/aci/data_source_aci_edrerrdisrecoverpol.go
@@ -63,7 +63,7 @@ func dataSourceAciErrorDisabledRecoveryPolicyReadContext(ctx context.Context, d 
 
 	rn := fmt.Sprintf("infra/edrErrDisRecoverPol-%s", name)
 	dn := fmt.Sprintf("uni/%s", rn)
-	edrErrDisRecoverPol, err := getRemoteErrorDisabledRecoveryPolicy(aciClient, dn)
+	edrErrDisRecoverPol, err := GetRemoteErrorDisabledRecoveryPolicy(aciClient, dn)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -81,7 +81,7 @@ func dataSourceAciErrorDisabledRecoveryPolicyReadContext(ctx context.Context, d 
 
 	for _, val := range events {
 		edrEventDn := val
-		edrEvent, err := getRemoteErrorDisabledRecoveryEvent(aciClient, edrEventDn)
+		edrEvent, err := GetRemoteErrorDisabledRecoveryEvent(aciClient, edrEventDn)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/aci/data_source_aci_mcpinstpol.go
+++ b/aci/data_source_aci_mcpinstpol.go
@@ -37,11 +37,6 @@ func dataSourceAciMiscablingProtocolInstancePolicy() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			"key": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
 			"loop_detect_mult": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -72,7 +67,7 @@ func dataSourceAciMiscablingProtocolInstancePolicyReadContext(ctx context.Contex
 
 	rn := fmt.Sprintf("infra/mcpInstP-%s", name)
 	dn := fmt.Sprintf("uni/%s", rn)
-	mcpInstPol, err := getRemoteMiscablingProtocolInstancePolicy(aciClient, dn)
+	mcpInstPol, err := GetRemoteMiscablingProtocolInstancePolicy(aciClient, dn)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/aci/resource_aci_aaaconsoleauth.go
+++ b/aci/resource_aci_aaaconsoleauth.go
@@ -57,7 +57,7 @@ func resourceAciConsoleAuthenticationMethod() *schema.Resource {
 	}
 }
 
-func getRemoteConsoleAuthenticationMethod(client *client.Client, dn string) (*models.ConsoleAuthenticationMethod, error) {
+func GetRemoteConsoleAuthenticationMethod(client *client.Client, dn string) (*models.ConsoleAuthenticationMethod, error) {
 	aaaConsoleAuthCont, err := client.Get(dn)
 	if err != nil {
 		return nil, err
@@ -88,7 +88,7 @@ func resourceAciConsoleAuthenticationMethodImport(d *schema.ResourceData, m inte
 	log.Printf("[DEBUG] %s: Beginning Import", d.Id())
 	aciClient := m.(*client.Client)
 	dn := d.Id()
-	aaaConsoleAuth, err := getRemoteConsoleAuthenticationMethod(aciClient, dn)
+	aaaConsoleAuth, err := GetRemoteConsoleAuthenticationMethod(aciClient, dn)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func resourceAciConsoleAuthenticationMethodRead(ctx context.Context, d *schema.R
 	log.Printf("[DEBUG] %s: Beginning Read", d.Id())
 	aciClient := m.(*client.Client)
 	dn := d.Id()
-	aaaConsoleAuth, err := getRemoteConsoleAuthenticationMethod(aciClient, dn)
+	aaaConsoleAuth, err := GetRemoteConsoleAuthenticationMethod(aciClient, dn)
 	if err != nil {
 		d.SetId("")
 		return diag.FromErr(err)

--- a/aci/resource_aci_aaauserrole.go
+++ b/aci/resource_aci_aaauserrole.go
@@ -68,6 +68,7 @@ func setUserRoleAttributes(aaaUserRole *models.UserRole, d *schema.ResourceData)
 	if err != nil {
 		return nil, err
 	}
+	d.Set("annotation", aaaUserRoleMap["annotation"])
 	d.Set("name", aaaUserRoleMap["name"])
 	d.Set("priv_type", aaaUserRoleMap["privType"])
 	d.Set("name_alias", aaaUserRoleMap["nameAlias"])

--- a/aci/resource_aci_edrerrdisrecoverpol.go
+++ b/aci/resource_aci_edrerrdisrecoverpol.go
@@ -98,7 +98,7 @@ func resourceAciErrorDisabledRecoveryPolicy() *schema.Resource {
 	}
 }
 
-func getRemoteErrorDisabledRecoveryPolicy(client *client.Client, dn string) (*models.ErrorDisabledRecoveryPolicy, error) {
+func GetRemoteErrorDisabledRecoveryPolicy(client *client.Client, dn string) (*models.ErrorDisabledRecoveryPolicy, error) {
 	edrErrDisRecoverPolCont, err := client.Get(dn)
 	if err != nil {
 		return nil, err
@@ -110,7 +110,7 @@ func getRemoteErrorDisabledRecoveryPolicy(client *client.Client, dn string) (*mo
 	return edrErrDisRecoverPol, nil
 }
 
-func getRemoteErrorDisabledRecoveryEvent(client *client.Client, dn string) (*models.ErrorDisabledRecoveryEvent, error) {
+func GetRemoteErrorDisabledRecoveryEvent(client *client.Client, dn string) (*models.ErrorDisabledRecoveryEvent, error) {
 	edrEventPCont, err := client.Get(dn)
 	if err != nil {
 		return nil, err
@@ -162,7 +162,7 @@ func resourceAciErrorDisabledRecoveryPolicyImport(d *schema.ResourceData, m inte
 	log.Printf("[DEBUG] %s: Beginning Import", d.Id())
 	aciClient := m.(*client.Client)
 	dn := d.Id()
-	edrErrDisRecoverPol, err := getRemoteErrorDisabledRecoveryPolicy(aciClient, dn)
+	edrErrDisRecoverPol, err := GetRemoteErrorDisabledRecoveryPolicy(aciClient, dn)
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +353,7 @@ func resourceAciErrorDisabledRecoveryPolicyRead(ctx context.Context, d *schema.R
 	log.Printf("[DEBUG] %s: Beginning Read", d.Id())
 	aciClient := m.(*client.Client)
 	dn := d.Id()
-	edrErrDisRecoverPol, err := getRemoteErrorDisabledRecoveryPolicy(aciClient, dn)
+	edrErrDisRecoverPol, err := GetRemoteErrorDisabledRecoveryPolicy(aciClient, dn)
 	if err != nil {
 		d.SetId("")
 		return diag.FromErr(err)
@@ -369,7 +369,7 @@ func resourceAciErrorDisabledRecoveryPolicyRead(ctx context.Context, d *schema.R
 
 	for _, val := range events {
 		edrEventDn := val.(string)
-		edrEvent, err := getRemoteErrorDisabledRecoveryEvent(aciClient, edrEventDn)
+		edrEvent, err := GetRemoteErrorDisabledRecoveryEvent(aciClient, edrEventDn)
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/aci/resource_aci_mcpinstpol.go
+++ b/aci/resource_aci_mcpinstpol.go
@@ -87,7 +87,7 @@ func resourceAciMiscablingProtocolInstancePolicy() *schema.Resource {
 	}
 }
 
-func getRemoteMiscablingProtocolInstancePolicy(client *client.Client, dn string) (*models.MiscablingProtocolInstancePolicy, error) {
+func GetRemoteMiscablingProtocolInstancePolicy(client *client.Client, dn string) (*models.MiscablingProtocolInstancePolicy, error) {
 	mcpInstPolCont, err := client.Get(dn)
 	if err != nil {
 		return nil, err
@@ -148,7 +148,7 @@ func resourceAciMiscablingProtocolInstancePolicyImport(d *schema.ResourceData, m
 	log.Printf("[DEBUG] %s: Beginning Import", d.Id())
 	aciClient := m.(*client.Client)
 	dn := d.Id()
-	mcpInstPol, err := getRemoteMiscablingProtocolInstancePolicy(aciClient, dn)
+	mcpInstPol, err := GetRemoteMiscablingProtocolInstancePolicy(aciClient, dn)
 	if err != nil {
 		return nil, err
 	}
@@ -184,6 +184,10 @@ func resourceAciMiscablingProtocolInstancePolicyCreate(ctx context.Context, d *s
 		ctrlList := make([]string, 0, 1)
 		for _, val := range Ctrl.([]interface{}) {
 			ctrlList = append(ctrlList, val.(string))
+		}
+		err := checkDuplicate(ctrlList)
+		if err != nil {
+			return diag.FromErr(err)
 		}
 		Ctrl := strings.Join(ctrlList, ",")
 		mcpInstPolAttr.Ctrl = Ctrl
@@ -259,6 +263,10 @@ func resourceAciMiscablingProtocolInstancePolicyUpdate(ctx context.Context, d *s
 		for _, val := range Ctrl.([]interface{}) {
 			ctrlList = append(ctrlList, val.(string))
 		}
+		err := checkDuplicate(ctrlList)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 		Ctrl := strings.Join(ctrlList, ",")
 		mcpInstPolAttr.Ctrl = Ctrl
 	} else {
@@ -310,7 +318,7 @@ func resourceAciMiscablingProtocolInstancePolicyRead(ctx context.Context, d *sch
 	log.Printf("[DEBUG] %s: Beginning Read", d.Id())
 	aciClient := m.(*client.Client)
 	dn := d.Id()
-	mcpInstPol, err := getRemoteMiscablingProtocolInstancePolicy(aciClient, dn)
+	mcpInstPol, err := GetRemoteMiscablingProtocolInstancePolicy(aciClient, dn)
 	if err != nil {
 		d.SetId("")
 		return diag.FromErr(err)

--- a/testacc/data_source_aci_aaaConsoleAuth_test.go
+++ b/testacc/data_source_aci_aaaConsoleAuth_test.go
@@ -1,0 +1,93 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aci/aci"
+)
+
+func TestAccAciConsoleAuthenticationDataSource_Basic(t *testing.T) {
+	resourceName := "aci_console_authentication.test"
+	dataSourceName := "data.aci_console_authentication.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	aaaConsoleAuth, err := aci.GetRemoteConsoleAuthenticationMethod(sharedAciClient(), "uni/userext/authrealm/consoleauth")
+	if err != nil {
+		t.Errorf("reading initial config of aaaConsoleAuth")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccAciConsoleAuthenticationConfigDataSource(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "provider_group", resourceName, "provider_group"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "realm", resourceName, "realm"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "realm_sub_type", resourceName, "realm_sub_type"),
+				),
+			},
+			{
+				Config:      CreateAccAciConsoleAuthenticationDataSourceUpdate(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccAciConsoleAuthenticationDataSourceUpdatedResource("annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+			{
+				Config: restoreConsoleAuthentication(aaaConsoleAuth),
+			},
+		},
+	})
+}
+
+func CreateAccAciConsoleAuthenticationConfigDataSource() string {
+	fmt.Println("=== STEP  Testing console_authentication Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_console_authentication" "test" {}
+
+	data "aci_console_authentication" "test" {
+		depends_on = [ aci_console_authentication.test ]
+	}
+	`)
+	return resource
+}
+
+func CreateAccAciConsoleAuthenticationDataSourceUpdate(key, value string) string {
+	fmt.Println("=== STEP  Testing console_authentication Data Source with random attribute")
+	resource := fmt.Sprintf(`
+
+	resource "aci_console_authentication" "test" {}
+
+	data "aci_console_authentication" "test" {
+		%s = "%s"
+		depends_on = [ aci_console_authentication.test ]
+	}
+	`, key, value)
+	return resource
+}
+
+func CreateAccAciConsoleAuthenticationDataSourceUpdatedResource(key, value string) string {
+	fmt.Println("=== STEP  Testing console_authentication Data Source with updated resource")
+	resource := fmt.Sprintf(`
+
+	resource "aci_console_authentication" "test" {
+		%s = "%s"
+	}
+
+	data "aci_console_authentication" "test" {
+		depends_on = [ aci_console_authentication.test ]
+	}
+	`, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_aaalogindomain_test.go
+++ b/testacc/data_source_aci_aaalogindomain_test.go
@@ -1,0 +1,154 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciLoginDomainDataSource_Basic(t *testing.T) {
+	resourceName := "aci_login_domain.test"
+	dataSourceName := "data.aci_login_domain.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLoginDomainDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateLoginDomainDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLoginDomainConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "provider_group", resourceName, "provider_group"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "realm", resourceName, "realm"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "realm_sub_type", resourceName, "realm_sub_type"),
+				),
+			},
+			{
+				Config:      CreateAccLoginDomainDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccLoginDomainDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccLoginDomainDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccLoginDomainConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  Testing login_domain Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_login_domain" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_login_domain" "test" {
+	
+		name  = aci_login_domain.test.name
+		depends_on = [ aci_login_domain.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateLoginDomainDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Testing login_domain Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_login_domain" "test" {
+	
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_login_domain" "test" {
+	
+	#	name  = aci_login_domain.test.name
+		depends_on = [ aci_login_domain.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccLoginDomainDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  Testing login_domain Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_login_domain" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_login_domain" "test" {
+	
+		name  = "${aci_login_domain.test.name}_invalid"
+		depends_on = [ aci_login_domain.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLoginDomainDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  Testing login_domain Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_login_domain" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_login_domain" "test" {
+	
+		name  = aci_login_domain.test.name
+		%s = "%s"
+		depends_on = [ aci_login_domain.test ]
+	}
+	`, rName, key, value)
+	return resource
+}
+
+func CreateAccLoginDomainDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  Testing login_domain Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_login_domain" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_login_domain" "test" {
+	
+		name  = aci_login_domain.test.name
+		depends_on = [ aci_login_domain.test ]
+	}
+	`, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_aaauserdomain_test.go
+++ b/testacc/data_source_aci_aaauserdomain_test.go
@@ -1,0 +1,188 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciUserSecurityDomainDataSource_Basic(t *testing.T) {
+	resourceName := "aci_user_security_domain.test"
+	dataSourceName := "data.aci_user_security_domain.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	aaaUserName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciUserSecurityDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateUserSecurityDomainDSWithoutRequired(aaaUserName, rName, "local_user_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateUserSecurityDomainDSWithoutRequired(aaaUserName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccUserSecurityDomainConfigDataSource(aaaUserName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "local_user_dn", resourceName, "local_user_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+				),
+			},
+			{
+				Config:      CreateAccUserSecurityDomainDataSourceUpdate(aaaUserName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccUserSecurityDomainDSWithInvalidParentDn(aaaUserName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+
+			{
+				Config: CreateAccUserSecurityDomainDataSourceUpdatedResource(aaaUserName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccUserSecurityDomainConfigDataSource(aaaUserName, rName string) string {
+	fmt.Println("=== STEP  testing user_security_domain Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+
+	data "aci_user_security_domain" "test" {
+		local_user_dn = aci_user_security_domain.test.local_user_dn
+		name  = aci_user_security_domain.test.name
+		depends_on = [ aci_user_security_domain.test ]
+	}
+	`, aaaUserName, rName)
+	return resource
+}
+
+func CreateUserSecurityDomainDSWithoutRequired(aaaUserName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing user_security_domain Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "local_user_dn":
+		rBlock += `
+	data "aci_user_security_domain" "test" {
+	#	local_user_dn  = aci_local_user.test.id
+		name  = aci_user_security_domain.test.name
+		depends_on = [ aci_user_security_domain.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_user_security_domain" "test" {
+		local_user_dn  = aci_local_user.test.id
+	#	name  = aci_user_security_domain.test.name
+		depends_on = [ aci_user_security_domain.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, aaaUserName, rName)
+}
+
+func CreateAccUserSecurityDomainDSWithInvalidParentDn(aaaUserName, rName string) string {
+	fmt.Println("=== STEP  testing user_security_domain Data Source with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+
+	data "aci_user_security_domain" "test" {
+		local_user_dn  = "${aci_local_user.test.id}_invalid"
+		name  = aci_user_security_domain.test.name
+		depends_on = [ aci_user_security_domain.test ]
+	}
+	`, aaaUserName, rName)
+	return resource
+}
+
+func CreateAccUserSecurityDomainDataSourceUpdate(aaaUserName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing user_security_domain Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+
+	data "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = aci_user_security_domain.test.name
+		%s = "%s"
+		depends_on = [ aci_user_security_domain.test ]
+	}
+	`, aaaUserName, rName, key, value)
+	return resource
+}
+
+func CreateAccUserSecurityDomainDataSourceUpdatedResource(aaaUserName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing user_security_domain Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = aci_user_security_domain.test.name
+		depends_on = [ aci_user_security_domain.test ]
+	}
+	`, aaaUserName, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_aaauserrole_test.go
+++ b/testacc/data_source_aci_aaauserrole_test.go
@@ -1,0 +1,211 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciUserSecurityDomainRoleDataSource_Basic(t *testing.T) {
+	resourceName := "aci_user_security_domain_role.test"
+	dataSourceName := "data.aci_user_security_domain_role.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	aaaUserName := makeTestVariable(acctest.RandString(5))
+	aaaUserDomainName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciUserSecurityDomainRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateUserSecurityDomainRoleDSWithoutRequired(aaaUserName, aaaUserDomainName, rName, "user_domain_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateUserSecurityDomainRoleDSWithoutRequired(aaaUserName, aaaUserDomainName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccUserSecurityDomainRoleConfigDataSource(aaaUserName, aaaUserDomainName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "user_domain_dn", resourceName, "user_domain_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "priv_type", resourceName, "priv_type"),
+				),
+			},
+			{
+				Config:      CreateAccUserSecurityDomainRoleDataSourceUpdate(aaaUserName, aaaUserDomainName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccUserSecurityDomainRoleDSWithInvalidParentDn(aaaUserName, aaaUserDomainName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccUserSecurityDomainRoleDataSourceUpdatedResource(aaaUserName, aaaUserDomainName, rName, "description", "description_testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccUserSecurityDomainRoleConfigDataSource(aaaUserName, aaaUserDomainName, rName string) string {
+	fmt.Println("=== STEP  testing user_security_domain_role Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+
+	resource "aci_user_security_domain_role" "test" {
+		user_domain_dn  =  aci_user_security_domain.test.id
+		name  = "%s"
+	}
+
+	data "aci_user_security_domain_role" "test" {
+		user_domain_dn  =  aci_user_security_domain.test.id
+		name  = aci_user_security_domain_role.test.name
+		depends_on = [ aci_user_security_domain_role.test ]
+	}
+	`, aaaUserName, aaaUserDomainName, rName)
+	return resource
+}
+
+func CreateUserSecurityDomainRoleDSWithoutRequired(aaaUserName, aaaUserDomainName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing user_security_domain_role Data Source without ", attrName)
+	rBlock := `
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+	
+	resource "aci_user_security_domain_role" "test" {
+		user_domain_dn  =  aci_user_security_domain.test.id
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "user_domain_dn":
+		rBlock += `
+	data "aci_user_security_domain_role" "test" {
+	#	user_domain_dn  =  aci_user_security_domain.test.id
+		name  = aci_user_security_domain_role.test.name
+		depends_on = [ aci_user_security_domain_role.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_user_security_domain_role" "test" {
+		user_domain_dn  =  aci_user_security_domain.test.id
+	#	name  = aci_user_security_domain_role.test.name
+		depends_on = [ aci_user_security_domain_role.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, aaaUserName, aaaUserDomainName, rName)
+}
+
+func CreateAccUserSecurityDomainRoleDSWithInvalidParentDn(aaaUserName, aaaUserDomainName, rName string) string {
+	fmt.Println("=== STEP  testing user_security_domain_role Data Source with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+	
+	resource "aci_user_security_domain_role" "test" {
+		user_domain_dn  =  aci_user_security_domain.test.id
+		name  = "%s"
+	}
+
+	data "aci_user_security_domain_role" "test" {
+		user_domain_dn  =  aci_user_security_domain.test.id
+		name  = "${aci_user_security_domain_role.test.name}_invalid"
+		depends_on = [ aci_user_security_domain_role.test ]
+	}
+	`, aaaUserName, aaaUserDomainName, rName)
+	return resource
+}
+
+func CreateAccUserSecurityDomainRoleDataSourceUpdate(aaaUserName, aaaUserDomainName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing user_security_domain_role Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+	resource "aci_user_security_domain_role" "test" {
+		user_domain_dn  =  aci_user_security_domain.test.id
+		name  = "%s"
+	}
+
+	data "aci_user_security_domain_role" "test" {
+		user_domain_dn  =  aci_user_security_domain.test.id
+		name  = aci_user_security_domain_role.test.name
+		%s = "%s"
+		depends_on = [ aci_user_security_domain_role.test ]
+	}
+	`, aaaUserName, aaaUserDomainName, rName, key, value)
+	return resource
+}
+
+func CreateAccUserSecurityDomainRoleDataSourceUpdatedResource(aaaUserName, aaaUserDomainName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing user_security_domain_role Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+
+	resource "aci_user_security_domain_role" "test" {
+		user_domain_dn  =  aci_user_security_domain.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_user_security_domain_role" "test" {
+		user_domain_dn  =  aci_user_security_domain.test.id
+		name  = aci_user_security_domain_role.test.name
+		depends_on = [ aci_user_security_domain_role.test ]
+	}
+	`, aaaUserName, aaaUserDomainName, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_edrErrDisRecoverPol_test.go
+++ b/testacc/data_source_aci_edrErrDisRecoverPol_test.go
@@ -1,0 +1,100 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aci/aci"
+)
+
+func TestAccAciErrorDisableRecoveryDataSource_Basic(t *testing.T) {
+	resourceName := "aci_error_disable_recovery.test"
+	dataSourceName := "data.aci_error_disable_recovery.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	edrErrDisRecoverPol, err := aci.GetRemoteErrorDisabledRecoveryPolicy(sharedAciClient(), "uni/infra/edrErrDisRecoverPol-default")
+	if err != nil {
+		t.Errorf("reading initial config of edrErrDisRecoverPol")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccErrorDisabledRecoveryConfigDataSource(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "err_dis_recov_intvl", resourceName, "err_dis_recov_intvl"),
+				),
+			},
+			{
+				Config:      CreateAccErrorDisabledRecoveryDataSourceUpdate(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccErrorDisabledRecoveryDataSourceUpdatedResource("annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+			{
+				Config: restoreErrorDisabledRecoveryPolicy(edrErrDisRecoverPol),
+			},
+		},
+	})
+}
+
+func CreateAccErrorDisabledRecoveryConfigDataSource() string {
+	fmt.Println("=== STEP  Testing error_disable_recovery Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_error_disable_recovery" "test" {
+
+	}
+
+	data "aci_error_disable_recovery" "test" {
+
+		depends_on = [ aci_error_disable_recovery.test ]
+	}
+	`)
+	return resource
+}
+
+func CreateAccErrorDisabledRecoveryDataSourceUpdate(key, value string) string {
+	fmt.Println("=== STEP  Testing error_disable_recovery Data Source with random attribute")
+	resource := fmt.Sprintf(`
+
+	resource "aci_error_disable_recovery" "test" {
+
+	}
+
+	data "aci_error_disable_recovery" "test" {
+
+		%s = "%s"
+		depends_on = [ aci_error_disable_recovery.test ]
+	}
+	`, key, value)
+	return resource
+}
+
+func CreateAccErrorDisabledRecoveryDataSourceUpdatedResource(key, value string) string {
+	fmt.Println("=== STEP  Testing error_disable_recovery Data Source with updated resource")
+	resource := fmt.Sprintf(`
+
+	resource "aci_error_disable_recovery" "test" {
+
+		%s = "%s"
+	}
+
+	data "aci_error_disable_recovery" "test" {
+
+		depends_on = [ aci_error_disable_recovery.test ]
+	}
+	`, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_eploopprotectp_test.go
+++ b/testacc/data_source_aci_eploopprotectp_test.go
@@ -27,7 +27,6 @@ func TestAccAciEndpointLoopProtectionDataSource_Basic(t *testing.T) {
 			{
 				Config: CreateAccEndpointLoopProtectionConfigDataSource(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),

--- a/testacc/data_source_aci_mcpinstpol_test.go
+++ b/testacc/data_source_aci_mcpinstpol_test.go
@@ -1,0 +1,110 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aci/aci"
+)
+
+func TestAccAciMCPInstancePolicyDataSource_Basic(t *testing.T) {
+	resourceName := "aci_mcp_instance_policy.test"
+	dataSourceName := "data.aci_mcp_instance_policy.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	key := acctest.RandString(5)
+	mcpInstancePolicy, err := aci.GetRemoteMiscablingProtocolInstancePolicy(sharedAciClient(), "uni/infra/mcpInstP-default")
+	if err != nil {
+		t.Errorf("reading initial config of MCP Instance Policy")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccMCPInstancePolicyConfigDataSource(key),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "admin_st", resourceName, "admin_st"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ctrl", resourceName, "ctrl"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "init_delay_time", resourceName, "init_delay_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "loop_detect_mult", resourceName, "loop_detect_mult"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "loop_protect_act", resourceName, "loop_protect_act"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "loop_protect_act", resourceName, "loop_protect_act"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tx_freq", resourceName, "tx_freq"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tx_freq_msec", resourceName, "tx_freq_msec"),
+				),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyDataSourceUpdate(key, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyDataSourceUpdatedResource(key, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyInitialConfig(key, mcpInstancePolicy),
+			},
+		},
+	})
+}
+
+func CreateAccMCPInstancePolicyConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing mcp_instance_policy Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_mcp_instance_policy" "test" {
+	
+		key  = "%s"
+	}
+
+	data "aci_mcp_instance_policy" "test" {
+	
+		depends_on = [ aci_mcp_instance_policy.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccMCPInstancePolicyDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing mcp_instance_policy Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_mcp_instance_policy" "test" {
+	
+		key  = "%s"
+	}
+
+	data "aci_mcp_instance_policy" "test" {
+		%s = "%s"
+		depends_on = [ aci_mcp_instance_policy.test ]
+	}
+	`, rName, key, value)
+	return resource
+}
+
+func CreateAccMCPInstancePolicyDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing mcp_instance_policy Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_mcp_instance_policy" "test" {
+	
+		key  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_mcp_instance_policy" "test" {
+	
+		depends_on = [ aci_mcp_instance_policy.test ]
+	}
+	`, rName, key, value)
+	return resource
+}

--- a/testacc/resource_aci_aaaConsoleAuth_test.go
+++ b/testacc/resource_aci_aaaConsoleAuth_test.go
@@ -1,0 +1,284 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/terraform-providers/terraform-provider-aci/aci"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciConsoleAuthentication_Basic(t *testing.T) {
+	var console_authentication_default models.ConsoleAuthenticationMethod
+	var console_authentication_updated models.ConsoleAuthenticationMethod
+	resourceName := "aci_console_authentication.test"
+	aaaConsoleAuth, err := aci.GetRemoteConsoleAuthenticationMethod(sharedAciClient(), "uni/userext/authrealm/consoleauth")
+	if err != nil {
+		t.Errorf("reading initial config of aaaConsoleAuth")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccAciConsoleAuthenticationConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccAciConsoleAuthenticationExists(resourceName, &console_authentication_default),
+					resource.TestCheckResourceAttrSet(resourceName, "realm"),
+					resource.TestCheckResourceAttrSet(resourceName, "realm_sub_type"),
+				),
+			},
+			{
+				Config: CreateAccAciConsoleAuthenticationConfigWithOptionalValues(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccAciConsoleAuthenticationExists(resourceName, &console_authentication_updated),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_console_authentication"),
+					resource.TestCheckResourceAttr(resourceName, "provider_group", "60"),
+					resource.TestCheckResourceAttr(resourceName, "realm", "ldap"),
+					resource.TestCheckResourceAttr(resourceName, "realm_sub_type", "default"),
+					testAccCheckAccAciConsoleAuthenticationIdEqual(&console_authentication_default, &console_authentication_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: restoreConsoleAuthentication(aaaConsoleAuth),
+			},
+		},
+	})
+}
+
+func TestAccAciConsoleAuthentication_Update(t *testing.T) {
+	var console_authentication_default models.ConsoleAuthenticationMethod
+	var console_authentication_updated models.ConsoleAuthenticationMethod
+	resourceName := "aci_console_authentication.test"
+	aaaConsoleAuth, err := aci.GetRemoteConsoleAuthenticationMethod(sharedAciClient(), "uni/userext/authrealm/consoleauth")
+	if err != nil {
+		t.Errorf("reading initial config of aaaConsoleAuth")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccAciConsoleAuthenticationConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccAciConsoleAuthenticationExists(resourceName, &console_authentication_default),
+				),
+			},
+			{
+				Config: CreateAccAciConsoleAuthenticationUpdatedAttr("realm", "local"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccAciConsoleAuthenticationExists(resourceName, &console_authentication_updated),
+					resource.TestCheckResourceAttr(resourceName, "realm", "local"),
+					testAccCheckAccAciConsoleAuthenticationIdEqual(&console_authentication_default, &console_authentication_updated),
+				),
+			},
+			{
+				Config: CreateAccAciConsoleAuthenticationUpdatedAttr("realm", "radius"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccAciConsoleAuthenticationExists(resourceName, &console_authentication_updated),
+					resource.TestCheckResourceAttr(resourceName, "realm", "radius"),
+					testAccCheckAccAciConsoleAuthenticationIdEqual(&console_authentication_default, &console_authentication_updated),
+				),
+			},
+			{
+				Config: CreateAccAciConsoleAuthenticationUpdatedAttr("realm", "rsa"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccAciConsoleAuthenticationExists(resourceName, &console_authentication_updated),
+					resource.TestCheckResourceAttr(resourceName, "realm", "rsa"),
+					testAccCheckAccAciConsoleAuthenticationIdEqual(&console_authentication_default, &console_authentication_updated),
+				),
+			},
+			{
+				Config: CreateAccAciConsoleAuthenticationUpdatedAttr("realm", "saml"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccAciConsoleAuthenticationExists(resourceName, &console_authentication_updated),
+					resource.TestCheckResourceAttr(resourceName, "realm", "saml"),
+					testAccCheckAccAciConsoleAuthenticationIdEqual(&console_authentication_default, &console_authentication_updated),
+				),
+			},
+			{
+				Config: CreateAccAciConsoleAuthenticationUpdatedAttr("realm", "tacacs"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccAciConsoleAuthenticationExists(resourceName, &console_authentication_updated),
+					resource.TestCheckResourceAttr(resourceName, "realm", "tacacs"),
+					testAccCheckAccAciConsoleAuthenticationIdEqual(&console_authentication_default, &console_authentication_updated),
+				),
+			},
+			{
+				Config: CreateAccAciConsoleAuthenticationUpdatedAttr("realm_sub_type", "duo"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccAciConsoleAuthenticationExists(resourceName, &console_authentication_updated),
+					resource.TestCheckResourceAttr(resourceName, "realm_sub_type", "duo"),
+					testAccCheckAccAciConsoleAuthenticationIdEqual(&console_authentication_default, &console_authentication_updated),
+				),
+			},
+			{
+				Config: CreateAccAciConsoleAuthenticationUpdatedAttr("provider_group", "0"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccAciConsoleAuthenticationExists(resourceName, &console_authentication_updated),
+					resource.TestCheckResourceAttr(resourceName, "provider_group", "0"),
+					testAccCheckAccAciConsoleAuthenticationIdEqual(&console_authentication_default, &console_authentication_updated),
+				),
+			},
+			{
+				Config: CreateAccAciConsoleAuthenticationUpdatedAttr("provider_group", "63"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAccAciConsoleAuthenticationExists(resourceName, &console_authentication_updated),
+					resource.TestCheckResourceAttr(resourceName, "provider_group", "63"),
+					testAccCheckAccAciConsoleAuthenticationIdEqual(&console_authentication_default, &console_authentication_updated),
+				),
+			},
+			{
+				Config: restoreConsoleAuthentication(aaaConsoleAuth),
+			},
+		},
+	})
+}
+
+func TestAccAciConsoleAuthentication_Negative(t *testing.T) {
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	aaaConsoleAuth, err := aci.GetRemoteConsoleAuthenticationMethod(sharedAciClient(), "uni/userext/authrealm/consoleauth")
+	if err != nil {
+		t.Errorf("reading initial config of aaaConsoleAuth")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccAciConsoleAuthenticationConfig(),
+			},
+			{
+				Config:      CreateAccAciConsoleAuthenticationUpdatedAttr("description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccAciConsoleAuthenticationUpdatedAttr("annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccAciConsoleAuthenticationUpdatedAttr("name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccAciConsoleAuthenticationUpdatedAttr("realm", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccAciConsoleAuthenticationUpdatedAttr("realm_sub_type", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccAciConsoleAuthenticationUpdatedAttr(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: restoreConsoleAuthentication(aaaConsoleAuth),
+			},
+		},
+	})
+}
+
+func restoreConsoleAuthentication(aaaConsoleAuth *models.ConsoleAuthenticationMethod) string {
+	resource := fmt.Sprintf(`
+	resource "aci_console_authentication" "test" {
+		annotation = "%s"
+		description = "%s"
+		name_alias = "%s"
+		provider_group = "%s"
+		realm          = "%s"
+		realm_sub_type = "%s"
+	}
+	`, aaaConsoleAuth.Annotation, aaaConsoleAuth.Description, aaaConsoleAuth.NameAlias, aaaConsoleAuth.ProviderGroup, aaaConsoleAuth.Realm, aaaConsoleAuth.RealmSubType)
+	return resource
+}
+
+func testAccCheckAccAciConsoleAuthenticationExists(name string, console_authentication *models.ConsoleAuthenticationMethod) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Console Autentication %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Console Autentication Data dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		console_authenticationFound := models.ConsoleAuthenticationMethodFromContainer(cont)
+		if console_authenticationFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Console Autentication %s not found", rs.Primary.ID)
+		}
+		*console_authentication = *console_authenticationFound
+		return nil
+	}
+}
+
+func testAccCheckAccAciConsoleAuthenticationIdEqual(m1, m2 *models.ConsoleAuthenticationMethod) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("Console Autentication DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func CreateAccAciConsoleAuthenticationConfig() string {
+	fmt.Println("=== STEP  Testing console_authentication creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_console_authentication" "test" {}
+	`)
+	return resource
+}
+
+func CreateAccAciConsoleAuthenticationConfigWithOptionalValues() string {
+	fmt.Println("=== STEP  Testing console_authentication creation with optional parameters")
+	resource := fmt.Sprint(`
+	resource "aci_console_authentication" "test" {
+		annotation     = "orchestrator:terraform_testacc"
+		provider_group = "60"
+		realm          = "ldap"
+		realm_sub_type = "default"
+		name_alias     = "test_console_authentication"
+		description    = "created while acceptance testing"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccAciConsoleAuthenticationUpdatedAttr(attribute, value string) string {
+	fmt.Printf("=== STEP  Testing console_authentication attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_console_authentication" "test" {
+	
+		%s = "%s"
+	}
+	`, attribute, value)
+	return resource
+}
+

--- a/testacc/resource_aci_aaalogindomain_test.go
+++ b/testacc/resource_aci_aaalogindomain_test.go
@@ -1,0 +1,423 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciLoginDomain_Basic(t *testing.T) {
+	var login_domain_default models.LoginDomain
+	var login_domain_updated models.LoginDomain
+	resourceName := "aci_login_domain.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLoginDomainDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateLoginDomainWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLoginDomainConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLoginDomainExists(resourceName, &login_domain_default),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "provider_group", ""),
+					resource.TestCheckResourceAttr(resourceName, "realm", "local"),
+					resource.TestCheckResourceAttr(resourceName, "realm_sub_type", "default"),
+	
+				),
+			},
+			{
+				Config: CreateAccLoginDomainConfigWithOptionalValues(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLoginDomainExists(resourceName, &login_domain_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "From Terraform"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "login_domain_alias"),
+					resource.TestCheckResourceAttr(resourceName, "provider_group", "60"),
+					resource.TestCheckResourceAttr(resourceName, "realm", "none"),
+					resource.TestCheckResourceAttr(resourceName, "realm_sub_type", "duo"),
+					testAccCheckAciLoginDomainIdEqual(&login_domain_default, &login_domain_updated),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+			{
+				Config:      CreateAccLoginDomainConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccLoginDomainRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+
+			{
+				Config: CreateAccLoginDomainConfigWithRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLoginDomainExists(resourceName, &login_domain_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciLoginDomainIdNotEqual(&login_domain_default, &login_domain_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciLoginDomain_Update(t *testing.T) {
+	var login_domain_default models.LoginDomain
+	var login_domain_updated models.LoginDomain
+	resourceName := "aci_login_domain.test"
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLoginDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLoginDomainConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLoginDomainExists(resourceName, &login_domain_default),
+				),
+			},
+			{
+				Config: CreateAccLoginDomainUpdatedAttr(rName, "realm", "ldap"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLoginDomainExists(resourceName, &login_domain_updated),
+					resource.TestCheckResourceAttr(resourceName, "realm", "ldap"),
+					testAccCheckAciLoginDomainIdEqual(&login_domain_default, &login_domain_updated),
+				),
+			},
+			{
+				Config: CreateAccLoginDomainUpdatedAttr(rName, "realm", "radius"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLoginDomainExists(resourceName, &login_domain_updated),
+					resource.TestCheckResourceAttr(resourceName, "realm", "radius"),
+					testAccCheckAciLoginDomainIdEqual(&login_domain_default, &login_domain_updated),
+				),
+			},
+			{
+				Config: CreateAccLoginDomainUpdatedAttr(rName, "realm", "rsa"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLoginDomainExists(resourceName, &login_domain_updated),
+					resource.TestCheckResourceAttr(resourceName, "realm", "rsa"),
+					testAccCheckAciLoginDomainIdEqual(&login_domain_default, &login_domain_updated),
+				),
+			},
+			{
+				Config: CreateAccLoginDomainUpdatedAttr(rName, "realm", "saml"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLoginDomainExists(resourceName, &login_domain_updated),
+					resource.TestCheckResourceAttr(resourceName, "realm", "saml"),
+					testAccCheckAciLoginDomainIdEqual(&login_domain_default, &login_domain_updated),
+				),
+			},
+			{
+				Config: CreateAccLoginDomainUpdatedAttr(rName, "realm", "tacacs"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLoginDomainExists(resourceName, &login_domain_updated),
+					resource.TestCheckResourceAttr(resourceName, "realm", "tacacs"),
+					testAccCheckAciLoginDomainIdEqual(&login_domain_default, &login_domain_updated),
+				),
+			},
+			{
+				Config: CreateAccLoginDomainUpdatedAttr(rName, "realm", "none"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLoginDomainExists(resourceName, &login_domain_updated),
+					resource.TestCheckResourceAttr(resourceName, "realm", "none"),
+					testAccCheckAciLoginDomainIdEqual(&login_domain_default, &login_domain_updated),
+				),
+			},
+			{
+				Config: CreateAccLoginDomainUpdatedAttr(rName, "provider_group", "0"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLoginDomainExists(resourceName, &login_domain_updated),
+					resource.TestCheckResourceAttr(resourceName, "provider_group", "0"),
+					testAccCheckAciLoginDomainIdEqual(&login_domain_default, &login_domain_updated),
+				),
+			},
+			{
+				Config: CreateAccLoginDomainUpdatedAttr(rName, "provider_group", "63"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLoginDomainExists(resourceName, &login_domain_updated),
+					resource.TestCheckResourceAttr(resourceName, "provider_group", "63"),
+					testAccCheckAciLoginDomainIdEqual(&login_domain_default, &login_domain_updated),
+				),
+			},
+			{
+				Config: CreateAccLoginDomainConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciLoginDomain_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLoginDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLoginDomainConfig(rName),
+			},
+
+			{
+				Config:      CreateAccLoginDomainUpdatedAttr(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLoginDomainUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLoginDomainUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLoginDomainUpdatedAttr(rName, "realm", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccLoginDomainUpdatedAttr(rName, "realm_sub_type", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccLoginDomainUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccLoginDomainConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciLoginDomain_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLoginDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLoginDomainConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciLoginDomainExists(name string, login_domain *models.LoginDomain) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Login Domain %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Login Domain dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		login_domainFound := models.LoginDomainFromContainer(cont)
+		if login_domainFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Login Domain %s not found", rs.Primary.ID)
+		}
+		*login_domain = *login_domainFound
+		return nil
+	}
+}
+
+func testAccCheckAciLoginDomainDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  Testing login_domain destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_login_domain" {
+			cont, err := client.Get(rs.Primary.ID)
+			login_domain := models.LoginDomainFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Login Domain %s Still exists", login_domain.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciLoginDomainIdEqual(m1, m2 *models.LoginDomain) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("login_domain DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciLoginDomainIdNotEqual(m1, m2 *models.LoginDomain) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("login_domain DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateLoginDomainWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Testing login_domain creation without ", attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_login_domain" "test" {
+	
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccLoginDomainConfigWithRequiredParams(rName string) string {
+	fmt.Println("=== STEP  Testing login_domain creation with name", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_login_domain" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+func CreateAccLoginDomainConfigUpdatedName(rName string) string {
+	fmt.Println("=== STEP  Testing login_domain creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_login_domain" "test" {
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLoginDomainConfig(rName string) string {
+	fmt.Println("=== STEP  Testing login_domain creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_login_domain" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLoginDomainConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  Testing multiple login_domain creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_login_domain" "test" {
+	
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLoginDomainConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Testing login_domain creation with optional parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_login_domain" "test" {
+		name             = "%s"
+		annotation       = "orchestrator:terraform_testacc"
+		provider_group   = "60" 
+		realm            = "none"
+		realm_sub_type   = "duo"
+		description      = "From Terraform"
+		name_alias       = "login_domain_alias"
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccLoginDomainRemovingRequiredField() string {
+	fmt.Println("=== STEP  Testing login_domain updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_login_domain" "test" {
+		annotation       = "orchestrator:terraform_testacc"
+		provider_group   = "66" 
+		realm            = "none"
+		realm_sub_type   = "duo"
+		description      = "From Terraform"
+		name_alias       = "login_domain_alias"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccLoginDomainUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  Testing login_domain attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_login_domain" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName, attribute, value)
+	return resource
+}
+
+func CreateAccLoginDomainUpdatedAttrList(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  Testing login_domain attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_login_domain" "test" {
+	
+		name  = "%s"
+		%s = %s
+	}
+	`, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_aaauserdomain_test.go
+++ b/testacc/resource_aci_aaauserdomain_test.go
@@ -1,0 +1,399 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciUserSecurityDomain_Basic(t *testing.T) {
+	var user_security_domain_default models.UserDomain
+	var user_security_domain_updated models.UserDomain
+	resourceName := "aci_user_security_domain.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	aaaUserName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciUserSecurityDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateUserSecurityDomainWithoutRequired(aaaUserName, rName, "local_user_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateUserSecurityDomainWithoutRequired(aaaUserName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccUserSecurityDomainConfig(aaaUserName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciUserSecurityDomainExists(resourceName, &user_security_domain_default),
+					resource.TestCheckResourceAttr(resourceName, "local_user_dn", fmt.Sprintf("uni/userext/user-%s", aaaUserName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+				),
+			},
+			{
+				Config: CreateAccUserSecurityDomainConfigWithOptionalValues(aaaUserName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciUserSecurityDomainExists(resourceName, &user_security_domain_updated),
+					resource.TestCheckResourceAttr(resourceName, "local_user_dn", fmt.Sprintf("uni/userext/user-%s", aaaUserName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_user_security_domain"),
+					testAccCheckAciUserSecurityDomainIdEqual(&user_security_domain_default, &user_security_domain_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccUserSecurityDomainConfigUpdatedName(aaaUserName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			{
+				Config:      CreateAccUserSecurityDomainRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccUserSecurityDomainConfigWithRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciUserSecurityDomainExists(resourceName, &user_security_domain_updated),
+					resource.TestCheckResourceAttr(resourceName, "local_user_dn", fmt.Sprintf("uni/userext/user-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciUserSecurityDomainIdNotEqual(&user_security_domain_default, &user_security_domain_updated),
+				),
+			},
+			{
+				Config: CreateAccUserSecurityDomainConfig(aaaUserName, rName),
+			},
+			{
+				Config: CreateAccUserSecurityDomainConfigWithRequiredParams(aaaUserName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciUserSecurityDomainExists(resourceName, &user_security_domain_updated),
+					resource.TestCheckResourceAttr(resourceName, "local_user_dn", fmt.Sprintf("uni/userext/user-%s", aaaUserName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciUserSecurityDomainIdNotEqual(&user_security_domain_default, &user_security_domain_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciUserSecurityDomain_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	aaaUserName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciUserSecurityDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccUserSecurityDomainConfig(aaaUserName, rName),
+			},
+			{
+				Config:      CreateAccUserSecurityDomainWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccUserSecurityDomainUpdatedAttr(aaaUserName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccUserSecurityDomainUpdatedAttr(aaaUserName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccUserSecurityDomainUpdatedAttr(aaaUserName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccUserSecurityDomainUpdatedAttr(aaaUserName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccUserSecurityDomainConfig(aaaUserName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciUserSecurityDomain_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	aaaUserName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciUserSecurityDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccUserSecurityDomainConfigMultiple(aaaUserName, rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciUserSecurityDomainExists(name string, user_security_domain *models.UserDomain) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("User Security Domain %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No User Security Domain dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		user_security_domainFound := models.UserDomainFromContainer(cont)
+		if user_security_domainFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("User Security Domain %s not found", rs.Primary.ID)
+		}
+		*user_security_domain = *user_security_domainFound
+		return nil
+	}
+}
+
+func testAccCheckAciUserSecurityDomainDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing user_security_domain destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_user_security_domain" {
+			cont, err := client.Get(rs.Primary.ID)
+			user_security_domain := models.UserDomainFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("User Security Domain %s Still exists", user_security_domain.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciUserSecurityDomainIdEqual(m1, m2 *models.UserDomain) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("user_security_domain DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciUserSecurityDomainIdNotEqual(m1, m2 *models.UserDomain) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("user_security_domain DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateUserSecurityDomainWithoutRequired(aaaUserName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing user_security_domain creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	`
+	switch attrName {
+	case "local_user_dn":
+		rBlock += `
+	resource "aci_user_security_domain" "test" {
+	#	local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, aaaUserName, rName)
+}
+
+func CreateAccUserSecurityDomainConfigWithRequiredParams(aaaUserName, rName string) string {
+	fmt.Println("=== STEP  testing user_security_domain creation with updated naming arguments")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+	`, aaaUserName, rName)
+	return resource
+}
+func CreateAccUserSecurityDomainConfigUpdatedName(aaaUserName, rName string) string {
+	fmt.Println("=== STEP  testing user_security_domain creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+	`, aaaUserName, rName)
+	return resource
+}
+
+func CreateAccUserSecurityDomainConfig(aaaUserName, rName string) string {
+	fmt.Println("=== STEP  testing user_security_domain creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+	`, aaaUserName, rName)
+	return resource
+}
+
+func CreateAccUserSecurityDomainConfigMultiple(aaaUserName, rName string) string {
+	fmt.Println("=== STEP  testing multiple user_security_domain creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, aaaUserName, rName)
+	return resource
+}
+
+func CreateAccUserSecurityDomainWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing user_security_domain creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_user_security_domain" "test" {
+		local_user_dn  = aci_tenant.test.id
+		name  = "%s"	
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccUserSecurityDomainConfigWithOptionalValues(aaaUserName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing user_security_domain creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+		
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_user_security_domain"
+		
+	}
+	`, aaaUserName, rName)
+
+	return resource
+}
+
+func CreateAccUserSecurityDomainRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing user_security_domain updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_user_security_domain" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_user_security_domain"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccUserSecurityDomainUpdatedAttr(aaaUserName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing user_security_domain attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, aaaUserName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccUserSecurityDomainUpdatedAttrList(aaaUserName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing user_security_domain attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+		%s = %s
+	}
+	`, aaaUserName, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_aaauserrole_test.go
+++ b/testacc/resource_aci_aaauserrole_test.go
@@ -1,0 +1,443 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciUserSecurityDomainRole_Basic(t *testing.T) {
+	var user_security_domain_role_default models.UserRole
+	var user_security_domain_role_updated models.UserRole
+	resourceName := "aci_user_security_domain_role.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	aaaUserName := makeTestVariable(acctest.RandString(5))
+	aaaUserDomainName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciUserSecurityDomainRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateUserSecurityDomainRoleWithoutRequired(aaaUserName, aaaUserDomainName, rName, "user_domain_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateUserSecurityDomainRoleWithoutRequired(aaaUserName, aaaUserDomainName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccUserSecurityDomainRoleConfig(aaaUserName, aaaUserDomainName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciUserSecurityDomainRoleExists(resourceName, &user_security_domain_role_default),
+					resource.TestCheckResourceAttr(resourceName, "user_domain_dn", fmt.Sprintf("uni/userext/user-%s/userdomain-%s", aaaUserName, aaaUserDomainName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "priv_type", "readPriv"),
+				),
+			},
+			{
+				Config: CreateAccUserSecurityDomainRoleConfigWithOptionalValues(aaaUserName, aaaUserDomainName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciUserSecurityDomainRoleExists(resourceName, &user_security_domain_role_updated),
+					resource.TestCheckResourceAttr(resourceName, "user_domain_dn", fmt.Sprintf("uni/userext/user-%s/userdomain-%s", aaaUserName, aaaUserDomainName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_user_security_domain_role"),
+					resource.TestCheckResourceAttr(resourceName, "priv_type", "writePriv"),
+					testAccCheckAciUserSecurityDomainRoleIdEqual(&user_security_domain_role_default, &user_security_domain_role_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccUserSecurityDomainRoleConfigUpdatedName(aaaUserName, aaaUserDomainName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			{
+				Config:      CreateAccUserSecurityDomainRoleRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccUserSecurityDomainRoleConfigWithRequiredParams(aaaUserName, rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciUserSecurityDomainRoleExists(resourceName, &user_security_domain_role_updated),
+					resource.TestCheckResourceAttr(resourceName, "user_domain_dn", fmt.Sprintf("uni/userext/user-%s/userdomain-%s", aaaUserName, rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciUserSecurityDomainRoleIdNotEqual(&user_security_domain_role_default, &user_security_domain_role_updated),
+				),
+			},
+			{
+				Config: CreateAccUserSecurityDomainRoleConfig(aaaUserName, aaaUserDomainName, rName),
+			},
+			{
+				Config: CreateAccUserSecurityDomainRoleConfigWithRequiredParams(aaaUserName, aaaUserDomainName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciUserSecurityDomainRoleExists(resourceName, &user_security_domain_role_updated),
+					resource.TestCheckResourceAttr(resourceName, "user_domain_dn", fmt.Sprintf("uni/userext/user-%s/userdomain-%s", aaaUserName, aaaUserDomainName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciUserSecurityDomainRoleIdNotEqual(&user_security_domain_role_default, &user_security_domain_role_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciUserSecurityDomainRole_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	aaaUserName := makeTestVariable(acctest.RandString(5))
+	aaaUserDomainName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciUserSecurityDomainRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccUserSecurityDomainRoleConfig(aaaUserName, aaaUserDomainName, rName),
+			},
+			{
+				Config:      CreateAccUserSecurityDomainRoleWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccUserSecurityDomainRoleUpdatedAttr(aaaUserName, aaaUserDomainName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccUserSecurityDomainRoleUpdatedAttr(aaaUserName, aaaUserDomainName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccUserSecurityDomainRoleUpdatedAttr(aaaUserName, aaaUserDomainName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccUserSecurityDomainRoleUpdatedAttr(aaaUserName, aaaUserDomainName, rName, "priv_type", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccUserSecurityDomainRoleUpdatedAttr(aaaUserName, aaaUserDomainName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccUserSecurityDomainRoleConfig(aaaUserName, aaaUserDomainName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciUserSecurityDomainRole_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	aaaUserName := makeTestVariable(acctest.RandString(5))
+	aaaUserDomainName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciUserSecurityDomainRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccUserSecurityDomainRoleConfigMultiple(aaaUserName, aaaUserDomainName, rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciUserSecurityDomainRoleExists(name string, user_security_domain_role *models.UserRole) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("User Security Domain Role %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No User Security Domain Role dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		user_security_domain_roleFound := models.UserRoleFromContainer(cont)
+		if user_security_domain_roleFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("User Security Domain Role %s not found", rs.Primary.ID)
+		}
+		*user_security_domain_role = *user_security_domain_roleFound
+		return nil
+	}
+}
+
+func testAccCheckAciUserSecurityDomainRoleDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing user_security_domain_role destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_user_security_domain_role" {
+			cont, err := client.Get(rs.Primary.ID)
+			user_security_domain_role := models.UserRoleFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("User Security Domain Role %s Still exists", user_security_domain_role.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciUserSecurityDomainRoleIdEqual(m1, m2 *models.UserRole) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("user_security_domain_role DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciUserSecurityDomainRoleIdNotEqual(m1, m2 *models.UserRole) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("user_security_domain_role DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateUserSecurityDomainRoleWithoutRequired(aaaUserName, aaaUserDomainName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing user_security_domain_role creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+	
+	`
+	switch attrName {
+	case "user_domain_dn":
+		rBlock += `
+	resource "aci_user_security_domain_role" "test" {
+	#	user_domain_dn  =  aci_user_security_domain.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_user_security_domain_role" "test" {
+		user_domain_dn  =  aci_user_security_domain.test.id
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, aaaUserName, aaaUserDomainName, rName)
+}
+
+func CreateAccUserSecurityDomainRoleConfigWithRequiredParams(aaaUserName, aaaUserDomainName, rName string) string {
+	fmt.Println("=== STEP  testing user_security_domain_role creation with updated naming arguments")
+	resource := fmt.Sprintf(`
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+	
+	resource "aci_user_security_domain_role" "test" {
+		user_domain_dn  =  aci_user_security_domain.test.id
+		name  = "%s"
+	}
+	`, aaaUserName, aaaUserDomainName, rName)
+	return resource
+}
+func CreateAccUserSecurityDomainRoleConfigUpdatedName(aaaUserName, aaaUserDomainName, rName string) string {
+	fmt.Println("=== STEP  testing user_security_domain_role creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+	
+	resource "aci_user_security_domain_role" "test" {
+		user_domain_dn  =  aci_user_security_domain.test.id
+		name  = "%s"
+	}
+	`, aaaUserName, aaaUserDomainName, rName)
+	return resource
+}
+
+func CreateAccUserSecurityDomainRoleConfig(aaaUserName, aaaUserDomainName, rName string) string {
+	fmt.Println("=== STEP  testing user_security_domain_role creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+
+	resource "aci_user_security_domain_role" "test" {
+		user_domain_dn  =  aci_user_security_domain.test.id
+		name  = "%s"
+	}
+	`, aaaUserName, aaaUserDomainName, rName)
+	return resource
+}
+
+func CreateAccUserSecurityDomainRoleConfigMultiple(aaaUserName, aaaUserDomainName, rName string) string {
+	fmt.Println("=== STEP  testing multiple user_security_domain_role creation with required arguments only")
+	resource := fmt.Sprintf(`
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+	
+	resource "aci_user_security_domain_role" "test" {
+		user_domain_dn  =  aci_user_security_domain.test.id
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, aaaUserName, aaaUserDomainName, rName)
+	return resource
+}
+
+func CreateAccUserSecurityDomainRoleWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing user_security_domain_role creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_user_security_domain_role" "test" {
+		user_domain_dn  = aci_tenant.test.id
+		name  = "%s"	
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccUserSecurityDomainRoleConfigWithOptionalValues(aaaUserName, aaaUserDomainName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing user_security_domain_role creation with optional parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+	
+	resource "aci_user_security_domain_role" "test" {
+		user_domain_dn  = "${ aci_user_security_domain.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_user_security_domain_role"
+		priv_type = "writePriv"
+		
+	}
+	`, aaaUserName, aaaUserDomainName, rName)
+
+	return resource
+}
+
+func CreateAccUserSecurityDomainRoleRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing user_security_domain_role updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_user_security_domain_role" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_user_security_domain_role"
+		priv_type = "writePriv"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccUserSecurityDomainRoleUpdatedAttr(aaaUserName, aaaUserDomainName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing user_security_domain_role attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+
+	resource "aci_user_security_domain_role" "test" {
+		user_domain_dn  =  aci_user_security_domain.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, aaaUserName, aaaUserDomainName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccUserSecurityDomainRoleUpdatedAttrList(aaaUserName, aaaUserDomainName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing user_security_domain_role attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_user_security_domain" "test" {
+		local_user_dn = aci_local_user.test.id
+		name  = "%s"
+	}
+	
+	resource "aci_user_security_domain_role" "test" {
+		user_domain_dn  =  aci_user_security_domain.test.id
+		name  = "%s"
+		%s = %s
+	}
+	`, aaaUserName, aaaUserDomainName, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_edrErrDisRecoverPol_test.go
+++ b/testacc/resource_aci_edrErrDisRecoverPol_test.go
@@ -1,0 +1,233 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/terraform-providers/terraform-provider-aci/aci"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciErrorDisableRecovery_Basic(t *testing.T) {
+	var error_disable_recovery_default models.ErrorDisabledRecoveryPolicy
+	var error_disable_recovery_updated models.ErrorDisabledRecoveryPolicy
+	resourceName := "aci_error_disable_recovery.test"
+	edrErrDisRecoverPol, err := aci.GetRemoteErrorDisabledRecoveryPolicy(sharedAciClient(), "uni/infra/edrErrDisRecoverPol-default")
+	if err != nil {
+		t.Errorf("reading initial config of edrErrDisRecoverPol")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccErrorDisabledRecoveryConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciErrorDisabledRecoveryExists(resourceName, &error_disable_recovery_default),
+					resource.TestCheckResourceAttrSet(resourceName, "err_dis_recov_intvl"),
+				),
+			},
+			{
+				Config: CreateAccErrorDisabledRecoveryConfigWithOptionalValues(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciErrorDisabledRecoveryExists(resourceName, &error_disable_recovery_updated),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_error_disable_recovery"),
+					resource.TestCheckResourceAttr(resourceName, "err_dis_recov_intvl", "30"),
+					testAccCheckAciErrorDisabledRecoveryIdEqual(&error_disable_recovery_default, &error_disable_recovery_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: restoreErrorDisabledRecoveryPolicy(edrErrDisRecoverPol),
+			},
+		},
+	})
+}
+
+func TestAccAciErrorDisableRecovery_Update(t *testing.T) {
+	var error_disable_recovery_default models.ErrorDisabledRecoveryPolicy
+	var error_disable_recovery_updated models.ErrorDisabledRecoveryPolicy
+	resourceName := "aci_error_disable_recovery.test"
+	edrErrDisRecoverPol, err := aci.GetRemoteErrorDisabledRecoveryPolicy(sharedAciClient(), "uni/infra/edrErrDisRecoverPol-default")
+	if err != nil {
+		t.Errorf("reading initial config of edrErrDisRecoverPol")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccErrorDisabledRecoveryConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciErrorDisabledRecoveryExists(resourceName, &error_disable_recovery_default),
+				),
+			},
+			{
+				Config: CreateAccErrorDisabledRecoveryUpdatedAttr("err_dis_recov_intvl", "65535"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciErrorDisabledRecoveryExists(resourceName, &error_disable_recovery_updated),
+					resource.TestCheckResourceAttr(resourceName, "err_dis_recov_intvl", "65535"),
+					testAccCheckAciErrorDisabledRecoveryIdEqual(&error_disable_recovery_default, &error_disable_recovery_updated),
+				),
+			},
+			{
+				Config: CreateAccErrorDisabledRecoveryUpdatedAttr("err_dis_recov_intvl", "32767"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciErrorDisabledRecoveryExists(resourceName, &error_disable_recovery_updated),
+					resource.TestCheckResourceAttr(resourceName, "err_dis_recov_intvl", "32767"),
+					testAccCheckAciErrorDisabledRecoveryIdEqual(&error_disable_recovery_default, &error_disable_recovery_updated),
+				),
+			},
+			{
+				Config: restoreErrorDisabledRecoveryPolicy(edrErrDisRecoverPol),
+			},
+		},
+	})
+}
+
+func TestAccAciErrorDisableRecovery_Negative(t *testing.T) {
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	edrErrDisRecoverPol, err := aci.GetRemoteErrorDisabledRecoveryPolicy(sharedAciClient(), "uni/infra/edrErrDisRecoverPol-default")
+	if err != nil {
+		t.Errorf("reading initial config of edrErrDisRecoverPol")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccErrorDisabledRecoveryConfig(),
+			},
+			{
+				Config:      CreateAccErrorDisabledRecoveryUpdatedAttr("description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccErrorDisabledRecoveryUpdatedAttr("annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccErrorDisabledRecoveryUpdatedAttr("name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccErrorDisabledRecoveryUpdatedAttr("err_dis_recov_intvl", "29"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccErrorDisabledRecoveryUpdatedAttr("err_dis_recov_intvl", "65536"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccErrorDisabledRecoveryUpdatedAttr("err_dis_recov_intvl", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccErrorDisabledRecoveryUpdatedAttr(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: restoreErrorDisabledRecoveryPolicy(edrErrDisRecoverPol),
+			},
+		},
+	})
+}
+
+func restoreErrorDisabledRecoveryPolicy(edrErrDisRecoverPol *models.ErrorDisabledRecoveryPolicy) string {
+	resource := fmt.Sprintf(`
+	resource "aci_error_disable_recovery" "test" {
+		annotation = "%s"
+		description = "%s"
+		name_alias = "%s"
+		err_dis_recov_intvl = "%s"
+	}
+	`, edrErrDisRecoverPol.Annotation, edrErrDisRecoverPol.Description, edrErrDisRecoverPol.NameAlias, edrErrDisRecoverPol.ErrDisRecovIntvl)
+	return resource
+}
+
+func testAccCheckAciErrorDisabledRecoveryExists(name string, error_disable_recovery *models.ErrorDisabledRecoveryPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Error Disable Recovery %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Error Disable Recovery dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		error_disable_recoveryFound := models.ErrorDisabledRecoveryPolicyFromContainer(cont)
+		if error_disable_recoveryFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Error Disable Recovery %s not found", rs.Primary.ID)
+		}
+		*error_disable_recovery = *error_disable_recoveryFound
+		return nil
+	}
+}
+
+func testAccCheckAciErrorDisabledRecoveryIdEqual(m1, m2 *models.ErrorDisabledRecoveryPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("error_disable_recovery DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func CreateAccErrorDisabledRecoveryConfig() string {
+	fmt.Println("=== STEP  Testing error_disable_recovery creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_error_disable_recovery" "test" {}
+	`)
+	return resource
+}
+
+func CreateAccErrorDisabledRecoveryConfigWithOptionalValues() string {
+	fmt.Println("=== STEP  Testing error_disable_recovery creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_error_disable_recovery" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_error_disable_recovery"
+        err_dis_recov_intvl = "30"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccErrorDisabledRecoveryUpdatedAttr(attribute, value string) string {
+	fmt.Printf("=== STEP  Testing error_disable_recovery attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_error_disable_recovery" "test" {
+	
+		%s = "%s"
+	}
+	`, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_epcontrolp_test.go
+++ b/testacc/resource_aci_epcontrolp_test.go
@@ -80,6 +80,14 @@ func TestAccAciEndpointControls_Update(t *testing.T) {
 				),
 			},
 			{
+				Config: CreateAccEndpointControlsUpdatedAttr("admin_st", "disabled"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciEndpointControlsExists(resourceName, &endpoint_controls_updated),
+					resource.TestCheckResourceAttr(resourceName, "admin_st", "disabled"),
+					testAccCheckAciEndpointControlsIdEqual(&endpoint_controls_default, &endpoint_controls_updated),
+				),
+			},
+			{
 				Config: CreateAccEndpointControlsUpdatedAttr("hold_intvl", "3600"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciEndpointControlsExists(resourceName, &endpoint_controls_updated),

--- a/testacc/resource_aci_eploopprotectp_test.go
+++ b/testacc/resource_aci_eploopprotectp_test.go
@@ -80,11 +80,11 @@ func TestAccAciEndpointLoopProtection_Update(t *testing.T) {
 				),
 			},
 			{
-				Config: CreateAccEndpointLoopProtectionUpdatedAttrList("action", StringListtoString([]string{"bd-learn-disable"})),
+				Config: CreateAccEndpointLoopProtectionUpdatedAttrList("action", StringListtoString([]string{"port-disable"})),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciEndpointLoopProtectionExists(resourceName, &endpoint_loop_protection_updated),
 					resource.TestCheckResourceAttr(resourceName, "action.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "action.0", "bd-learn-disable"),
+					resource.TestCheckResourceAttr(resourceName, "action.0", "port-disable"),
 				),
 			},
 			{
@@ -103,6 +103,14 @@ func TestAccAciEndpointLoopProtection_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "action.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "action.0", "port-disable"),
 					resource.TestCheckResourceAttr(resourceName, "action.1", "bd-learn-disable"),
+				),
+			},
+			{
+				Config: CreateAccEndpointLoopProtectionUpdatedAttr("admin_st", "disabled"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciEndpointLoopProtectionExists(resourceName, &endpoint_loop_protection_updated),
+					resource.TestCheckResourceAttr(resourceName, "admin_st", "disabled"),
+					testAccCheckAciEndpointLoopProtectionIdEqual(&endpoint_loop_protection_default, &endpoint_loop_protection_updated),
 				),
 			},
 			{

--- a/testacc/resource_aci_mcpinstpol_test.go
+++ b/testacc/resource_aci_mcpinstpol_test.go
@@ -1,0 +1,495 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aci/aci"
+)
+
+func TestAccAciMCPInstancePolicy_Basic(t *testing.T) {
+	var mcp_instance_policy_default models.MiscablingProtocolInstancePolicy
+	var mcp_instance_policy_updated models.MiscablingProtocolInstancePolicy
+	resourceName := "aci_mcp_instance_policy.test"
+	key := acctest.RandString(5)
+	mcpInstancePolicy, err := aci.GetRemoteMiscablingProtocolInstancePolicy(sharedAciClient(), "uni/infra/mcpInstP-default")
+	if err != nil {
+		t.Errorf("reading initial config of MCP Instance Policy")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateMCPInstancePolicyWithoutRequired(key, "key"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyConfig(key),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMCPInstancePolicyExists(resourceName, &mcp_instance_policy_default),
+					resource.TestCheckResourceAttr(resourceName, "key", key),
+					resource.TestCheckResourceAttrSet(resourceName, "admin_st"),
+					resource.TestCheckResourceAttrSet(resourceName, "init_delay_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "loop_detect_mult"),
+					resource.TestCheckResourceAttrSet(resourceName, "loop_protect_act"),
+					resource.TestCheckResourceAttrSet(resourceName, "loop_protect_act"),
+					resource.TestCheckResourceAttrSet(resourceName, "tx_freq"),
+					resource.TestCheckResourceAttrSet(resourceName, "tx_freq_msec"),
+				),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyConfigWithOptionalValues(key),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMCPInstancePolicyExists(resourceName, &mcp_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "key", key),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_mcp_instance_policy"),
+					resource.TestCheckResourceAttr(resourceName, "admin_st", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.0", "pdu-per-vlan"),
+					resource.TestCheckResourceAttr(resourceName, "init_delay_time", "0"),
+					resource.TestCheckResourceAttr(resourceName, "loop_detect_mult", "1"),
+					resource.TestCheckResourceAttr(resourceName, "loop_protect_act", "port-disable"),
+					resource.TestCheckResourceAttr(resourceName, "tx_freq", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tx_freq_msec", "100"),
+					testAccCheckAciMCPInstancePolicyIdEqual(&mcp_instance_policy_default, &mcp_instance_policy_updated),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"key"},
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyInitialConfig(key, mcpInstancePolicy),
+			},
+		},
+	})
+}
+
+func TestAccAciMCPInstancePolicy_Update(t *testing.T) {
+	var mcp_instance_policy_default models.MiscablingProtocolInstancePolicy
+	var mcp_instance_policy_updated models.MiscablingProtocolInstancePolicy
+	resourceName := "aci_mcp_instance_policy.test"
+	key := acctest.RandString(5)
+	mcpInstancePolicy, err := aci.GetRemoteMiscablingProtocolInstancePolicy(sharedAciClient(), "uni/infra/mcpInstP-default")
+	if err != nil {
+		t.Errorf("reading initial config of MCP Instance Policy")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccMCPInstancePolicyConfig(key),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMCPInstancePolicyExists(resourceName, &mcp_instance_policy_default),
+				),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyUpdatedAttrList(key, "ctrl", StringListtoString([]string{"pdu-per-vlan"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMCPInstancePolicyExists(resourceName, &mcp_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.0", "pdu-per-vlan"),
+				),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyUpdatedAttrList(key, "ctrl", StringListtoString([]string{"pdu-per-vlan", "stateful-ha"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMCPInstancePolicyExists(resourceName, &mcp_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.0", "pdu-per-vlan"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.1", "stateful-ha"),
+				),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyUpdatedAttrList(key, "ctrl", StringListtoString([]string{"stateful-ha"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMCPInstancePolicyExists(resourceName, &mcp_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.0", "stateful-ha"),
+				),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyUpdatedAttrList(key, "ctrl", StringListtoString([]string{"stateful-ha", "pdu-per-vlan"})),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMCPInstancePolicyExists(resourceName, &mcp_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.0", "stateful-ha"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl.1", "pdu-per-vlan"),
+				),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyUpdatedAttrList(key, "ctrl", "[]"),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyUpdatedAttr(key, "admin_st", "disabled"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMCPInstancePolicyExists(resourceName, &mcp_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "admin_st", "disabled"),
+					testAccCheckAciMCPInstancePolicyIdEqual(&mcp_instance_policy_default, &mcp_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyUpdatedAttr(key, "init_delay_time", "1800"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMCPInstancePolicyExists(resourceName, &mcp_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "init_delay_time", "1800"),
+					testAccCheckAciMCPInstancePolicyIdEqual(&mcp_instance_policy_default, &mcp_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyUpdatedAttr(key, "init_delay_time", "900"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMCPInstancePolicyExists(resourceName, &mcp_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "init_delay_time", "900"),
+					testAccCheckAciMCPInstancePolicyIdEqual(&mcp_instance_policy_default, &mcp_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyUpdatedAttr(key, "loop_detect_mult", "255"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMCPInstancePolicyExists(resourceName, &mcp_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "loop_detect_mult", "255"),
+					testAccCheckAciMCPInstancePolicyIdEqual(&mcp_instance_policy_default, &mcp_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyUpdatedAttr(key, "loop_detect_mult", "127"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMCPInstancePolicyExists(resourceName, &mcp_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "loop_detect_mult", "127"),
+					testAccCheckAciMCPInstancePolicyIdEqual(&mcp_instance_policy_default, &mcp_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyUpdatedAttr(key, "loop_protect_act", "port-disable"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMCPInstancePolicyExists(resourceName, &mcp_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "loop_protect_act", "port-disable"),
+				),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyUpdatedAttr(key, "tx_freq_msec", "500"),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyUpdatedAttr(key, "tx_freq", "299"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMCPInstancePolicyExists(resourceName, &mcp_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tx_freq", "299"),
+					testAccCheckAciMCPInstancePolicyIdEqual(&mcp_instance_policy_default, &mcp_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyUpdatedAttr(key, "tx_freq", "150"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMCPInstancePolicyExists(resourceName, &mcp_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tx_freq", "150"),
+					testAccCheckAciMCPInstancePolicyIdEqual(&mcp_instance_policy_default, &mcp_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyUpdatedAttr(key, "tx_freq_msec", "999"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMCPInstancePolicyExists(resourceName, &mcp_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tx_freq_msec", "999"),
+					testAccCheckAciMCPInstancePolicyIdEqual(&mcp_instance_policy_default, &mcp_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyUpdatedAttr(key, "tx_freq_msec", "499"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciMCPInstancePolicyExists(resourceName, &mcp_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "tx_freq_msec", "499"),
+					testAccCheckAciMCPInstancePolicyIdEqual(&mcp_instance_policy_default, &mcp_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyInitialConfig(key, mcpInstancePolicy),
+			},
+		},
+	})
+}
+
+func TestAccAciMCPInstancePolicy_Negative(t *testing.T) {
+	key := acctest.RandString(5)
+	mcpInstancePolicy, err := aci.GetRemoteMiscablingProtocolInstancePolicy(sharedAciClient(), "uni/infra/mcpInstP-default")
+	if err != nil {
+		t.Errorf("reading initial config of MCP Instance Policy")
+	}
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccMCPInstancePolicyConfig(key),
+			},
+
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, "admin_st", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttrList(key, "ctrl", StringListtoString([]string{randomValue})),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttrList(key, "ctrl", StringListtoString([]string{"pdu-per-vlan", "pdu-per-vlan"})),
+				ExpectError: regexp.MustCompile(`duplication is not supported in list`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, "init_delay_time", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, "init_delay_time", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, "init_delay_time", "1801"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, "loop_detect_mult", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, "loop_detect_mult", "0"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, "loop_detect_mult", "256"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, "loop_protect_act", randomValue),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, "tx_freq", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, "tx_freq", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, "tx_freq", "301"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, "tx_freq_msec", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, "tx_freq_msec", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, "tx_freq_msec", "1000"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccMCPInstancePolicyUpdatedAttr(key, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccMCPInstancePolicyInitialConfig(key, mcpInstancePolicy),
+			},
+		},
+	})
+}
+
+func testAccCheckAciMCPInstancePolicyExists(name string, mcp_instance_policy *models.MiscablingProtocolInstancePolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("MCP Instance Policy %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No MCP Instance Policy dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		mcp_instance_policyFound := models.MiscablingProtocolInstancePolicyFromContainer(cont)
+		if mcp_instance_policyFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("MCP Instance Policy %s not found", rs.Primary.ID)
+		}
+		*mcp_instance_policy = *mcp_instance_policyFound
+		return nil
+	}
+}
+
+func testAccCheckAciMCPInstancePolicyIdEqual(m1, m2 *models.MiscablingProtocolInstancePolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("mcp_instance_policy DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciMCPInstancePolicyIdNotEqual(m1, m2 *models.MiscablingProtocolInstancePolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("mcp_instance_policy DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateMCPInstancePolicyWithoutRequired(key, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing mcp_instance_policy creation without ", attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "key":
+		rBlock += `
+	resource "aci_mcp_instance_policy" "test" {
+	
+	#	key  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, key)
+}
+
+func CreateAccMCPInstancePolicyConfig(key string) string {
+	fmt.Println("=== STEP  testing mcp_instance_policy creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_mcp_instance_policy" "test" {
+	
+		key  = "%s"
+	}
+	`, key)
+	return resource
+}
+
+func CreateAccMCPInstancePolicyConfigWithOptionalValues(key string) string {
+	fmt.Println("=== STEP  Basic: testing mcp_instance_policy creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_mcp_instance_policy" "test" {
+	
+		key  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_mcp_instance_policy"
+		admin_st = "enabled"
+		ctrl = ["pdu-per-vlan"]
+		init_delay_time = "0"
+		loop_detect_mult = "1"
+		loop_protect_act = "port-disable"
+		tx_freq = "0"
+		tx_freq_msec = "100"	
+	}
+	`, key)
+
+	return resource
+}
+
+func CreateAccMCPInstancePolicyInitialConfig(key string, mcpInstancePolicy *models.MiscablingProtocolInstancePolicy) string {
+	fmt.Println("=== STEP  Basic: testing mcp_instance_policy creation with Initial Config")
+	resource := fmt.Sprintf(`
+	resource "aci_mcp_instance_policy" "test" {
+		key  = "%s"
+		description = "%s"
+		annotation = "%s"
+		name_alias = "%s"
+		admin_st = "%s"
+		ctrl = %s
+		init_delay_time = "%s"
+		loop_detect_mult = "%s"
+		loop_protect_act = "%s"
+		tx_freq = "%s"
+		tx_freq_msec = "%s"
+	}
+	`, key, mcpInstancePolicy.Description, mcpInstancePolicy.Annotation, mcpInstancePolicy.NameAlias, mcpInstancePolicy.AdminSt, StringListtoString(convertToStringArray(mcpInstancePolicy.Ctrl)), mcpInstancePolicy.InitDelayTime, mcpInstancePolicy.LoopDetectMult, mcpInstancePolicy.LoopProtectAct, mcpInstancePolicy.TxFreq, mcpInstancePolicy.TxFreqMsec)
+	return resource
+}
+
+func CreateAccMCPInstancePolicyRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing mcp_instance_policy updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_mcp_instance_policy" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_mcp_instance_policy"
+		admin_st = "enabled"
+		ctrl = ["pdu-per-vlan"]
+		init_delay_time = "1"
+		loop_detect_mult = "2"
+		loop_protect_act = "port-disable"
+		tx_freq = "1"
+		tx_freq_msec = "1"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccMCPInstancePolicyUpdatedAttr(key, attribute, value string) string {
+	fmt.Printf("=== STEP  testing mcp_instance_policy attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_mcp_instance_policy" "test" {
+	
+		key  = "%s"
+		%s = "%s"
+	}
+	`, key, attribute, value)
+	return resource
+}
+
+func CreateAccMCPInstancePolicyUpdatedAttrList(key, attribute, value string) string {
+	fmt.Printf("=== STEP  testing mcp_instance_policy attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_mcp_instance_policy" "test" {
+	
+		key  = "%s"
+		%s = %s
+	}
+	`, key, attribute, value)
+	return resource
+}

--- a/testacc/utils.go
+++ b/testacc/utils.go
@@ -239,7 +239,7 @@ func GetQuoted(s string) string {
 func StringListtoString(list []string) string {
 	val := ""
 	if len(list) == 1 && list[0] == "" {
-		return "\"\""
+		return "[]"
 	}
 	val = val + "["
 	for i := 0; i < len(list)-1; i++ {

--- a/website/docs/d/mcp_instance_policy.html.markdown
+++ b/website/docs/d/mcp_instance_policy.html.markdown
@@ -37,7 +37,6 @@ data "aci_mcp_instance_policy" "example" {}
 * `admin_st` - (Optional) Admin State. The administrative state of the object or policy.
 * `ctrl` - (Optional) Controls. The control state.
 * `init_delay_time` - (Optional) Init Delay Time. 
-* `key` - (optional) Secret Key. The key or password used to uniquely identify this configuration object.
 * `loop_detect_mult` - (Optional) Loop Detection Multiplier. 
 * `loop_protect_act` - (Optional) Loop Protection Action. 
 * `tx_freq` - (Optional) Transmission Frequency. Sets the transmission frequency of the instance advertisements.

--- a/website/docs/r/login_domain.html.markdown
+++ b/website/docs/r/login_domain.html.markdown
@@ -27,8 +27,8 @@ Manages ACI Login Domain
 resource "aci_login_domain" "example" {
   name             = "example"
   annotation       = "orchestrator:terraform"
-  provider_group   = "example" 
-  realm            = "local"
+  provider_group   = "60" 
+  realm            = "none"
   realm_sub_type   = "default"
   description      = "From Terraform"
   name_alias       = "login_domain_alias"


### PR DESCRIPTION
$ go test -v -run TestAccAciEndpointLoopProtection_Update -timeout=60m
=== RUN   TestAccAciEndpointLoopProtection_Update
=== STEP  testing endpoint_loop_protection creation with required arguments only
=== STEP  testing endpoint_loop_protection attribute: action = ["port-disable"]
=== STEP  testing endpoint_loop_protection attribute: action = ["bd-learn-disable","port-disable"]
=== STEP  testing endpoint_loop_protection attribute: action = ["port-disable","bd-learn-disable"]
=== STEP  testing endpoint_loop_protection attribute: admin_st = disabled
=== STEP  testing endpoint_loop_protection attribute: loop_detect_intvl = 300
=== STEP  testing endpoint_loop_protection attribute: loop_detect_intvl = 135
=== STEP  testing endpoint_loop_protection attribute: loop_detect_mult = 255
=== STEP  testing endpoint_loop_protection attribute: loop_detect_mult = 127
=== STEP  Basic: testing endpoint_loop_protection creation with initial config
--- PASS: TestAccAciEndpointLoopProtection_Update (366.31s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   368.153s

$ go test -v -run TestAccAciEndpointLoopProtectionDataSource_Basic -timeout=60m
=== RUN   TestAccAciEndpointLoopProtectionDataSource_Basic
=== STEP  testing endpoint_loop_protection Data Source with required arguments only
=== STEP  testing endpoint_loop_protection Data Source with random attribute
=== STEP  testing endpoint_loop_protection Data Source with updated resource
=== STEP  Basic: testing endpoint_loop_protection creation with initial config
--- PASS: TestAccAciEndpointLoopProtectionDataSource_Basic (189.89s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   191.904s

$ go test -v -run TestAccAciEndpointControls_Update -timeout=60m
=== RUN   TestAccAciEndpointControls_Update
=== STEP  testing endpoint_controls creation with required arguments only
=== STEP  testing endpoint_controls attribute: admin_st = disabled
=== STEP  testing endpoint_controls attribute: hold_intvl = 3600
=== STEP  testing endpoint_controls attribute: hold_intvl = 1650
=== STEP  testing endpoint_controls attribute: rogue_ep_detect_intvl = 3600
=== STEP  testing endpoint_controls attribute: rogue_ep_detect_intvl = 1785
=== STEP  testing endpoint_controls attribute: rogue_ep_detect_mult = 65535
=== STEP  testing endpoint_controls attribute: rogue_ep_detect_mult = 32766
=== STEP  Basic: testing endpoint_controls creation with Initial Config
--- PASS: TestAccAciEndpointControls_Update (756.15s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   757.682s



$ go test -v -run TestAccAciMCPInstancePolicy -timeout=60m
=== RUN   TestAccAciMCPInstancePolicyDataSource_Basic
=== STEP  testing mcp_instance_policy Data Source with required arguments only
=== STEP  testing mcp_instance_policy Data Source with random attribute
=== STEP  testing mcp_instance_policy Data Source with updated resource
=== STEP  Basic: testing mcp_instance_policy creation with Initial Config
--- PASS: TestAccAciMCPInstancePolicyDataSource_Basic (178.29s)

$ go test -v -run TestAccAciMCPInstancePolicy_Basic -timeout=60m
=== RUN   TestAccAciMCPInstancePolicy_Basic
=== STEP  Basic: testing mcp_instance_policy creation without  key
=== STEP  testing mcp_instance_policy creation with required arguments only
=== STEP  Basic: testing mcp_instance_policy creation with optional parameters
=== STEP  Basic: testing mcp_instance_policy updation without required parameters
=== STEP  Basic: testing mcp_instance_policy creation with Initial Config
--- PASS: TestAccAciMCPInstancePolicy_Basic (181.44s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   183.207s

$ go test -v -run TestAccAciMCPInstancePolicy_Negative -timeout=60m
=== RUN   TestAccAciMCPInstancePolicy_Negative
=== STEP  testing mcp_instance_policy creation with required arguments only
=== STEP  testing mcp_instance_policy attribute: description = iowm3qpc6q8dvicu62822hjadxai8q2h7ovwknpfj
=== STEP  testing mcp_instance_policy attribute: annotation = dg4tnjwnlwsoi2f9cgx46aqfvb2sf6wuwmnqa34lm1
=== STEP  testing mcp_instance_policy attribute: name_alias = u2rjmnozkwkpo80i009t9x9ohtz8vjf48ucbuicxoi
=== STEP  testing mcp_instance_policy attribute: admin_st = ygcr7
=== STEP  testing mcp_instance_policy attribute: ctrl = ["ygcr7"]
=== STEP  testing mcp_instance_policy attribute: ctrl = ["pdu-per-vlan","pdu-per-vlan"]
=== STEP  testing mcp_instance_policy attribute: init_delay_time = ygcr7
=== STEP  testing mcp_instance_policy attribute: init_delay_time = -1
=== STEP  testing mcp_instance_policy attribute: init_delay_time = 1801
=== STEP  testing mcp_instance_policy attribute: loop_detect_mult = ygcr7
=== STEP  testing mcp_instance_policy attribute: loop_detect_mult = 0
=== STEP  testing mcp_instance_policy attribute: loop_detect_mult = 256
=== STEP  testing mcp_instance_policy attribute: loop_protect_act = ygcr7
=== STEP  testing mcp_instance_policy attribute: tx_freq = ygcr7
=== STEP  testing mcp_instance_policy attribute: tx_freq = -1
=== STEP  testing mcp_instance_policy attribute: tx_freq = 301
=== STEP  testing mcp_instance_policy attribute: tx_freq_msec = ygcr7
=== STEP  testing mcp_instance_policy attribute: tx_freq_msec = -1
=== STEP  testing mcp_instance_policy attribute: tx_freq_msec = 1000
=== STEP  testing mcp_instance_policy attribute: crrzd = ygcr7
=== STEP  Basic: testing mcp_instance_policy creation with Initial Config
--- PASS: TestAccAciMCPInstancePolicy_Negative (357.20s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   358.828s

$ go test -v -run TestAccAciMCPInstancePolicy_Update -timeout=60m
=== RUN   TestAccAciMCPInstancePolicy_Update
=== STEP  testing mcp_instance_policy creation with required arguments only
=== STEP  testing mcp_instance_policy attribute: ctrl = ["pdu-per-vlan"]
=== STEP  testing mcp_instance_policy attribute: ctrl = ["pdu-per-vlan","stateful-ha"]
=== STEP  testing mcp_instance_policy attribute: ctrl = ["stateful-ha"]
=== STEP  testing mcp_instance_policy attribute: ctrl = ["stateful-ha","pdu-per-vlan"]
=== STEP  testing mcp_instance_policy attribute: ctrl = []
=== STEP  testing mcp_instance_policy attribute: admin_st = disabled
=== STEP  testing mcp_instance_policy attribute: init_delay_time = 1800
=== STEP  testing mcp_instance_policy attribute: init_delay_time = 900
=== STEP  testing mcp_instance_policy attribute: loop_detect_mult = 255
=== STEP  testing mcp_instance_policy attribute: loop_detect_mult = 127
=== STEP  testing mcp_instance_policy attribute: loop_protect_act = port-disable
=== STEP  testing mcp_instance_policy attribute: tx_freq_msec = 500
=== STEP  testing mcp_instance_policy attribute: tx_freq = 299
=== STEP  testing mcp_instance_policy attribute: tx_freq = 150
=== STEP  testing mcp_instance_policy attribute: tx_freq_msec = 999
=== STEP  testing mcp_instance_policy attribute: tx_freq_msec = 499
=== STEP  Basic: testing mcp_instance_policy creation with Initial Config
--- PASS: TestAccAciMCPInstancePolicy_Update (659.48s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   661.050s

$ go test -v -run TestAccAciConsoleAuthentication -timeout=60m
=== RUN   TestAccAciConsoleAuthenticationDataSource_Basic
=== STEP  Testing console_authentication Data Source with required arguments only
=== STEP  Testing console_authentication Data Source with random attribute
=== STEP  Testing console_authentication Data Source with updated resource
--- PASS: TestAccAciConsoleAuthenticationDataSource_Basic (135.99s)
=== RUN   TestAccAciConsoleAuthentication_Basic
=== STEP  Testing console_authentication creation with required arguments only
=== STEP  Testing console_authentication creation with optional parameters
--- PASS: TestAccAciConsoleAuthentication_Basic (155.10s)
=== RUN   TestAccAciConsoleAuthentication_Update
=== STEP  Testing console_authentication creation with required arguments only
=== STEP  Testing console_authentication attribute: realm = local
=== STEP  Testing console_authentication attribute: realm = radius
=== STEP  Testing console_authentication attribute: realm = rsa
=== STEP  Testing console_authentication attribute: realm = saml
=== STEP  Testing console_authentication attribute: realm = tacacs
=== STEP  Testing console_authentication attribute: realm_sub_type = duo
=== STEP  Testing console_authentication attribute: provider_group = 0
=== STEP  Testing console_authentication attribute: provider_group = 63
--- PASS: TestAccAciConsoleAuthentication_Update (327.38s)
=== RUN   TestAccAciConsoleAuthentication_Negative
=== STEP  Testing console_authentication creation with required arguments only
=== STEP  Testing console_authentication attribute: description = v92orziljc0hi20yuy4iipqpoyysu2efirhpyikkr9y7o3b2rsk3w8s3ssnlnchbietorhooh1p6q2drk68nlr4ggzglwa0jxnge0etg1uymjzbdejnmul3a3eo320apj
=== STEP  Testing console_authentication attribute: annotation = 9fdskv2m9taynfdzjx9spi2j6jp8ih7bh9fexzjstuonlxwoxj147etsdzusa1b639l9q10u4ejem2mdapkqj677qczj0i0ir8sqy01ivuc94zouj3pnfipda6gfgwtuw
=== STEP  Testing console_authentication attribute: name_alias = 0y9emu9mhjevk124ia4rqdaainjzvrj9riplphvwyorv3an17jqvhmtpx2syibdx
=== STEP  Testing console_authentication attribute: realm = u6ed6
=== STEP  Testing console_authentication attribute: realm_sub_type = u6ed6
=== STEP  Testing console_authentication attribute: yxokr = u6ed6
--- PASS: TestAccAciConsoleAuthentication_Negative (138.24s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   758.253s

$ go test -v -run TestAccAciErrorDisableRecovery -timeout=60m
=== RUN   TestAccAciErrorDisableRecoveryDataSource_Basic
=== STEP  Testing error_disable_recovery Data Source with required arguments only
=== STEP  Testing error_disable_recovery Data Source with random attribute
=== STEP  Testing error_disable_recovery Data Source with updated resource
--- PASS: TestAccAciErrorDisableRecoveryDataSource_Basic (120.86s)
=== RUN   TestAccAciErrorDisableRecovery_Basic
=== STEP  Testing error_disable_recovery creation with required arguments only
=== STEP  Testing error_disable_recovery creation with optional parameters
--- PASS: TestAccAciErrorDisableRecovery_Basic (141.15s)
=== RUN   TestAccAciErrorDisableRecovery_Update
=== STEP  Testing error_disable_recovery creation with required arguments only
=== STEP  Testing error_disable_recovery attribute: err_dis_recov_intvl = 65535
=== STEP  Testing error_disable_recovery attribute: err_dis_recov_intvl = 32767
--- PASS: TestAccAciErrorDisableRecovery_Update (154.71s)
=== RUN   TestAccAciErrorDisableRecovery_Negative
=== STEP  Testing error_disable_recovery creation with required arguments only
=== STEP  Testing error_disable_recovery attribute: description = p4yzfpxba0esxla2osfnl71wmp73axt7xifvh2cnmr1yhkp49p9h6cdrs93lv3vl4c8m8j48mk81dqazjztvuf4qpijyj4ci4y3t4fsm4psmtv3g9ctpgypdaeg3nxa9k
=== STEP  Testing error_disable_recovery attribute: annotation = onlznwp0olfshgzmbgt47mfe3ffzoggdhk00r0kr1pi9ws9z7zh4txwqwb0oiii1yo826231xnzknqq69qmqx9qd2zaor2hwcc8vc9d0albwt1k88yr70jxwd0jclxan9
=== STEP  Testing error_disable_recovery attribute: name_alias = l1x06nap0sqoftebongq0kjesjwejxaxrzm27swpn6s2cka1vhwh2bdofy8nfp8a
=== STEP  Testing error_disable_recovery attribute: err_dis_recov_intvl = 29
=== STEP  Testing error_disable_recovery attribute: err_dis_recov_intvl = 65536
=== STEP  Testing error_disable_recovery attribute: err_dis_recov_intvl = vk8s3
=== STEP  Testing error_disable_recovery attribute: zigxp = vk8s3
--- PASS: TestAccAciErrorDisableRecovery_Negative (164.05s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   582.778s


$ go test -v -run TestAccAciLoginDomain -timeout=60m
=== RUN   TestAccAciLoginDomainDataSource_Basic
=== STEP  Testing login_domain Data Source without  name
=== STEP  Testing login_domain Data Source with required arguments only
=== STEP  Testing login_domain Data Source with random attribute
=== STEP  Testing login_domain Data Source with invalid name
=== STEP  Testing login_domain Data Source with updated resource
=== PAUSE TestAccAciLoginDomainDataSource_Basic
=== RUN   TestAccAciLoginDomain_Basic
=== STEP  Testing login_domain creation without  name
=== STEP  Testing login_domain creation with required arguments only
=== STEP  Testing login_domain creation with optional parameters
=== STEP  Testing login_domain creation with invalid name =  xsggk27jjb8wrywnxc1uzcsx6fdakvcsa4a0k293v8r
=== STEP  Testing login_domain updation without required parameters
=== STEP  Testing login_domain creation with name acctest_jdc0x
=== PAUSE TestAccAciLoginDomain_Basic
=== RUN   TestAccAciLoginDomain_Update
=== STEP  Testing login_domain creation with required arguments only
=== STEP  Testing login_domain attribute: realm = ldap
=== STEP  Testing login_domain attribute: realm = radius
=== STEP  Testing login_domain attribute: realm = rsa
=== STEP  Testing login_domain attribute: realm = saml
=== STEP  Testing login_domain attribute: realm = tacacs
=== STEP  Testing login_domain attribute: realm = none
=== STEP  Testing login_domain attribute: provider_group = 0
=== STEP  Testing login_domain attribute: provider_group = 63
=== STEP  Testing login_domain creation with required arguments only
=== PAUSE TestAccAciLoginDomain_Update
=== RUN   TestAccAciLoginDomain_Negative
=== STEP  Testing login_domain creation with required arguments only
=== STEP  Testing login_domain attribute: description = xfs7xgypn946vhamqzkoz398u6ttzy4971hrw82suu3z8msj
=== STEP  Testing login_domain attribute: annotation = 3bpu3m4cjpnpsvrsf7urkdpatvb0afnzvt9mm9b2wkcx2qi10
=== STEP  Testing login_domain attribute: name_alias = hss08vyk7bgwg4jjc7swqdnijj1ry8qkvkbnmfwzegpnvsul6
=== STEP  Testing login_domain attribute: realm = 1r0ob
=== STEP  Testing login_domain attribute: realm_sub_type = 1r0ob
=== STEP  Testing login_domain attribute: zrsej = 1r0ob
=== STEP  Testing login_domain creation with required arguments only
=== PAUSE TestAccAciLoginDomain_Negative
=== RUN   TestAccAciLoginDomain_MultipleCreateDelete
=== STEP  Testing multiple login_domain creation with required arguments only
=== PAUSE TestAccAciLoginDomain_MultipleCreateDelete
=== CONT  TestAccAciLoginDomainDataSource_Basic
=== CONT  TestAccAciLoginDomain_Negative
=== CONT  TestAccAciLoginDomain_Basic
=== CONT  TestAccAciLoginDomain_MultipleCreateDelete
=== CONT  TestAccAciLoginDomain_Update
=== STEP  Testing login_domain destroy
--- PASS: TestAccAciLoginDomain_MultipleCreateDelete (63.79s)
=== STEP  Testing login_domain destroy
--- PASS: TestAccAciLoginDomainDataSource_Basic (144.79s)
=== STEP  Testing login_domain destroy
--- PASS: TestAccAciLoginDomain_Negative (167.25s)
=== STEP  Testing login_domain destroy
--- PASS: TestAccAciLoginDomain_Basic (193.81s)
=== STEP  Testing login_domain destroy
--- PASS: TestAccAciLoginDomain_Update (363.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   364.910s



$ go test -v -run TestAccAciUserSecurityDomain -timeout=60m
=== RUN   TestAccAciUserSecurityDomainDataSource_Basic
=== STEP  Basic: testing user_security_domain Data Source without  local_user_dn
=== STEP  Basic: testing user_security_domain Data Source without  name
=== STEP  testing user_security_domain Data Source with required arguments only
=== STEP  testing user_security_domain Data Source with random attribute
=== STEP  testing user_security_domain Data Source with Invalid Parent Dn
=== STEP  testing user_security_domain Data Source with updated resource
=== PAUSE TestAccAciUserSecurityDomainDataSource_Basic
=== RUN   TestAccAciUserSecurityDomain_Basic
=== STEP  Basic: testing user_security_domain creation without  local_user_dn
=== STEP  Basic: testing user_security_domain creation without  name
=== STEP  testing user_security_domain creation with required arguments only
=== STEP  Basic: testing user_security_domain creation with optional parameters
=== STEP  testing user_security_domain creation with invalid name =  phtwfajqhf96gz82emp33m33o14hzqj13ck8wrgp243fwv6gg4zhe2j6na1gtyfim
=== STEP  Basic: testing user_security_domain updation without required parameters
=== STEP  testing user_security_domain creation with updated naming arguments
=== STEP  testing user_security_domain creation with required arguments only
=== STEP  testing user_security_domain creation with updated naming arguments
=== PAUSE TestAccAciUserSecurityDomain_Basic
=== RUN   TestAccAciUserSecurityDomain_Negative
=== STEP  testing user_security_domain creation with required arguments only
=== STEP  Negative Case: testing user_security_domain creation with invalid parent Dn
=== STEP  testing user_security_domain attribute: description = 8bgzufhwphbrpxgqv2nsb9ac9xsjc89279k3xq638868yzkqbongnfo1lcbqalu2jmljvjlrb9s40zdxx28f3xptdk8qqwe2rj7gbjvptowslmsxqa47h3gz3h3dj6uft
=== STEP  testing user_security_domain attribute: annotation = t9ieg0blae66m6m8muaj163tqb74jphomi4rxgmv27sfnt7v7sanbwyn9da228lyqkmbuy9pj9zgjvv6gua2uupbp86ip3ihy06s610u8drzahbhsfi0t0clmapopzv9o
=== STEP  testing user_security_domain attribute: name_alias = fte3ryigb9poxiuwqn4k4h49c390jst7p3y4rp8t89g8swlwyczdbod9mf3mmw92
=== STEP  testing user_security_domain attribute: mrwll = sqzqs
=== STEP  testing user_security_domain creation with required arguments only
=== PAUSE TestAccAciUserSecurityDomain_Negative
=== RUN   TestAccAciUserSecurityDomain_MultipleCreateDelete
=== STEP  testing multiple user_security_domain creation with required arguments only
=== PAUSE TestAccAciUserSecurityDomain_MultipleCreateDelete
=== CONT  TestAccAciUserSecurityDomainDataSource_Basic
=== CONT  TestAccAciUserSecurityDomain_Negative
=== CONT  TestAccAciUserSecurityDomain_Basic
=== CONT  TestAccAciUserSecurityDomain_MultipleCreateDelete
=== STEP  testing user_security_domain destroy
--- PASS: TestAccAciUserSecurityDomain_MultipleCreateDelete (78.46s)
=== STEP  testing user_security_domain destroy
--- PASS: TestAccAciUserSecurityDomainDataSource_Basic (152.00s)
=== STEP  testing user_security_domain destroy
--- PASS: TestAccAciUserSecurityDomain_Negative (197.30s)
=== STEP  testing user_security_domain destroy
--- PASS: TestAccAciUserSecurityDomain_Basic (323.89s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   326.645s

$ go test -v -run TestAccAciUserSecurityDomainRole -timeout=60m
=== RUN   TestAccAciUserSecurityDomainRoleDataSource_Basic
=== STEP  Basic: testing user_security_domain_role Data Source without  user_domain_dn
=== STEP  Basic: testing user_security_domain_role Data Source without  name
=== STEP  testing user_security_domain_role Data Source with required arguments only
=== STEP  testing user_security_domain_role Data Source with random attribute
=== STEP  testing user_security_domain_role Data Source with Invalid Parent Dn
=== STEP  testing user_security_domain_role Data Source with updated resource
=== PAUSE TestAccAciUserSecurityDomainRoleDataSource_Basic
=== RUN   TestAccAciUserSecurityDomainRole_Basic
=== STEP  Basic: testing user_security_domain_role creation without  user_domain_dn
=== STEP  Basic: testing user_security_domain_role creation without  name
=== STEP  testing user_security_domain_role creation with required arguments only
=== STEP  Basic: testing user_security_domain_role creation with optional parameters
=== STEP  testing user_security_domain_role creation with invalid name =  83tq2f2py9cdamqahbyykf3neo7eoqcgcifmhxeo3sejgblcy8e827smz8j9trazj
=== STEP  Basic: testing user_security_domain_role updation without required parameters
=== STEP  testing user_security_domain_role creation with updated naming arguments
=== STEP  testing user_security_domain_role creation with required arguments only
=== STEP  testing user_security_domain_role creation with updated naming arguments
=== PAUSE TestAccAciUserSecurityDomainRole_Basic
=== RUN   TestAccAciUserSecurityDomainRole_Negative
=== STEP  testing user_security_domain_role creation with required arguments only
=== STEP  Negative Case: testing user_security_domain_role creation with invalid parent Dn
=== STEP  testing user_security_domain_role attribute: description = zz1n7k462hdwfyqwax9kaem66yjyfaxx2l6zcec60jwf8jgsxk1bdmfje84o7zrg3qyzpvg11e9uukwcn4ynh7ik0go0e4wmf9m4uw2cyacf1aitoib4sr0aqwtwbgir1
=== STEP  testing user_security_domain_role attribute: annotation = fttergjd9jbwg90kzvlrodye88ionrmbdvj0tlwtovqkz0kdzeq8v9eu3alw39m09kqg0ra24fmielt7j00ulwilctylc0whq937ezvgvxoyqaa9um8mtrborecbwu00y
=== STEP  testing user_security_domain_role attribute: name_alias = 04tsfmopa0yvjbe3vb1avi4iys0b2fn1snimycj068xp6qm1hyov67l8tm11s6ie
=== STEP  testing user_security_domain_role attribute: priv_type = 70wus
=== STEP  testing user_security_domain_role attribute: ofrww = 70wus
=== STEP  testing user_security_domain_role creation with required arguments only
=== PAUSE TestAccAciUserSecurityDomainRole_Negative
=== RUN   TestAccAciUserSecurityDomainRole_MultipleCreateDelete
=== STEP  testing multiple user_security_domain_role creation with required arguments only
=== PAUSE TestAccAciUserSecurityDomainRole_MultipleCreateDelete
=== CONT  TestAccAciUserSecurityDomainRoleDataSource_Basic
=== CONT  TestAccAciUserSecurityDomainRole_Negative
=== CONT  TestAccAciUserSecurityDomainRole_MultipleCreateDelete
=== CONT  TestAccAciUserSecurityDomainRole_Basic
=== STEP  testing user_security_domain_role destroy
--- PASS: TestAccAciUserSecurityDomainRole_MultipleCreateDelete (147.50s)
=== STEP  testing user_security_domain_role destroy
--- PASS: TestAccAciUserSecurityDomainRoleDataSource_Basic (225.00s)
=== STEP  testing user_security_domain_role destroy
--- PASS: TestAccAciUserSecurityDomainRole_Negative (273.53s)
=== STEP  testing user_security_domain_role destroy
--- PASS: TestAccAciUserSecurityDomainRole_Basic (363.66s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   366.813s
