### PR TITLE
added resource test file for 02-02-22

### DIFF
--- a/aci/data_source_aci_fabricnodeidentp.go
+++ b/aci/data_source_aci_fabricnodeidentp.go
@@ -35,6 +35,12 @@ func dataSourceAciFabricNodeMember() *schema.Resource {
 				Computed: true,
 			},
 
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"name_alias": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,

--- a/aci/data_source_aci_qosinstpol.go
+++ b/aci/data_source_aci_qosinstpol.go
@@ -74,7 +74,7 @@ func dataSourceAciQOSInstancePolicyReadContext(ctx context.Context, d *schema.Re
 
 	rn := fmt.Sprintf("infra/qosinst-%s", name)
 	dn := fmt.Sprintf("uni/%s", rn)
-	qosInstPol, err := getRemoteQOSInstancePolicy(aciClient, dn)
+	qosInstPol, err := GetRemoteQOSInstancePolicy(aciClient, dn)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/aci/resource_aci_fabricnodeidentp.go
+++ b/aci/resource_aci_fabricnodeidentp.go
@@ -35,10 +35,8 @@ func resourceAciFabricNodeMember() *schema.Resource {
 
 			"name": &schema.Schema{
 				Type: schema.TypeString,
-				// Required: true,
-				// ForceNew: true,
-				Optional: true,
-				Computed: true,
+				Required: true,
+				ForceNew: true,
 			},
 
 			"ext_pool_id": &schema.Schema{

--- a/aci/resource_aci_qosinstpol.go
+++ b/aci/resource_aci_qosinstpol.go
@@ -87,7 +87,7 @@ func resourceAciQOSInstancePolicy() *schema.Resource {
 	}
 }
 
-func getRemoteQOSInstancePolicy(client *client.Client, dn string) (*models.QOSInstancePolicy, error) {
+func GetRemoteQOSInstancePolicy(client *client.Client, dn string) (*models.QOSInstancePolicy, error) {
 	qosInstPolCont, err := client.Get(dn)
 	if err != nil {
 		return nil, err
@@ -128,7 +128,7 @@ func resourceAciQOSInstancePolicyImport(d *schema.ResourceData, m interface{}) (
 	log.Printf("[DEBUG] %s: Beginning Import", d.Id())
 	aciClient := m.(*client.Client)
 	dn := d.Id()
-	qosInstPol, err := getRemoteQOSInstancePolicy(aciClient, dn)
+	qosInstPol, err := GetRemoteQOSInstancePolicy(aciClient, dn)
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +274,7 @@ func resourceAciQOSInstancePolicyRead(ctx context.Context, d *schema.ResourceDat
 	log.Printf("[DEBUG] %s: Beginning Read", d.Id())
 	aciClient := m.(*client.Client)
 	dn := d.Id()
-	qosInstPol, err := getRemoteQOSInstancePolicy(aciClient, dn)
+	qosInstPol, err := GetRemoteQOSInstancePolicy(aciClient, dn)
 	if err != nil {
 		d.SetId("")
 		return diag.FromErr(err)

--- a/testacc/data_source_aci_aaarsaprovider_test.go
+++ b/testacc/data_source_aci_aaarsaprovider_test.go
@@ -15,13 +15,13 @@ func TestAccAciRSAProviderDataSource_Basic(t *testing.T) {
 	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
 	randomValue := acctest.RandString(10)
 	rName := makeTestVariable(acctest.RandString(5))
-	
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:	  func(){ testAccPreCheck(t) },
-		ProviderFactories:    testAccProviders,
-		CheckDestroy: testAccCheckAciRSAProviderDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciRSAProviderDestroy,
 		Steps: []resource.TestStep{
-			
+
 			{
 				Config:      CreateRSAProviderDSWithoutRequired(rName, "name"),
 				ExpectError: regexp.MustCompile(`Missing required argument`),
@@ -29,7 +29,7 @@ func TestAccAciRSAProviderDataSource_Basic(t *testing.T) {
 			{
 				Config: CreateAccRSAProviderConfigDataSource(rName),
 				Check: resource.ComposeTestCheckFunc(
-					
+
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
@@ -40,14 +40,13 @@ func TestAccAciRSAProviderDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "monitoring_user", resourceName, "monitoring_user"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "retries", resourceName, "retries"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "timeout", resourceName, "timeout"),
-					
 				),
 			},
 			{
 				Config:      CreateAccRSAProviderDataSourceUpdate(rName, randomParameter, randomValue),
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
 			},
-			
+
 			{
 				Config:      CreateAccRSAProviderDSWithInvalidName(rName),
 				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
@@ -61,7 +60,6 @@ func TestAccAciRSAProviderDataSource_Basic(t *testing.T) {
 		},
 	})
 }
-
 
 func CreateAccRSAProviderConfigDataSource(rName string) string {
 	fmt.Println("=== STEP  testing rsa_provider Data Source with required arguments only")
@@ -82,7 +80,7 @@ func CreateAccRSAProviderConfigDataSource(rName string) string {
 }
 
 func CreateRSAProviderDSWithoutRequired(rName, attrName string) string {
-	fmt.Println("=== STEP  Basic: testing rsa_provider Data Source without ",attrName)
+	fmt.Println("=== STEP  Basic: testing rsa_provider Data Source without ", attrName)
 	rBlock := `
 	
 	resource "aci_rsa_provider" "test" {
@@ -100,9 +98,8 @@ func CreateRSAProviderDSWithoutRequired(rName, attrName string) string {
 	}
 		`
 	}
-	return fmt.Sprintf(rBlock,rName)
+	return fmt.Sprintf(rBlock, rName)
 }
-
 
 func CreateAccRSAProviderDSWithInvalidName(rName string) string {
 	fmt.Println("=== STEP  testing rsa_provider Data Source with invalid name")
@@ -137,7 +134,7 @@ func CreateAccRSAProviderDataSourceUpdate(rName, key, value string) string {
 		%s = "%s"
 		depends_on = [ aci_rsa_provider.test ]
 	}
-	`, rName,key,value)
+	`, rName, key, value)
 	return resource
 }
 
@@ -156,6 +153,6 @@ func CreateAccRSAProviderDataSourceUpdatedResource(rName, key, value string) str
 		name  = aci_rsa_provider.test.name
 		depends_on = [ aci_rsa_provider.test ]
 	}
-	`, rName,key,value)
+	`, rName, key, value)
 	return resource
 }

--- a/testacc/data_source_aci_cloudctxprofile_test.go
+++ b/testacc/data_source_aci_cloudctxprofile_test.go
@@ -37,6 +37,9 @@ func TestAccAciCloudContextProfileDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "type", resourceName, "type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "primary_cidr", resourceName, "primary_cidr"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "region", resourceName, "region"),
 				),
 			},
 			{

--- a/testacc/data_source_aci_fabricnodeblk_maintgrp_test.go
+++ b/testacc/data_source_aci_fabricnodeblk_maintgrp_test.go
@@ -1,0 +1,192 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciNodeBlockMGDataSource_Basic(t *testing.T) {
+	resourceName := "aci_maintenance_group_node.test"
+	dataSourceName := "data.aci_maintenance_group_node.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	maintMaintGrpName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciNodeBlockMGDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateNodeBlockMGDSWithoutRequired(maintMaintGrpName, rName, "pod_maintenance_group_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateNodeBlockMGDSWithoutRequired(maintMaintGrpName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccNodeBlockMGConfigDataSource(maintMaintGrpName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "pod_maintenance_group_dn", resourceName, "pod_maintenance_group_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "from_", resourceName, "from_"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "to_", resourceName, "to_"),
+				),
+			},
+			{
+				Config:      CreateAccNodeBlockMGDataSourceUpdate(maintMaintGrpName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccNodeBlockMGDSWithInvalidName(maintMaintGrpName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+
+			{
+				Config: CreateAccNodeBlockMGDataSourceUpdatedResource(maintMaintGrpName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccNodeBlockMGConfigDataSource(maintMaintGrpName, rName string) string {
+	fmt.Println("=== STEP  testing maintenance_group_node Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_pod_maintenance_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+		name  = "%s"
+	}
+
+	data "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+		name  = aci_maintenance_group_node.test.name
+		depends_on = [ aci_maintenance_group_node.test ]
+	}
+	`, maintMaintGrpName, rName)
+	return resource
+}
+
+func CreateNodeBlockMGDSWithoutRequired(maintMaintGrpName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing maintenance_group_node Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_pod_maintenance_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "pod_maintenance_group_dn":
+		rBlock += `
+	data "aci_maintenance_group_node" "test" {
+	#	pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+		name  = aci_maintenance_group_node.test.name
+		depends_on = [ aci_maintenance_group_node.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+	#	name  = aci_maintenance_group_node.test.name
+		depends_on = [ aci_maintenance_group_node.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, maintMaintGrpName, rName)
+}
+
+func CreateAccNodeBlockMGDSWithInvalidName(maintMaintGrpName, rName string) string {
+	fmt.Println("=== STEP  testing maintenance_group_node Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_pod_maintenance_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+		name  = "%s"
+	}
+
+	data "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+		name  = "${aci_maintenance_group_node.test.name}_invalid"
+		depends_on = [ aci_maintenance_group_node.test ]
+	}
+	`, maintMaintGrpName, rName)
+	return resource
+}
+
+func CreateAccNodeBlockMGDataSourceUpdate(maintMaintGrpName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing maintenance_group_node Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_pod_maintenance_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+		name  = "%s"
+	}
+
+	data "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+		name  = aci_maintenance_group_node.test.name
+		%s = "%s"
+		depends_on = [ aci_maintenance_group_node.test ]
+	}
+	`, maintMaintGrpName, rName, key, value)
+	return resource
+}
+
+func CreateAccNodeBlockMGDataSourceUpdatedResource(maintMaintGrpName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing maintenance_group_node Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_pod_maintenance_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+		name  = aci_maintenance_group_node.test.name
+		depends_on = [ aci_maintenance_group_node.test ]
+	}
+	`, maintMaintGrpName, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_fabricnodeidentp_test.go
+++ b/testacc/data_source_aci_fabricnodeidentp_test.go
@@ -1,0 +1,163 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciFabricNodeMemberDataSource_Basic(t *testing.T) {
+	resourceName := "aci_fabric_node_member.test"
+	dataSourceName := "data.aci_fabric_node_member.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	serial := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFabricNodeMemberDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateFabricNodeMemberDSWithoutRequired(rName, serial, fabricNodeMemNodeId5, "serial"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccFabricNodeMemberConfigDataSource(rName, serial, fabricNodeMemNodeId5),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "serial", resourceName, "serial"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ext_pool_id", resourceName, "ext_pool_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "fabric_id", resourceName, "fabric_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "node_id", resourceName, "node_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "node_type", resourceName, "node_type"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "pod_id", resourceName, "pod_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "role", resourceName, "role"),
+				),
+			},
+			{
+				Config:      CreateAccFabricNodeMemberDataSourceUpdate(rName, serial, fabricNodeMemNodeId5, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccFabricNodeMemberDSWithInvalidSerial(rName, serial, fabricNodeMemNodeId5),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccFabricNodeMemberDataSourceUpdatedResource(rName, serial, fabricNodeMemNodeId5, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccFabricNodeMemberConfigDataSource(name, serial, node string) string {
+	fmt.Println("=== STEP  testing fabric_node_member Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_fabric_node_member" "test" {
+		name = "%s"
+		serial  = "%s"
+		node_id = "%s"
+	}
+
+	data "aci_fabric_node_member" "test" {
+
+		serial  = aci_fabric_node_member.test.serial
+		depends_on = [ aci_fabric_node_member.test ]
+	}
+	`, name, serial, node)
+	return resource
+}
+
+func CreateFabricNodeMemberDSWithoutRequired(name, serial, node, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing fabric_node_member Data Source without ", attrName)
+	rBlock := `
+
+	resource "aci_fabric_node_member" "test" {
+		name = "%s"
+		serial  = "%s"
+		node_id = "%s"
+	}
+	`
+	switch attrName {
+	case "serial":
+		rBlock += `
+	data "aci_fabric_node_member" "test" {
+
+	#	serial  = aci_fabric_node_member.test.serial
+		depends_on = [ aci_fabric_node_member.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, name, serial, node)
+}
+
+func CreateAccFabricNodeMemberDSWithInvalidSerial(name, serial, node string) string {
+	fmt.Println("=== STEP  testing fabric_node_member Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+
+	resource "aci_fabric_node_member" "test" {
+		name = "%s"
+		serial  = "%s"
+		node_id = "%s"
+	}
+
+	data "aci_fabric_node_member" "test" {
+
+		serial  = "${aci_fabric_node_member.test.serial}_invalid"
+		depends_on = [ aci_fabric_node_member.test ]
+	}
+	`, name, serial, node)
+	return resource
+}
+
+func CreateAccFabricNodeMemberDataSourceUpdate(name, serial, node, key, value string) string {
+	fmt.Println("=== STEP  testing fabric_node_member Data Source with random attribute")
+	resource := fmt.Sprintf(`
+
+	resource "aci_fabric_node_member" "test" {
+		name = "%s"
+		serial  = "%s"
+		node_id = "%s"
+	}
+
+	data "aci_fabric_node_member" "test" {
+
+		serial  = aci_fabric_node_member.test.serial
+		%s = "%s"
+		depends_on = [ aci_fabric_node_member.test ]
+	}
+	`, name, serial, node, key, value)
+	return resource
+}
+
+func CreateAccFabricNodeMemberDataSourceUpdatedResource(rName, serial, node, key, value string) string {
+	fmt.Println("=== STEP  testing fabric_node_member Data Source with updated resource")
+	resource := fmt.Sprintf(`
+
+	resource "aci_fabric_node_member" "test" {
+		name = "%s"
+		serial  = "%s"
+		node_id = "%s"
+		%s = "%s"
+	}
+
+	data "aci_fabric_node_member" "test" {
+
+		serial  = aci_fabric_node_member.test.serial
+		depends_on = [ aci_fabric_node_member.test ]
+	}
+	`, name, serial, node, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_firmwarefwp_test.go
+++ b/testacc/data_source_aci_firmwarefwp_test.go
@@ -15,13 +15,13 @@ func TestAccAciFirmwarePolicyDataSource_Basic(t *testing.T) {
 	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
 	randomValue := acctest.RandString(10)
 	rName := makeTestVariable(acctest.RandString(5))
-	
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:	  func(){ testAccPreCheck(t) },
-		ProviderFactories:    testAccProviders,
-		CheckDestroy: testAccCheckAciFirmwarePolicyDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFirmwarePolicyDestroy,
 		Steps: []resource.TestStep{
-			
+
 			{
 				Config:      CreateFirmwarePolicyDSWithoutRequired(rName, "name"),
 				ExpectError: regexp.MustCompile(`Missing required argument`),
@@ -29,7 +29,7 @@ func TestAccAciFirmwarePolicyDataSource_Basic(t *testing.T) {
 			{
 				Config: CreateAccFirmwarePolicyConfigDataSource(rName),
 				Check: resource.ComposeTestCheckFunc(
-					
+
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
@@ -39,14 +39,13 @@ func TestAccAciFirmwarePolicyDataSource_Basic(t *testing.T) {
 					resource.TestCheckResourceAttrPair(dataSourceName, "internal_label", resourceName, "internal_label"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "version", resourceName, "version"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "version_check_override", resourceName, "version_check_override"),
-					
 				),
 			},
 			{
 				Config:      CreateAccFirmwarePolicyDataSourceUpdate(rName, randomParameter, randomValue),
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
 			},
-			
+
 			{
 				Config:      CreateAccFirmwarePolicyDSWithInvalidName(rName),
 				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
@@ -60,7 +59,6 @@ func TestAccAciFirmwarePolicyDataSource_Basic(t *testing.T) {
 		},
 	})
 }
-
 
 func CreateAccFirmwarePolicyConfigDataSource(rName string) string {
 	fmt.Println("=== STEP  testing firmware_policy Data Source with required arguments only")
@@ -81,7 +79,7 @@ func CreateAccFirmwarePolicyConfigDataSource(rName string) string {
 }
 
 func CreateFirmwarePolicyDSWithoutRequired(rName, attrName string) string {
-	fmt.Println("=== STEP  Basic: testing firmware_policy Data Source without ",attrName)
+	fmt.Println("=== STEP  Basic: testing firmware_policy Data Source without ", attrName)
 	rBlock := `
 	
 	resource "aci_firmware_policy" "test" {
@@ -99,9 +97,8 @@ func CreateFirmwarePolicyDSWithoutRequired(rName, attrName string) string {
 	}
 		`
 	}
-	return fmt.Sprintf(rBlock,rName)
+	return fmt.Sprintf(rBlock, rName)
 }
-
 
 func CreateAccFirmwarePolicyDSWithInvalidName(rName string) string {
 	fmt.Println("=== STEP  testing firmware_policy Data Source with invalid name")
@@ -136,7 +133,7 @@ func CreateAccFirmwarePolicyDataSourceUpdate(rName, key, value string) string {
 		%s = "%s"
 		depends_on = [ aci_firmware_policy.test ]
 	}
-	`, rName,key,value)
+	`, rName, key, value)
 	return resource
 }
 
@@ -155,6 +152,6 @@ func CreateAccFirmwarePolicyDataSourceUpdatedResource(rName, key, value string) 
 		name  = aci_firmware_policy.test.name
 		depends_on = [ aci_firmware_policy.test ]
 	}
-	`, rName,key,value)
+	`, rName, key, value)
 	return resource
 }

--- a/testacc/data_source_aci_fvnsvxlaninstp_test.go
+++ b/testacc/data_source_aci_fvnsvxlaninstp_test.go
@@ -1,0 +1,152 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciVXLANPoolDataSource_Basic(t *testing.T) {
+	resourceName := "aci_vxlan_pool.test"
+	dataSourceName := "data.aci_vxlan_pool.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVXLANPoolDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateVXLANPoolDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccVXLANPoolConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+				),
+			},
+			{
+				Config:      CreateAccVXLANPoolDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccVXLANPoolDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccVXLANPoolDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccVXLANPoolConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing vxlan_pool Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vxlan_pool" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_vxlan_pool" "test" {
+	
+		name  = aci_vxlan_pool.test.name
+		depends_on = [ aci_vxlan_pool.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateVXLANPoolDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing vxlan_pool Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_vxlan_pool" "test" {
+	
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_vxlan_pool" "test" {
+	
+	#	name  = aci_vxlan_pool.test.name
+		depends_on = [ aci_vxlan_pool.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccVXLANPoolDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing vxlan_pool Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vxlan_pool" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_vxlan_pool" "test" {
+	
+		name  = "${aci_vxlan_pool.test.name}_invalid"
+		depends_on = [ aci_vxlan_pool.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccVXLANPoolDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing vxlan_pool Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vxlan_pool" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_vxlan_pool" "test" {
+	
+		name  = aci_vxlan_pool.test.name
+		%s = "%s"
+		depends_on = [ aci_vxlan_pool.test ]
+	}
+	`, rName, key, value)
+	return resource
+}
+
+func CreateAccVXLANPoolDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing vxlan_pool Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vxlan_pool" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_vxlan_pool" "test" {
+	
+		name  = aci_vxlan_pool.test.name
+		depends_on = [ aci_vxlan_pool.test ]
+	}
+	`, rName, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_qosinstpol_test.go
+++ b/testacc/data_source_aci_qosinstpol_test.go
@@ -1,0 +1,100 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/terraform-providers/terraform-provider-aci/aci"
+)
+
+func TestAccAciQOSInstancePolicyDataSource_Basic(t *testing.T) {
+	resourceName := "aci_qos_instance_policy.test"
+	dataSourceName := "data.aci_qos_instance_policy.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	QOSInstancePolicy, err := aci.GetRemoteQOSInstancePolicy(sharedAciClient(), "uni/infra/qosinst-default")
+	if err != nil {
+		t.Errorf("reading initial config of QOSInstancePolicy")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccQOSInstancePolicyConfigDataSource(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etrap_age_timer", resourceName, "etrap_age_timer"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etrap_bw_thresh", resourceName, "etrap_bw_thresh"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etrap_byte_ct", resourceName, "etrap_byte_ct"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "etrap_st", resourceName, "etrap_st"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "fabric_flush_interval", resourceName, "fabric_flush_interval"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "fabric_flush_st", resourceName, "fabric_flush_st"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ctrl.#", resourceName, "ctrl.#"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "uburst_spine_queues", resourceName, "uburst_spine_queues"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "uburst_tor_queues", resourceName, "uburst_tor_queues"),
+				),
+			},
+			{
+				Config:      CreateAccQOSInstancePolicyDataSourceUpdate(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccQOSInstancePolicyDataSourceUpdatedResource("annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+			{
+				Config: restoreQOSInstancePolicy(QOSInstancePolicy),
+			},
+		},
+	})
+}
+
+func CreateAccQOSInstancePolicyConfigDataSource() string {
+	fmt.Println("=== STEP  testing qos_instance_policy Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_qos_instance_policy" "test" {}
+
+	data "aci_qos_instance_policy" "test" {
+		depends_on = [ aci_qos_instance_policy.test ]
+	}
+	`)
+	return resource
+}
+
+func CreateAccQOSInstancePolicyDataSourceUpdate(key, value string) string {
+	fmt.Println("=== STEP  testing qos_instance_policy Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_qos_instance_policy" "test" {}
+
+	data "aci_qos_instance_policy" "test" {
+		%s = "%s"
+		depends_on = [ aci_qos_instance_policy.test ]
+	}
+	`, key, value)
+	return resource
+}
+
+func CreateAccQOSInstancePolicyDataSourceUpdatedResource(key, value string) string {
+	fmt.Println("=== STEP  testing qos_instance_policy Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_qos_instance_policy" "test" {
+		%s = "%s"
+	}
+
+	data "aci_qos_instance_policy" "test" {
+		depends_on = [ aci_qos_instance_policy.test ]
+	}
+	`, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_spansrcgrp_test.go
+++ b/testacc/data_source_aci_spansrcgrp_test.go
@@ -15,15 +15,15 @@ func TestAccAciSPANSourceGroupDataSource_Basic(t *testing.T) {
 	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
 	randomValue := acctest.RandString(10)
 	rName := makeTestVariable(acctest.RandString(5))
-	
+
 	fvTenantName := makeTestVariable(acctest.RandString(5))
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:	  func(){ testAccPreCheck(t) },
-		ProviderFactories:    testAccProviders,
-		CheckDestroy: testAccCheckAciSPANSourceGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSPANSourceGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      CreateSPANSourceGroupDSWithoutRequired(fvTenantName, rName,"tenant_dn"),
+				Config:      CreateSPANSourceGroupDSWithoutRequired(fvTenantName, rName, "tenant_dn"),
 				ExpectError: regexp.MustCompile(`Missing required argument`),
 			},
 			{
@@ -33,25 +33,24 @@ func TestAccAciSPANSourceGroupDataSource_Basic(t *testing.T) {
 			{
 				Config: CreateAccSPANSourceGroupConfigDataSource(fvTenantName, rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair(dataSourceName, "tenant_dn", resourceName, "tenant_dn",),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tenant_dn", resourceName, "tenant_dn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "admin_st", resourceName, "admin_st"),
-					
 				),
 			},
 			{
 				Config:      CreateAccSPANSourceGroupDataSourceUpdate(fvTenantName, rName, randomParameter, randomValue),
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
 			},
-			
+
 			{
 				Config:      CreateAccSPANSourceGroupDSWithInvalidName(fvTenantName, rName),
 				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
 			},
-			
+
 			{
 				Config: CreateAccSPANSourceGroupDataSourceUpdatedResource(fvTenantName, rName, "annotation", "orchestrator:terraform-testacc"),
 				Check: resource.ComposeTestCheckFunc(
@@ -61,7 +60,6 @@ func TestAccAciSPANSourceGroupDataSource_Basic(t *testing.T) {
 		},
 	})
 }
-
 
 func CreateAccSPANSourceGroupConfigDataSource(fvTenantName, rName string) string {
 	fmt.Println("=== STEP  testing span_source_group Data Source with required arguments only")
@@ -87,7 +85,7 @@ func CreateAccSPANSourceGroupConfigDataSource(fvTenantName, rName string) string
 }
 
 func CreateSPANSourceGroupDSWithoutRequired(fvTenantName, rName, attrName string) string {
-	fmt.Println("=== STEP  Basic: testing span_source_group Data Source without ",attrName)
+	fmt.Println("=== STEP  Basic: testing span_source_group Data Source without ", attrName)
 	rBlock := `
 	
 	resource "aci_tenant" "test" {
@@ -118,7 +116,7 @@ func CreateSPANSourceGroupDSWithoutRequired(fvTenantName, rName, attrName string
 	}
 		`
 	}
-	return fmt.Sprintf(rBlock,fvTenantName, rName)
+	return fmt.Sprintf(rBlock, fvTenantName, rName)
 }
 
 func CreateAccSPANSourceGroupDSWithInvalidName(fvTenantName, rName string) string {
@@ -164,7 +162,7 @@ func CreateAccSPANSourceGroupDataSourceUpdate(fvTenantName, rName, key, value st
 		%s = "%s"
 		depends_on = [ aci_span_source_group.test ]
 	}
-	`, fvTenantName, rName,key,value)
+	`, fvTenantName, rName, key, value)
 	return resource
 }
 
@@ -188,6 +186,6 @@ func CreateAccSPANSourceGroupDataSourceUpdatedResource(fvTenantName, rName, key,
 		name  = aci_span_source_group.test.name
 		depends_on = [ aci_span_source_group.test ]
 	}
-	`, fvTenantName, rName,key,value)
+	`, fvTenantName, rName, key, value)
 	return resource
 }

--- a/testacc/provider_test.go
+++ b/testacc/provider_test.go
@@ -43,6 +43,11 @@ const fabDn3 = "topology/pod-1/node-111"
 const fabDn4 = "topology/pod-1/node-1"
 const vmmProvProfileDn = "uni/vmmp-VMware"
 const vmmProvProfileDnOther = "uni/vmmp-OpenShift"
+const fabricNodeMemNodeId1 = "301"
+const fabricNodeMemNodeId2 = "302"
+const fabricNodeMemNodeId3 = "303"
+const fabricNodeMemNodeId4 = "304"
+const fabricNodeMemNodeId5 = "306"
 
 func init() {
 	testAccProvider = aci.Provider()

--- a/testacc/resource_aci_aaaldapprovider_test.go
+++ b/testacc/resource_aci_aaaldapprovider_test.go
@@ -176,6 +176,14 @@ func TestAccAciLDAPProvider_Update(t *testing.T) {
 				),
 			},
 			{
+				Config: CreateAccLDAPProviderUpdatedAttr(rName, "ldap", "timeout", "18"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLDAPProviderExists(resourceName, &ldap_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "18"),
+					testAccCheckAciLDAPProviderIdEqual(&ldap_provider_default, &ldap_provider_updated),
+				),
+			},
+			{
 				Config: CreateAccLDAPProviderConfig(rName, "ldap"),
 			},
 		},

--- a/testacc/resource_aci_cloudctxprofile_test.go
+++ b/testacc/resource_aci_cloudctxprofile_test.go
@@ -116,6 +116,7 @@ func TestAccAciCloudContextProfile_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciCloudContextProfileExists(resourceName, &cloud_context_profile_updated),
 					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "relation_cloud_rs_to_ctx", fmt.Sprintf("uni/tn-%s/ctx-%s", rNameUpdated, rNameUpdated)),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					testAccCheckAciCloudContextProfileIdNotEqual(&cloud_context_profile_default, &cloud_context_profile_updated),
 				),
@@ -128,6 +129,7 @@ func TestAccAciCloudContextProfile_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciCloudContextProfileExists(resourceName, &cloud_context_profile_updated),
 					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "relation_cloud_rs_to_ctx", fmt.Sprintf("uni/tn-%s/ctx-%s", rName, rName)),
 					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
 					testAccCheckAciCloudContextProfileIdNotEqual(&cloud_context_profile_default, &cloud_context_profile_updated),
 				),

--- a/testacc/resource_aci_fabricnodeblk_maintgrp_test.go
+++ b/testacc/resource_aci_fabricnodeblk_maintgrp_test.go
@@ -1,0 +1,495 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciNodeBlockMG_Basic(t *testing.T) {
+	var maintenance_group_node_default models.NodeBlockMG
+	var maintenance_group_node_updated models.NodeBlockMG
+	resourceName := "aci_maintenance_group_node.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	maintMaintGrpName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciNodeBlockMGDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateNodeBlockMGWithoutRequired(maintMaintGrpName, rName, "pod_maintenance_group_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateNodeBlockMGWithoutRequired(maintMaintGrpName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccNodeBlockMGConfig(maintMaintGrpName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciNodeBlockMGExists(resourceName, &maintenance_group_node_default),
+					resource.TestCheckResourceAttr(resourceName, "pod_maintenance_group_dn", fmt.Sprintf("uni/fabric/maintgrp-%s", maintMaintGrpName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "from_", "1"),
+					resource.TestCheckResourceAttr(resourceName, "to_", "1"),
+				),
+			},
+			{
+				Config: CreateAccNodeBlockMGConfigWithOptionalValues(maintMaintGrpName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciNodeBlockMGExists(resourceName, &maintenance_group_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "pod_maintenance_group_dn", fmt.Sprintf("uni/fabric/maintgrp-%s", maintMaintGrpName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_maintenance_group_node"),
+					resource.TestCheckResourceAttr(resourceName, "from_", "2"),
+					resource.TestCheckResourceAttr(resourceName, "to_", "2"),
+
+					testAccCheckAciNodeBlockMGIdEqual(&maintenance_group_node_default, &maintenance_group_node_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccNodeBlockMGConfigUpdatedName(maintMaintGrpName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccNodeBlockMGRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccNodeBlockMGConfigWithRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciNodeBlockMGExists(resourceName, &maintenance_group_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "pod_maintenance_group_dn", fmt.Sprintf("uni/fabric/maintgrp-%s", rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciNodeBlockMGIdNotEqual(&maintenance_group_node_default, &maintenance_group_node_updated),
+				),
+			},
+			{
+				Config: CreateAccNodeBlockMGConfig(maintMaintGrpName, rName),
+			},
+			{
+				Config: CreateAccNodeBlockMGConfigWithRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciNodeBlockMGExists(resourceName, &maintenance_group_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "pod_maintenance_group_dn", fmt.Sprintf("uni/fabric/maintgrp-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciNodeBlockMGIdNotEqual(&maintenance_group_node_default, &maintenance_group_node_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciNodeBlockMG_Update(t *testing.T) {
+	var maintenance_group_node_default models.NodeBlockMG
+	var maintenance_group_node_updated models.NodeBlockMG
+	resourceName := "aci_maintenance_group_node.test"
+	rName := makeTestVariable(acctest.RandString(5))
+
+	maintMaintGrpName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciNodeBlockMGDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccNodeBlockMGConfig(maintMaintGrpName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciNodeBlockMGExists(resourceName, &maintenance_group_node_default),
+				),
+			},
+			{
+				Config: CreateAccNodeBlockMGUpdatedAttr(maintMaintGrpName, rName, "to_", "16000"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciNodeBlockMGExists(resourceName, &maintenance_group_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "to_", "16000"),
+					testAccCheckAciNodeBlockMGIdEqual(&maintenance_group_node_default, &maintenance_group_node_updated),
+				),
+			},
+			{
+				Config: CreateAccNodeBlockMGUpdatedAttr(maintMaintGrpName, rName, "from_", "16000"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciNodeBlockMGExists(resourceName, &maintenance_group_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "from_", "16000"),
+					testAccCheckAciNodeBlockMGIdEqual(&maintenance_group_node_default, &maintenance_group_node_updated),
+				),
+			},
+			{
+				Config: CreateAccNodeBlockMGUpdatedAttr(maintMaintGrpName, rName, "from_", "7999"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciNodeBlockMGExists(resourceName, &maintenance_group_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "from_", "7999"),
+					testAccCheckAciNodeBlockMGIdEqual(&maintenance_group_node_default, &maintenance_group_node_updated),
+				),
+			},
+			{
+				Config: CreateAccNodeBlockMGUpdatedAttr(maintMaintGrpName, rName, "to_", "7999"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciNodeBlockMGExists(resourceName, &maintenance_group_node_updated),
+					resource.TestCheckResourceAttr(resourceName, "to_", "7999"),
+					testAccCheckAciNodeBlockMGIdEqual(&maintenance_group_node_default, &maintenance_group_node_updated),
+				),
+			},
+
+			{
+				Config: CreateAccNodeBlockMGConfig(maintMaintGrpName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciNodeBlockMG_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	maintMaintGrpName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciNodeBlockMGDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccNodeBlockMGConfig(maintMaintGrpName, rName),
+			},
+			{
+				Config:      CreateAccNodeBlockMGWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccNodeBlockMGUpdatedAttr(maintMaintGrpName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccNodeBlockMGUpdatedAttr(maintMaintGrpName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccNodeBlockMGUpdatedAttr(maintMaintGrpName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccNodeBlockMGUpdatedAttr(maintMaintGrpName, rName, "from_", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccNodeBlockMGUpdatedAttr(maintMaintGrpName, rName, "from_", "0"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccNodeBlockMGUpdatedAttr(maintMaintGrpName, rName, "from_", "16001"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccNodeBlockMGUpdatedAttr(maintMaintGrpName, rName, "to_", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccNodeBlockMGUpdatedAttr(maintMaintGrpName, rName, "to_", "0"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccNodeBlockMGUpdatedAttr(maintMaintGrpName, rName, "to_", "16001"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccNodeBlockMGUpdatedAttr(maintMaintGrpName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccNodeBlockMGConfig(maintMaintGrpName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciNodeBlockMG_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	maintMaintGrpName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciNodeBlockMGDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccNodeBlockMGConfigMultiple(maintMaintGrpName, rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciNodeBlockMGExists(name string, maintenance_group_node *models.NodeBlockMG) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Node Block MG %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Node Block MG dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		maintenance_group_nodeFound := models.NodeBlockFromContainerMG(cont)
+		if maintenance_group_nodeFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Node Block MG %s not found", rs.Primary.ID)
+		}
+		*maintenance_group_node = *maintenance_group_nodeFound
+		return nil
+	}
+}
+
+func testAccCheckAciNodeBlockMGDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing maintenance_group_node destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_maintenance_group_node" {
+			cont, err := client.Get(rs.Primary.ID)
+			maintenance_group_node := models.NodeBlockFromContainerMG(cont)
+			if err == nil {
+				return fmt.Errorf("Node Block MG %s Still exists", maintenance_group_node.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciNodeBlockMGIdEqual(m1, m2 *models.NodeBlockMG) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("maintenance_group_node DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciNodeBlockMGIdNotEqual(m1, m2 *models.NodeBlockMG) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("maintenance_group_node DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateNodeBlockMGWithoutRequired(maintMaintGrpName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing maintenance_group_node creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_pod_maintenance_group" "test" {
+		name 		= "%s"
+		
+	}
+	
+	`
+	switch attrName {
+	case "pod_maintenance_group_dn":
+		rBlock += `
+	resource "aci_maintenance_group_node" "test" {
+	#	pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, maintMaintGrpName, rName)
+}
+
+func CreateAccNodeBlockMGConfigWithRequiredParams(prName, rName string) string {
+	fmt.Printf("=== STEP  testing maintenance_group_node creation with parent resource name %s and resource name %s\n", prName, rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_pod_maintenance_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+		name  = "%s"
+	}
+	`, prName, rName)
+	return resource
+}
+func CreateAccNodeBlockMGConfigUpdatedName(maintMaintGrpName, rName string) string {
+	fmt.Println("=== STEP  testing maintenance_group_node creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_pod_maintenance_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+		name  = "%s"
+	}
+	`, maintMaintGrpName, rName)
+	return resource
+}
+
+func CreateAccNodeBlockMGConfig(maintMaintGrpName, rName string) string {
+	fmt.Println("=== STEP  testing maintenance_group_node creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_pod_maintenance_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+		name  = "%s"
+	}
+	`, maintMaintGrpName, rName)
+	return resource
+}
+
+func CreateAccNodeBlockMGConfigMultiple(maintMaintGrpName, rName string) string {
+	fmt.Println("=== STEP  testing multiple maintenance_group_node creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_pod_maintenance_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+		name  = "%s_${count.index}"
+		from_ = (count.index+1)*10 
+		to_ = (count.index+1)*10+5
+		count = 5
+	}
+	`, maintMaintGrpName, rName)
+	return resource
+}
+
+func CreateAccNodeBlockMGWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing maintenance_group_node creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_tenant.test.id
+		name  = "%s"	
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccNodeBlockMGConfigWithOptionalValues(maintMaintGrpName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing maintenance_group_node creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_pod_maintenance_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = "${aci_pod_maintenance_group.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_maintenance_group_node"
+		from_ = "2"
+		to_ = "2"
+		
+	}
+	`, maintMaintGrpName, rName)
+
+	return resource
+}
+
+func CreateAccNodeBlockMGRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing maintenance_group_node updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_maintenance_group_node" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_maintenance_group_node"
+		from_ = "2"
+		to_ = "2"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccNodeBlockMGUpdatedAttr(maintMaintGrpName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing maintenance_group_node attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_pod_maintenance_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, maintMaintGrpName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccNodeBlockMGUpdatedAttrList(maintMaintGrpName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing maintenance_group_node attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_pod_maintenance_group" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_maintenance_group_node" "test" {
+		pod_maintenance_group_dn  = aci_pod_maintenance_group.test.id
+		name  = "%s"
+		%s = %s
+	}
+	`, maintMaintGrpName, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_fabricnodeidentp_test.go
+++ b/testacc/resource_aci_fabricnodeidentp_test.go
@@ -1,0 +1,433 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciFabricNodeMember_Basic(t *testing.T) {
+	var fabric_node_member_default models.FabricNodeMember
+	var fabric_node_member_updated models.FabricNodeMember
+	resourceName := "aci_fabric_node_member.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	serial1 := makeTestVariable(acctest.RandString(5))
+	serial2 := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFabricNodeMemberDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateFabricNodeMemberWithoutRequired(rName, serial1, "serial"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateFabricNodeMemberWithoutRequired(rName, serial1, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccFabricNodeMemberConfig(rName, serial1, fabricNodeMemNodeId1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeMemberExists(resourceName, &fabric_node_member_default),
+					resource.TestCheckResourceAttr(resourceName, "serial", serial1),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "ext_pool_id", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fabric_id", "1"),
+					resource.TestCheckResourceAttr(resourceName, "node_id", fabricNodeMemNodeId1),
+					resource.TestCheckResourceAttr(resourceName, "node_type", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "pod_id", "1"),
+					resource.TestCheckResourceAttr(resourceName, "role", "unspecified"),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeMemberConfigWithOptionalValues(rNameUpdated, serial1, fabricNodeMemNodeId1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeMemberExists(resourceName, &fabric_node_member_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					resource.TestCheckResourceAttr(resourceName, "serial", serial1),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_fabric_node_member"),
+					resource.TestCheckResourceAttr(resourceName, "node_id", fabricNodeMemNodeId1),
+					resource.TestCheckResourceAttr(resourceName, "node_type", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "pod_id", "1"),
+					resource.TestCheckResourceAttr(resourceName, "role", "unspecified"),
+					resource.TestCheckResourceAttr(resourceName, "ext_pool_id", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fabric_id", "1"),
+					testAccCheckAciFabricNodeMemberIdEqual(&fabric_node_member_default, &fabric_node_member_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+			{
+				Config:      CreateAccFabricNodeMemberRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateAccFabricNodeMemberConfigWithRequiredParams(acctest.RandString(65), serial2, fabricNodeMemNodeId4),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+			{
+				Config: CreateAccFabricNodeMemberConfigWithRequiredParams(rNameUpdated, serial2, fabricNodeMemNodeId1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeMemberExists(resourceName, &fabric_node_member_updated),
+					resource.TestCheckResourceAttr(resourceName, "serial", serial2),
+					testAccCheckAciFabricNodeMemberIdNotEqual(&fabric_node_member_default, &fabric_node_member_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciFabricNodeMember_Update(t *testing.T) {
+	var fabric_node_member_default models.FabricNodeMember
+	var fabric_node_member_updated models.FabricNodeMember
+	resourceName := "aci_fabric_node_member.test"
+	serial1 := makeTestVariable(acctest.RandString(5))
+	serial2 := makeTestVariable(acctest.RandString(5))
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFabricNodeMemberDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccFabricNodeMemberConfig(rName, serial1, fabricNodeMemNodeId2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeMemberExists(resourceName, &fabric_node_member_default),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeMemberUpdatedAttr(rName, serial2, fabricNodeMemNodeId2, "ext_pool_id", "100"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeMemberExists(resourceName, &fabric_node_member_updated),
+					resource.TestCheckResourceAttr(resourceName, "ext_pool_id", "100"),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeMemberUpdatedAttr(rName, serial1, fabricNodeMemNodeId2, "fabric_id", "100"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeMemberExists(resourceName, &fabric_node_member_updated),
+					resource.TestCheckResourceAttr(resourceName, "fabric_id", "100"),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeMemberUpdatedAttr(rName, serial2, fabricNodeMemNodeId2, "node_type", "remote-leaf-wan"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeMemberExists(resourceName, &fabric_node_member_updated),
+					resource.TestCheckResourceAttr(resourceName, "node_type", "remote-leaf-wan"),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeMemberUpdatedAttr(rName, serial1, fabricNodeMemNodeId2, "pod_id", "126"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeMemberExists(resourceName, &fabric_node_member_updated),
+					resource.TestCheckResourceAttr(resourceName, "pod_id", "126"),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeMemberUpdatedAttr(rName, serial2, fabricNodeMemNodeId2, "pod_id", "254"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeMemberExists(resourceName, &fabric_node_member_updated),
+					resource.TestCheckResourceAttr(resourceName, "pod_id", "254"),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeMemberUpdatedAttr(rName, serial1, fabricNodeMemNodeId2, "role", "leaf"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeMemberExists(resourceName, &fabric_node_member_updated),
+					resource.TestCheckResourceAttr(resourceName, "role", "leaf"),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeMemberUpdatedAttr(rName, serial2, fabricNodeMemNodeId2, "role", "spine"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciFabricNodeMemberExists(resourceName, &fabric_node_member_updated),
+					resource.TestCheckResourceAttr(resourceName, "role", "spine"),
+				),
+			},
+			{
+				Config: CreateAccFabricNodeMemberConfig(rName, serial1, fabricNodeMemNodeId2),
+			},
+		},
+	})
+}
+
+func TestAccAciFabricNodeMember_Negative(t *testing.T) {
+	serial1 := makeTestVariable(acctest.RandString(5))
+	serial2 := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFabricNodeMemberDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccFabricNodeMemberConfig(rName, serial1, fabricNodeMemNodeId3),
+			},
+
+			{
+				Config:      CreateAccFabricNodeMemberUpdatedAttr(rName, serial2, fabricNodeMemNodeId4, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccFabricNodeMemberUpdatedAttr(rName, serial2, fabricNodeMemNodeId4, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccFabricNodeMemberUpdatedAttr(rName, serial2, fabricNodeMemNodeId4, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccFabricNodeMemberUpdatedAttr(rName, serial2, fabricNodeMemNodeId4, "ext_pool_id", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccFabricNodeMemberUpdatedAttr(rName, serial2, fabricNodeMemNodeId4, "fabric_id", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccFabricNodeMemberUpdatedAttr(rName, serial2, fabricNodeMemNodeId4, "node_type", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccFabricNodeMemberUpdatedAttr(rName, serial2, fabricNodeMemNodeId4, "pod_id", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccFabricNodeMemberUpdatedAttr(rName, serial2, fabricNodeMemNodeId4, "pod_id", "0"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccFabricNodeMemberUpdatedAttr(rName, serial2, fabricNodeMemNodeId4, "pod_id", "255"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccFabricNodeMemberUpdatedAttr(rName, serial2, fabricNodeMemNodeId4, "role", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccFabricNodeMemberUpdatedAttrNode(rName, serial2, "100"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccFabricNodeMemberUpdatedAttrNode(rName, serial2, "4001"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccFabricNodeMemberUpdatedAttrNode(rName, serial2, randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccFabricNodeMemberUpdatedAttr(rName, serial2, fabricNodeMemNodeId4, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccFabricNodeMemberConfig(rName, serial2, fabricNodeMemNodeId4),
+			},
+		},
+	})
+}
+
+func testAccCheckAciFabricNodeMemberExists(name string, fabric_node_member *models.FabricNodeMember) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Fabric Node Member %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Fabric Node Member dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		fabric_node_memberFound := models.FabricNodeMemberFromContainer(cont)
+		if fabric_node_memberFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Fabric Node Member %s not found", rs.Primary.ID)
+		}
+		*fabric_node_member = *fabric_node_memberFound
+		return nil
+	}
+}
+
+func testAccCheckAciFabricNodeMemberDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing fabric_node_member destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_fabric_node_member" {
+			cont, err := client.Get(rs.Primary.ID)
+			fabric_node_member := models.FabricNodeMemberFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Fabric Node Member %s Still exists", fabric_node_member.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciFabricNodeMemberIdEqual(m1, m2 *models.FabricNodeMember) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("fabric_node_member DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciFabricNodeMemberIdNotEqual(m1, m2 *models.FabricNodeMember) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("fabric_node_member DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateFabricNodeMemberWithoutRequired(name, serial, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing fabric_node_member creation without ", attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "serial":
+		rBlock += `
+	resource "aci_fabric_node_member" "test" {
+		name = "%s"
+	#	serial  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_fabric_node_member" "test" {
+	#	name = "%s"
+		serial  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, name, serial)
+}
+
+func CreateAccFabricNodeMemberConfigWithRequiredParams(name, serial, node string) string {
+	fmt.Printf("=== STEP  testing fabric_node_member creation with serial %s and name %s\n", serial, name)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_fabric_node_member" "test" {
+		serial  = "%s"
+		node_id = "%s"
+		name = "%s"
+	}
+	`, serial, node, name)
+	return resource
+}
+
+func CreateAccFabricNodeMemberConfig(name, serial, node string) string {
+	fmt.Println("=== STEP  testing fabric_node_member creation with required arguments and node_id")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_fabric_node_member" "test" {
+		serial  = "%s"
+		name = "%s"
+		node_id = "%s"
+	}
+	`, serial, name, node)
+	return resource
+}
+
+func CreateAccFabricNodeMemberConfigWithOptionalValues(name, serial, node string) string {
+	fmt.Println("=== STEP  Basic: testing fabric_node_member creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_fabric_node_member" "test" {
+		name = "%s"
+		serial  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_fabric_node_member"
+		node_id = "%s"
+		node_type = "unspecified"
+		pod_id = "1"
+		role = "unspecified"
+		ext_pool_id = "0"
+		fabric_id = "1"
+	}
+	`, name, serial, node)
+
+	return resource
+}
+
+func CreateAccFabricNodeMemberRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing fabric_node_member updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_fabric_node_member" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_fabric_node_member"
+		node_id = "102"
+		node_type = "remote-leaf-wan"
+		pod_id = "2"
+		role = "leaf"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccFabricNodeMemberUpdatedAttrNode(name, serial, node string) string {
+	fmt.Printf("=== STEP  testing fabric_node_member attribute: node = %s \n", node)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_fabric_node_member" "test" {
+		name = "%s"
+		serial  = "%s"
+		node_id = "%s"
+	}
+	`, name, serial, node)
+	return resource
+}
+
+func CreateAccFabricNodeMemberUpdatedAttr(name, serial, node, attribute, value string) string {
+	fmt.Printf("=== STEP  testing fabric_node_member attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_fabric_node_member" "test" {
+		name = "%s"
+		serial  = "%s"
+		node_id = "%s"
+		%s = "%s"
+	}
+	`, name, serial, node, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_firmwarefwp_test.go
+++ b/testacc/resource_aci_firmwarefwp_test.go
@@ -18,13 +18,13 @@ func TestAccAciFirmwarePolicy_Basic(t *testing.T) {
 	resourceName := "aci_firmware_policy.test"
 	rName := makeTestVariable(acctest.RandString(5))
 	rNameUpdated := makeTestVariable(acctest.RandString(5))
-	
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:	  func(){ testAccPreCheck(t) },
-		ProviderFactories:    testAccProviders,
-		CheckDestroy: testAccCheckAciFirmwarePolicyDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFirmwarePolicyDestroy,
 		Steps: []resource.TestStep{
-			
+
 			{
 				Config:      CreateFirmwarePolicyWithoutRequired(rName, "name"),
 				ExpectError: regexp.MustCompile(`Missing required argument`),
@@ -33,35 +33,34 @@ func TestAccAciFirmwarePolicy_Basic(t *testing.T) {
 				Config: CreateAccFirmwarePolicyConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciFirmwarePolicyExists(resourceName, &firmware_policy_default),
-					
-					resource.TestCheckResourceAttr(resourceName, "name",rName),
-					resource.TestCheckResourceAttr(resourceName, "annotation","orchestrator:terraform"),
-					resource.TestCheckResourceAttr(resourceName, "description",""),
-					resource.TestCheckResourceAttr(resourceName, "name_alias",""),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
 					resource.TestCheckResourceAttr(resourceName, "effective_on_reboot", "no"),
 					resource.TestCheckResourceAttr(resourceName, "ignore_compat", "no"),
 					resource.TestCheckResourceAttr(resourceName, "internal_label", ""),
 					resource.TestCheckResourceAttr(resourceName, "version", ""),
 					resource.TestCheckResourceAttr(resourceName, "version_check_override", "untriggered"),
-					
 				),
 			},
 			{
-				Config: CreateAccFirmwarePolicyConfigWithOptionalValues(rName), 
+				Config: CreateAccFirmwarePolicyConfigWithOptionalValues(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciFirmwarePolicyExists(resourceName, &firmware_policy_updated),
-					resource.TestCheckResourceAttr(resourceName, "name",rName),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
 					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
 					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_firmware_policy"),
 					resource.TestCheckResourceAttr(resourceName, "effective_on_reboot", "yes"),
 					resource.TestCheckResourceAttr(resourceName, "ignore_compat", "yes"),
-					resource.TestCheckResourceAttr(resourceName, "internal_label", "internal_label_test"),					
+					resource.TestCheckResourceAttr(resourceName, "internal_label", "internal_label_test"),
 					resource.TestCheckResourceAttr(resourceName, "version", "n9000-14.2(3q)"),
 					resource.TestCheckResourceAttr(resourceName, "version_check_override", "trigger"),
 					testAccCheckAciFirmwarePolicyIdEqual(&firmware_policy_default, &firmware_policy_updated),
 				),
-			},  
+			},
 			{
 				ResourceName:      resourceName,
 				ImportState:       true,
@@ -71,18 +70,18 @@ func TestAccAciFirmwarePolicy_Basic(t *testing.T) {
 				Config:      CreateAccFirmwarePolicyConfigUpdatedName(acctest.RandString(65)),
 				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
 			},
-			
+
 			{
 				Config:      CreateAccFirmwarePolicyRemovingRequiredField(),
 				ExpectError: regexp.MustCompile(`Missing required argument`),
 			},
-			
+
 			{
 				Config: CreateAccFirmwarePolicyConfigWithRequiredParams(rNameUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAciFirmwarePolicyExists(resourceName, &firmware_policy_updated),
-					
-					resource.TestCheckResourceAttr(resourceName, "name",rNameUpdated),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
 					testAccCheckAciFirmwarePolicyIdNotEqual(&firmware_policy_default, &firmware_policy_updated),
 				),
 			},
@@ -95,11 +94,11 @@ func TestAccAciFirmwarePolicy_Update(t *testing.T) {
 	var firmware_policy_updated models.FirmwarePolicy
 	resourceName := "aci_firmware_policy.test"
 	rName := makeTestVariable(acctest.RandString(5))
-	
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:	  func(){ testAccPreCheck(t) },
-		ProviderFactories:    testAccProviders,
-		CheckDestroy: testAccCheckAciFirmwarePolicyDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFirmwarePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: CreateAccFirmwarePolicyConfig(rName),
@@ -107,7 +106,7 @@ func TestAccAciFirmwarePolicy_Update(t *testing.T) {
 					testAccCheckAciFirmwarePolicyExists(resourceName, &firmware_policy_default),
 				),
 			},
-			
+
 			{
 				Config: CreateAccFirmwarePolicyUpdatedAttr(rName, "version_check_override", "trigger-immediate"),
 				Check: resource.ComposeTestCheckFunc(
@@ -133,19 +132,19 @@ func TestAccAciFirmwarePolicy_Update(t *testing.T) {
 
 func TestAccAciFirmwarePolicy_Negative(t *testing.T) {
 	rName := makeTestVariable(acctest.RandString(5))
-	
+
 	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
 	randomValue := acctest.RandString(5)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:	  func(){ testAccPreCheck(t) },
-		ProviderFactories:    testAccProviders,
-		CheckDestroy: testAccCheckAciFirmwarePolicyDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFirmwarePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: CreateAccFirmwarePolicyConfig(rName),
 			},
-			
+
 			{
 				Config:      CreateAccFirmwarePolicyUpdatedAttr(rName, "description", acctest.RandString(129)),
 				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
@@ -158,32 +157,32 @@ func TestAccAciFirmwarePolicy_Negative(t *testing.T) {
 				Config:      CreateAccFirmwarePolicyUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
 				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
 			},
-			
+
 			{
 				Config:      CreateAccFirmwarePolicyUpdatedAttr(rName, "effective_on_reboot", randomValue),
 				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
 			},
-			
+
 			{
 				Config:      CreateAccFirmwarePolicyUpdatedAttr(rName, "ignore_compat", randomValue),
 				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
 			},
-			
+
 			{
 				Config:      CreateAccFirmwarePolicyUpdatedAttr(rName, "internal_label", acctest.RandString(513)),
 				ExpectError: regexp.MustCompile(`failed validation for value`),
 			},
-			
+
 			{
 				Config:      CreateAccFirmwarePolicyUpdatedAttr(rName, "version", acctest.RandString(513)),
 				ExpectError: regexp.MustCompile(`failed validation for value`),
 			},
-			
+
 			{
 				Config:      CreateAccFirmwarePolicyUpdatedAttr(rName, "version_check_override", randomValue),
 				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
 			},
-			
+
 			{
 				Config:      CreateAccFirmwarePolicyUpdatedAttr(rName, randomParameter, randomValue),
 				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
@@ -197,11 +196,11 @@ func TestAccAciFirmwarePolicy_Negative(t *testing.T) {
 
 func TestAccAciFirmwarePolicy_MultipleCreateDelete(t *testing.T) {
 	rName := makeTestVariable(acctest.RandString(5))
-	
+
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:	  func(){ testAccPreCheck(t) },
-		ProviderFactories:    testAccProviders,
-		CheckDestroy: testAccCheckAciFirmwarePolicyDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciFirmwarePolicyDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: CreateAccFirmwarePolicyConfigMultiple(rName),
@@ -238,17 +237,17 @@ func testAccCheckAciFirmwarePolicyExists(name string, firmware_policy *models.Fi
 	}
 }
 
-func testAccCheckAciFirmwarePolicyDestroy(s *terraform.State) error {	
+func testAccCheckAciFirmwarePolicyDestroy(s *terraform.State) error {
 	fmt.Println("=== STEP  testing firmware_policy destroy")
 	client := testAccProvider.Meta().(*client.Client)
 	for _, rs := range s.RootModule().Resources {
-		 if rs.Type == "aci_firmware_policy" {
-			cont,err := client.Get(rs.Primary.ID)
+		if rs.Type == "aci_firmware_policy" {
+			cont, err := client.Get(rs.Primary.ID)
 			firmware_policy := models.FirmwarePolicyFromContainer(cont)
 			if err == nil {
-				return fmt.Errorf("Firmware Policy %s Still exists",firmware_policy.DistinguishedName)
+				return fmt.Errorf("Firmware Policy %s Still exists", firmware_policy.DistinguishedName)
 			}
-		}else{
+		} else {
 			continue
 		}
 	}
@@ -274,7 +273,7 @@ func testAccCheckAciFirmwarePolicyIdNotEqual(m1, m2 *models.FirmwarePolicy) reso
 }
 
 func CreateFirmwarePolicyWithoutRequired(rName, attrName string) string {
-	fmt.Println("=== STEP  Basic: testing firmware_policy creation without ",attrName)
+	fmt.Println("=== STEP  Basic: testing firmware_policy creation without ", attrName)
 	rBlock := `
 	
 	`
@@ -287,11 +286,11 @@ func CreateFirmwarePolicyWithoutRequired(rName, attrName string) string {
 	}
 		`
 	}
-	return fmt.Sprintf(rBlock,rName)
+	return fmt.Sprintf(rBlock, rName)
 }
 
 func CreateAccFirmwarePolicyConfigWithRequiredParams(rName string) string {
-	fmt.Println("=== STEP  testing firmware_policy creation with name =",rName)
+	fmt.Println("=== STEP  testing firmware_policy creation with name =", rName)
 	resource := fmt.Sprintf(`
 	
 	resource "aci_firmware_policy" "test" {
@@ -302,7 +301,7 @@ func CreateAccFirmwarePolicyConfigWithRequiredParams(rName string) string {
 	return resource
 }
 func CreateAccFirmwarePolicyConfigUpdatedName(rName string) string {
-	fmt.Println("=== STEP  testing firmware_policy creation with invalid name = ",rName)
+	fmt.Println("=== STEP  testing firmware_policy creation with invalid name = ", rName)
 	resource := fmt.Sprintf(`
 	
 	resource "aci_firmware_policy" "test" {
@@ -337,8 +336,6 @@ func CreateAccFirmwarePolicyConfigMultiple(rName string) string {
 	`, rName)
 	return resource
 }
-
-
 
 func CreateAccFirmwarePolicyConfigWithOptionalValues(rName string) string {
 	fmt.Println("=== STEP  Basic: testing firmware_policy creation with optional parameters")
@@ -381,7 +378,7 @@ func CreateAccFirmwarePolicyRemovingRequiredField() string {
 	return resource
 }
 
-func CreateAccFirmwarePolicyUpdatedAttr(rName,attribute,value string) string {
+func CreateAccFirmwarePolicyUpdatedAttr(rName, attribute, value string) string {
 	fmt.Printf("=== STEP  testing firmware_policy attribute: %s = %s \n", attribute, value)
 	resource := fmt.Sprintf(`
 	
@@ -390,11 +387,11 @@ func CreateAccFirmwarePolicyUpdatedAttr(rName,attribute,value string) string {
 		name  = "%s"
 		%s = "%s"
 	}
-	`, rName,attribute,value)
+	`, rName, attribute, value)
 	return resource
 }
 
-func CreateAccFirmwarePolicyUpdatedAttrList(rName,attribute,value string) string {
+func CreateAccFirmwarePolicyUpdatedAttrList(rName, attribute, value string) string {
 	fmt.Printf("=== STEP  testing firmware_policy attribute: %s = %s \n", attribute, value)
 	resource := fmt.Sprintf(`
 	
@@ -403,6 +400,6 @@ func CreateAccFirmwarePolicyUpdatedAttrList(rName,attribute,value string) string
 		name  = "%s"
 		%s = %s
 	}
-	`, rName,attribute,value)
+	`, rName, attribute, value)
 	return resource
 }

--- a/testacc/resource_aci_fvnsvxlaninstp_test.go
+++ b/testacc/resource_aci_fvnsvxlaninstp_test.go
@@ -1,0 +1,321 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciVXLANPool_Basic(t *testing.T) {
+	var vxlan_pool_default models.VXLANPool
+	var vxlan_pool_updated models.VXLANPool
+	resourceName := "aci_vxlan_pool.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVXLANPoolDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateVXLANPoolWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccVXLANPoolConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVXLANPoolExists(resourceName, &vxlan_pool_default),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+				),
+			},
+			{
+				Config: CreateAccVXLANPoolConfigWithOptionalValues(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVXLANPoolExists(resourceName, &vxlan_pool_updated),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_vxlan_pool"),
+
+					testAccCheckAciVXLANPoolIdEqual(&vxlan_pool_default, &vxlan_pool_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccVXLANPoolConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccVXLANPoolRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+
+			{
+				Config: CreateAccVXLANPoolConfigWithRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciVXLANPoolExists(resourceName, &vxlan_pool_updated),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciVXLANPoolIdNotEqual(&vxlan_pool_default, &vxlan_pool_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciVXLANPool_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVXLANPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccVXLANPoolConfig(rName),
+			},
+
+			{
+				Config:      CreateAccVXLANPoolUpdatedAttr(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccVXLANPoolUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccVXLANPoolUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccVXLANPoolUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccVXLANPoolConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciVXLANPool_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciVXLANPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccVXLANPoolConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciVXLANPoolExists(name string, vxlan_pool *models.VXLANPool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("VXLAN Pool %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No VXLAN Pool dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		vxlan_poolFound := models.VXLANPoolFromContainer(cont)
+		if vxlan_poolFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("VXLAN Pool %s not found", rs.Primary.ID)
+		}
+		*vxlan_pool = *vxlan_poolFound
+		return nil
+	}
+}
+
+func testAccCheckAciVXLANPoolDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing vxlan_pool destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_vxlan_pool" {
+			cont, err := client.Get(rs.Primary.ID)
+			vxlan_pool := models.VXLANPoolFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("VXLAN Pool %s Still exists", vxlan_pool.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciVXLANPoolIdEqual(m1, m2 *models.VXLANPool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("vxlan_pool DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciVXLANPoolIdNotEqual(m1, m2 *models.VXLANPool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("vxlan_pool DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateVXLANPoolWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing vxlan_pool creation without ", attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_vxlan_pool" "test" {
+	
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccVXLANPoolConfigWithRequiredParams(rName string) string {
+	fmt.Println("=== STEP  testing vxlan_pool creation with name =", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vxlan_pool" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+func CreateAccVXLANPoolConfigUpdatedName(rName string) string {
+	fmt.Println("=== STEP  testing vxlan_pool creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vxlan_pool" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccVXLANPoolConfig(rName string) string {
+	fmt.Println("=== STEP  testing vxlan_pool creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vxlan_pool" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccVXLANPoolConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple vxlan_pool creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vxlan_pool" "test" {
+	
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccVXLANPoolConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing vxlan_pool creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vxlan_pool" "test" {
+	
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_vxlan_pool"
+		
+	}
+	`, rName)
+
+	return resource
+}
+
+func CreateAccVXLANPoolRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing vxlan_pool updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_vxlan_pool" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_vxlan_pool"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccVXLANPoolUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing vxlan_pool attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vxlan_pool" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName, attribute, value)
+	return resource
+}
+
+func CreateAccVXLANPoolUpdatedAttrList(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing vxlan_pool attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_vxlan_pool" "test" {
+	
+		name  = "%s"
+		%s = %s
+	}
+	`, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_qosinstpol_test.go
+++ b/testacc/resource_aci_qosinstpol_test.go
@@ -1,0 +1,437 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/terraform-providers/terraform-provider-aci/aci"
+)
+
+func TestAccAciQOSInstancePolicy_Basic(t *testing.T) {
+	var qos_instance_policy_default models.QOSInstancePolicy
+	var qos_instance_policy_updated models.QOSInstancePolicy
+	resourceName := "aci_qos_instance_policy.test"
+	QOSInstancePolicy, err := aci.GetRemoteQOSInstancePolicy(sharedAciClient(), "uni/infra/qosinst-default")
+	if err != nil {
+		t.Errorf("reading initial config of QOSInstancePolicy")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccQOSInstancePolicyConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciQOSInstancePolicyExists(resourceName, &qos_instance_policy_default),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttrSet(resourceName, "etrap_age_timer"),
+					resource.TestCheckResourceAttrSet(resourceName, "etrap_bw_thresh"),
+					resource.TestCheckResourceAttrSet(resourceName, "etrap_byte_ct"),
+					resource.TestCheckResourceAttrSet(resourceName, "etrap_st"),
+					resource.TestCheckResourceAttrSet(resourceName, "ctrl"),
+					resource.TestCheckResourceAttrSet(resourceName, "fabric_flush_interval"),
+					resource.TestCheckResourceAttrSet(resourceName, "fabric_flush_st"),
+					resource.TestCheckResourceAttrSet(resourceName, "uburst_spine_queues"),
+					resource.TestCheckResourceAttrSet(resourceName, "uburst_tor_queues"),
+				),
+			},
+			{
+				Config: CreateAccQOSInstancePolicyConfigWithOptionalValues(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciQOSInstancePolicyExists(resourceName, &qos_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_qos_instance_policy"),
+					resource.TestCheckResourceAttr(resourceName, "etrap_st", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "etrap_age_timer", "0"),
+					resource.TestCheckResourceAttr(resourceName, "etrap_bw_thresh", "0"),
+					resource.TestCheckResourceAttr(resourceName, "etrap_byte_ct", "0"),
+					resource.TestCheckResourceAttr(resourceName, "fabric_flush_interval", "100"),
+					resource.TestCheckResourceAttr(resourceName, "fabric_flush_st", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "ctrl", "none"),
+					resource.TestCheckResourceAttr(resourceName, "uburst_spine_queues", "0"),
+					resource.TestCheckResourceAttr(resourceName, "uburst_tor_queues", "0"),
+					testAccCheckAciQOSInstancePolicyIdEqual(&qos_instance_policy_default, &qos_instance_policy_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: restoreQOSInstancePolicy(QOSInstancePolicy),
+			},
+		},
+	})
+}
+
+func TestAccAciQOSInstancePolicy_Update(t *testing.T) {
+	var qos_instance_policy_default models.QOSInstancePolicy
+	var qos_instance_policy_updated models.QOSInstancePolicy
+	resourceName := "aci_qos_instance_policy.test"
+	QOSInstancePolicy, err := aci.GetRemoteQOSInstancePolicy(sharedAciClient(), "uni/infra/qosinst-default")
+	if err != nil {
+		t.Errorf("reading initial config of QOSInstancePolicy")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccQOSInstancePolicyConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciQOSInstancePolicyExists(resourceName, &qos_instance_policy_default),
+				),
+			},
+			{
+				Config: CreateAccQOSInstancePolicyUpdatedAttr("etrap_age_timer", "500"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciQOSInstancePolicyExists(resourceName, &qos_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "etrap_age_timer", "500"),
+					testAccCheckAciQOSInstancePolicyIdEqual(&qos_instance_policy_default, &qos_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccQOSInstancePolicyUpdatedAttr("etrap_bw_thresh", "500"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciQOSInstancePolicyExists(resourceName, &qos_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "etrap_bw_thresh", "500"),
+					testAccCheckAciQOSInstancePolicyIdEqual(&qos_instance_policy_default, &qos_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccQOSInstancePolicyUpdatedAttr("etrap_byte_ct", "500"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciQOSInstancePolicyExists(resourceName, &qos_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "etrap_byte_ct", "500"),
+					testAccCheckAciQOSInstancePolicyIdEqual(&qos_instance_policy_default, &qos_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccQOSInstancePolicyUpdatedAttr("etrap_st", "no"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciQOSInstancePolicyExists(resourceName, &qos_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "etrap_st", "no"),
+					testAccCheckAciQOSInstancePolicyIdEqual(&qos_instance_policy_default, &qos_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccQOSInstancePolicyUpdatedAttr("fabric_flush_interval", "1000"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciQOSInstancePolicyExists(resourceName, &qos_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "fabric_flush_interval", "1000"),
+					testAccCheckAciQOSInstancePolicyIdEqual(&qos_instance_policy_default, &qos_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccQOSInstancePolicyUpdatedAttr("fabric_flush_interval", "550"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciQOSInstancePolicyExists(resourceName, &qos_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "fabric_flush_interval", "550"),
+					testAccCheckAciQOSInstancePolicyIdEqual(&qos_instance_policy_default, &qos_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccQOSInstancePolicyUpdatedAttr("fabric_flush_st", "no"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciQOSInstancePolicyExists(resourceName, &qos_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "fabric_flush_st", "no"),
+					testAccCheckAciQOSInstancePolicyIdEqual(&qos_instance_policy_default, &qos_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccQOSInstancePolicyUpdatedAttr("uburst_spine_queues", "100"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciQOSInstancePolicyExists(resourceName, &qos_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "uburst_spine_queues", "100"),
+					testAccCheckAciQOSInstancePolicyIdEqual(&qos_instance_policy_default, &qos_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccQOSInstancePolicyUpdatedAttr("uburst_spine_queues", "50"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciQOSInstancePolicyExists(resourceName, &qos_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "uburst_spine_queues", "50"),
+					testAccCheckAciQOSInstancePolicyIdEqual(&qos_instance_policy_default, &qos_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccQOSInstancePolicyUpdatedAttr("uburst_tor_queues", "100"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciQOSInstancePolicyExists(resourceName, &qos_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "uburst_tor_queues", "100"),
+					testAccCheckAciQOSInstancePolicyIdEqual(&qos_instance_policy_default, &qos_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccQOSInstancePolicyUpdatedAttr("uburst_tor_queues", "50"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciQOSInstancePolicyExists(resourceName, &qos_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "uburst_tor_queues", "50"),
+					testAccCheckAciQOSInstancePolicyIdEqual(&qos_instance_policy_default, &qos_instance_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccQOSInstancePolicyUpdatedAttr("ctrl", "none"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciQOSInstancePolicyExists(resourceName, &qos_instance_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "ctrl", "none"),
+					testAccCheckAciQOSInstancePolicyIdEqual(&qos_instance_policy_default, &qos_instance_policy_updated),
+				),
+			},
+			{
+				Config: restoreQOSInstancePolicy(QOSInstancePolicy),
+			},
+		},
+	})
+}
+
+func TestAccAciQOSInstancePolicy_Negative(t *testing.T) {
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	QOSInstancePolicy, err := aci.GetRemoteQOSInstancePolicy(sharedAciClient(), "uni/infra/qosinst-default")
+	if err != nil {
+		t.Errorf("reading initial config of QOSInstancePolicy")
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccQOSInstancePolicyConfig(),
+			},
+
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("etrap_age_timer", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("etrap_age_timer", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("etrap_bw_thresh", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("etrap_bw_thresh", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("etrap_byte_ct", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("etrap_byte_ct", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("etrap_st", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("fabric_flush_interval", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("fabric_flush_interval", "99"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("fabric_flush_interval", "1001"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("fabric_flush_st", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("ctrl", randomValue),
+				ExpectError: regexp.MustCompile(`expected (.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("uburst_spine_queues", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("uburst_spine_queues", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("uburst_spine_queues", "101"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("uburst_tor_queues", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("uburst_tor_queues", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr("uburst_tor_queues", "101"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccQOSInstancePolicyUpdatedAttr(randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: restoreQOSInstancePolicy(QOSInstancePolicy),
+			},
+		},
+	})
+}
+
+func testAccCheckAciQOSInstancePolicyExists(name string, qos_instance_policy *models.QOSInstancePolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("QOS Instance Policy %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No QOS Instance Policy dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		qos_instance_policyFound := models.QOSInstancePolicyFromContainer(cont)
+		if qos_instance_policyFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("QOS Instance Policy %s not found", rs.Primary.ID)
+		}
+		*qos_instance_policy = *qos_instance_policyFound
+		return nil
+	}
+}
+
+func testAccCheckAciQOSInstancePolicyIdEqual(m1, m2 *models.QOSInstancePolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("qos_instance_policy DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func restoreQOSInstancePolicy(QOSInstancePolicy *models.QOSInstancePolicy) string {
+	var resource string
+	if QOSInstancePolicy.Ctrl == "dot1p-preserve" {
+		resource = fmt.Sprintf(`
+		resource "aci_qos_instance_policy" "test" {
+				name_alias            = "%s"
+				description           = "%s"
+				etrap_age_timer       = "%s" 
+				etrap_bw_thresh       = "%s"
+				etrap_byte_ct         = "%s"
+				etrap_st              = "%s"
+				fabric_flush_interval = "%s"
+				fabric_flush_st       = "%s"
+				annotation            = "%s"
+				ctrl                  = "dot1p-preserve"
+				uburst_spine_queues   = "%s"
+				uburst_tor_queues     = "%s"
+			  }
+		`, QOSInstancePolicy.NameAlias, QOSInstancePolicy.Description, QOSInstancePolicy.EtrapAgeTimer, QOSInstancePolicy.EtrapBwThresh, QOSInstancePolicy.EtrapByteCt, QOSInstancePolicy.EtrapSt, QOSInstancePolicy.FabricFlushInterval, QOSInstancePolicy.FabricFlushSt, QOSInstancePolicy.Annotation, QOSInstancePolicy.UburstSpineQueues, QOSInstancePolicy.UburstTorQueues)
+	} else {
+		resource = fmt.Sprintf(`
+		resource "aci_qos_instance_policy" "test" {
+				name_alias            = "%s"
+				description           = "%s"
+				etrap_age_timer       = "%s" 
+				etrap_bw_thresh       = "%s"
+				etrap_byte_ct         = "%s"
+				etrap_st              = "%s"
+				fabric_flush_interval = "%s"
+				fabric_flush_st       = "%s"
+				annotation            = "%s"
+				ctrl                  = "none"
+				uburst_spine_queues   = "%s"
+				uburst_tor_queues     = "%s"
+			  }
+		`, QOSInstancePolicy.NameAlias, QOSInstancePolicy.Description, QOSInstancePolicy.EtrapAgeTimer, QOSInstancePolicy.EtrapBwThresh, QOSInstancePolicy.EtrapByteCt, QOSInstancePolicy.EtrapSt, QOSInstancePolicy.FabricFlushInterval, QOSInstancePolicy.FabricFlushSt, QOSInstancePolicy.Annotation, QOSInstancePolicy.UburstSpineQueues, QOSInstancePolicy.UburstTorQueues)
+	}
+	return resource
+}
+
+func CreateAccQOSInstancePolicyConfig() string {
+	fmt.Println("=== STEP  testing qos_instance_policy creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_qos_instance_policy" "test" {
+	}
+	`)
+	return resource
+}
+
+func CreateAccQOSInstancePolicyConfigWithOptionalValues() string {
+	fmt.Println("=== STEP  Basic: testing qos_instance_policy creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_qos_instance_policy" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_qos_instance_policy"
+		etrap_st = "yes"
+		etrap_age_timer = "0"
+		etrap_bw_thresh = "0"
+		etrap_byte_ct = "0"
+		fabric_flush_interval = "100"
+		fabric_flush_st = "yes"
+		ctrl = "none"
+		uburst_spine_queues = "0"
+		uburst_tor_queues = "0"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccQOSInstancePolicyUpdatedAttr(attribute, value string) string {
+	fmt.Printf("=== STEP  testing qos_instance_policy attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_qos_instance_policy" "test" {
+		%s = "%s"
+	}
+	`, attribute, value)
+	return resource
+}

--- a/website/docs/d/fabric_node_member.html.markdown
+++ b/website/docs/d/fabric_node_member.html.markdown
@@ -35,3 +35,4 @@ data "aci_fabric_node_member" "example" {
 - `pod_id` - (Optional) pod id
 - `role` - (Optional) system role type
 - `serial` - (Optional) serial number
+- `name` - (Optional) Name of Fabric Node member.

--- a/website/docs/r/cloud_context_profile.html.markdown
+++ b/website/docs/r/cloud_context_profile.html.markdown
@@ -15,7 +15,7 @@ Manages ACI Cloud Context Profile
 ```hcl
 
 	resource "aci_cloud_context_profile" "foocloud_context_profile" {
-		name 		         = "cloud_ctx_prof"
+		name 		             = "cloud_ctx_prof"
 		description              = "cloud_context_profile created while acceptance testing"
 		tenant_dn                = aci_tenant.footenant.id
 		primary_cidr             = "10.230.231.1/16"

--- a/website/docs/r/cloud_context_profile.html.markdown
+++ b/website/docs/r/cloud_context_profile.html.markdown
@@ -15,17 +15,17 @@ Manages ACI Cloud Context Profile
 ```hcl
 
 	resource "aci_cloud_context_profile" "foocloud_context_profile" {
-		name 		             = "cloud_ctx_prof"
+		name 		         = "cloud_ctx_prof"
 		description              = "cloud_context_profile created while acceptance testing"
 		tenant_dn                = aci_tenant.footenant.id
 		primary_cidr             = "10.230.231.1/16"
 		region                   = "us-west-1"
 		cloud_vendor	         = "aws"
 		relation_cloud_rs_to_ctx = aci_vrf.example.id
-		hub_network  		 	 = "uni/tn-infra/gwrouterp-default"
-		annotation			     = "context_profile"
-		name_alias				 = "alias_context_profile"
-		type					 = "regular"
+		hub_network  		 = "uni/tn-infra/gwrouterp-default"
+		annotation		 = "context_profile"
+		name_alias		 = "alias_context_profile"
+		type			 = "regular"
 	}
 
 ```


### PR DESCRIPTION
=== RUN   TestAccAciVXLANPoolDataSource_Basic
=== STEP  Basic: testing vxlan_pool Data Source without  name
=== STEP  testing vxlan_pool Data Source with required arguments only
=== STEP  testing vxlan_pool Data Source with random attribute
=== STEP  testing vxlan_pool Data Source with invalid name
=== STEP  testing vxlan_pool Data Source with updated resource
=== PAUSE TestAccAciVXLANPoolDataSource_Basic
=== RUN   TestAccAciVXLANPool_Basic
=== STEP  Basic: testing vxlan_pool creation without  name
=== STEP  testing vxlan_pool creation with required arguments only
=== STEP  Basic: testing vxlan_pool creation with optional parameters
=== STEP  testing vxlan_pool creation with invalid name =  dlswpdjhhbd163yynu11wbondwvgubx0li6d3j3pqjyt2pkjy69onte6p616ysaqq
=== STEP  Basic: testing vxlan_pool updation without required parameters
=== STEP  testing vxlan_pool creation with name = acctest_pnth8
=== PAUSE TestAccAciVXLANPool_Basic
=== RUN   TestAccAciVXLANPool_Negative
=== STEP  testing vxlan_pool creation with required arguments only
=== STEP  testing vxlan_pool attribute: description = safhbum44rkkg9stkzc4273amtpgfh4pnd98thl4a806w4oak8n2y3lj3go8eiuzz7fm08giuppi0ukb46tt17yk692gfp7mm32q1zjwnl6fdash0h6idwx6py27g4o6l
=== STEP  testing vxlan_pool attribute: annotation = ua79c62bwz40ocpgf8mu1a4s6ga4i1tb498v1s0yzmhuaviaa071xq2bqs1piglss72dqv6c7fzk93htr71vyjarmgtxdk0mzpnq0ocpvsexnvlbz9i2mkf09xdfsoxmj
=== STEP  testing vxlan_pool attribute: name_alias = ec7am1fzx1ylhiy6ue0ubc3s1tyl3gudz03i7jvbtbdsezhn0apoz3444z91lsyx
=== STEP  testing vxlan_pool attribute: xpanl = rc39w
=== STEP  testing vxlan_pool creation with required arguments only
=== PAUSE TestAccAciVXLANPool_Negative
=== RUN   TestAccAciVXLANPool_MultipleCreateDelete
=== STEP  testing multiple vxlan_pool creation with required arguments only
=== PAUSE TestAccAciVXLANPool_MultipleCreateDelete
=== CONT  TestAccAciVXLANPoolDataSource_Basic
=== CONT  TestAccAciVXLANPool_Negative
=== CONT  TestAccAciVXLANPool_Basic
=== CONT  TestAccAciVXLANPool_MultipleCreateDelete
=== STEP  testing vxlan_pool destroy
--- PASS: TestAccAciVXLANPool_MultipleCreateDelete (20.28s)
=== STEP  testing vxlan_pool destroy
--- PASS: TestAccAciVXLANPoolDataSource_Basic (40.43s)
=== STEP  testing vxlan_pool destroy
--- PASS: TestAccAciVXLANPool_Negative (53.09s)
=== STEP  testing vxlan_pool destroy
--- PASS: TestAccAciVXLANPool_Basic (56.53s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   57.851s
=== RUN   TestAccAciNodeBlockMGDataSource_Basic
=== STEP  Basic: testing maintenance_group_node Data Source without  pod_maintenance_group_dn
=== STEP  Basic: testing maintenance_group_node Data Source without  name
=== STEP  testing maintenance_group_node Data Source with required arguments only
=== STEP  testing maintenance_group_node Data Source with random attribute
=== STEP  testing maintenance_group_node Data Source with invalid name
=== STEP  testing maintenance_group_node Data Source with updated resource
=== PAUSE TestAccAciNodeBlockMGDataSource_Basic
=== RUN   TestAccAciNodeBlockMG_Basic
=== STEP  Basic: testing maintenance_group_node creation without  pod_maintenance_group_dn
=== STEP  Basic: testing maintenance_group_node creation without  name
=== STEP  testing maintenance_group_node creation with required arguments only
=== STEP  Basic: testing maintenance_group_node creation with optional parameters
=== STEP  testing maintenance_group_node creation with invalid name =  hd4n0fqfucnaekd8e0yrmikwdvw3jke7t3zt3d9yf6i23wbzxq1h38cdt7y0pqp7j
=== STEP  Basic: testing maintenance_group_node updation without required parameters
=== STEP  testing maintenance_group_node creation with parent resource name acctest_swtqo and resource name acctest_niloj
=== STEP  testing maintenance_group_node creation with required arguments only
=== STEP  testing maintenance_group_node creation with parent resource name acctest_niloj and resource name acctest_swtqo
=== PAUSE TestAccAciNodeBlockMG_Basic
=== RUN   TestAccAciNodeBlockMG_Update
=== STEP  testing maintenance_group_node creation with required arguments only
=== STEP  testing maintenance_group_node attribute: to_ = 16000
=== STEP  testing maintenance_group_node attribute: from_ = 16000
=== STEP  testing maintenance_group_node attribute: from_ = 7999
=== STEP  testing maintenance_group_node attribute: to_ = 7999
=== STEP  testing maintenance_group_node creation with required arguments only
=== PAUSE TestAccAciNodeBlockMG_Update
=== RUN   TestAccAciNodeBlockMG_Negative
=== STEP  testing maintenance_group_node creation with required arguments only
=== STEP  Negative Case: testing maintenance_group_node creation with invalid parent Dn
=== STEP  testing maintenance_group_node attribute: description = 40p83c8lnrseg70vrcwn1a2io9rxl9abvnuwhd6vxxw9skamv6oobkxa6jeb9d3ubmoou7bt9rgbliq0dc21k6fy4xmm4kkhuuxp7vdsebz7stg8t2erxo4zl16uhz4uh
=== STEP  testing maintenance_group_node attribute: annotation = izi3ssv34fi078pwbvpfaqr7oiszarvxt1kciximxc4ph4c60oe41r1031ns2lczxsmle9j2h0iomg2frhk27l7b8px1xvry3sgjyqenwq2bkfcc98iu70tu29m9syeul
=== STEP  testing maintenance_group_node attribute: name_alias = iulz3njo71hp61sf7khx2hrq0yrvz1ionitl86z8pndroigqxqdmvnqgdvktzwcy
=== STEP  testing maintenance_group_node attribute: from_ = l1izf
=== STEP  testing maintenance_group_node attribute: from_ = 0
=== STEP  testing maintenance_group_node attribute: from_ = 16001
=== STEP  testing maintenance_group_node attribute: to_ = l1izf
=== STEP  testing maintenance_group_node attribute: to_ = 0
=== STEP  testing maintenance_group_node attribute: to_ = 16001
=== STEP  testing maintenance_group_node attribute: mznfk = l1izf
=== STEP  testing maintenance_group_node creation with required arguments only
=== PAUSE TestAccAciNodeBlockMG_Negative
=== RUN   TestAccAciNodeBlockMG_MultipleCreateDelete
=== STEP  testing multiple maintenance_group_node creation with required arguments only
=== PAUSE TestAccAciNodeBlockMG_MultipleCreateDelete
=== CONT  TestAccAciNodeBlockMGDataSource_Basic
=== CONT  TestAccAciNodeBlockMG_Negative
=== CONT  TestAccAciNodeBlockMG_Update
=== CONT  TestAccAciNodeBlockMG_Basic
=== CONT  TestAccAciNodeBlockMG_MultipleCreateDelete
=== STEP  testing maintenance_group_node destroy
--- PASS: TestAccAciNodeBlockMG_MultipleCreateDelete (69.31s)
=== STEP  testing maintenance_group_node destroy
--- PASS: TestAccAciNodeBlockMGDataSource_Basic (162.08s)
=== STEP  testing maintenance_group_node destroy
--- PASS: TestAccAciNodeBlockMG_Update (262.75s)
=== STEP  testing maintenance_group_node destroy
--- PASS: TestAccAciNodeBlockMG_Basic (266.32s)
=== STEP  testing maintenance_group_node destroy
--- PASS: TestAccAciNodeBlockMG_Negative (268.56s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   271.758s
=== RUN   TestAccAciFabricNodeMemberDataSource_Basic
=== STEP  Basic: testing fabric_node_member Data Source without  serial
=== STEP  testing fabric_node_member Data Source with required arguments only
=== STEP  testing fabric_node_member Data Source with random attribute
=== STEP  testing fabric_node_member Data Source with required arguments only
=== STEP  testing fabric_node_member Data Source with updated resource
=== PAUSE TestAccAciFabricNodeMemberDataSource_Basic
=== RUN   TestAccAciFabricNodeMember_Basic
=== STEP  Basic: testing fabric_node_member creation without  serial
=== STEP  Basic: testing fabric_node_member creation without  name
=== STEP  testing fabric_node_member creation with required arguments and node_id
=== STEP  Basic: testing fabric_node_member creation with optional parameters
=== STEP  Basic: testing fabric_node_member updation without required parameters
=== STEP  testing fabric_node_member creation with serial acctest_mz4f9 and name 88s44i31s3ymbhi7ptktkzfzxnonakd4neevh7z93w2hjdhidmhrxetilr0jprtwm
=== STEP  testing fabric_node_member creation with serial acctest_mz4f9 and name acctest_3yqo4
=== PAUSE TestAccAciFabricNodeMember_Basic
=== RUN   TestAccAciFabricNodeMember_Update
=== STEP  testing fabric_node_member creation with required arguments and node_id
=== STEP  testing fabric_node_member attribute: ext_pool_id = 100
=== STEP  testing fabric_node_member attribute: fabric_id = 100
=== STEP  testing fabric_node_member attribute: node_type = remote-leaf-wan
=== STEP  testing fabric_node_member attribute: pod_id = 126
=== STEP  testing fabric_node_member attribute: pod_id = 254
=== STEP  testing fabric_node_member attribute: role = leaf
=== STEP  testing fabric_node_member attribute: role = spine
=== STEP  testing fabric_node_member creation with required arguments and node_id
=== PAUSE TestAccAciFabricNodeMember_Update
=== RUN   TestAccAciFabricNodeMember_Negative
=== STEP  testing fabric_node_member creation with required arguments and node_id
=== STEP  testing fabric_node_member attribute: description = cbrbnymluhe3siformg198xu4hajccv147z8qi2z4rx7tn4lh8i92o6npjtyo2ec2dizokyuv8isf7aph2xtpwdjqlk1sbi10w1k0pf6rg2edzykzwgb6fyvauoexd947
=== STEP  testing fabric_node_member attribute: annotation = dd3zdxwiglhbla9le6txt7m1t12zqwhuvl8irek1er4ugcgscs49m0dznds0pwpco2wfgjs33qm8t43xi22wk372yilclmou4qgz7yhqxfw4pzdrfyd7syori4sdllsyv
=== STEP  testing fabric_node_member attribute: name_alias = o7ue2dgwk2fr84x4ttnfqenv48lsjvcss4b3ff1l8xvasv16be4ypyyv84c2ug88
=== STEP  testing fabric_node_member attribute: ext_pool_id = zmtmw
=== STEP  testing fabric_node_member attribute: fabric_id = zmtmw
=== STEP  testing fabric_node_member attribute: node_type = zmtmw
=== STEP  testing fabric_node_member attribute: pod_id = zmtmw
=== STEP  testing fabric_node_member attribute: pod_id = 0
=== STEP  testing fabric_node_member attribute: pod_id = 255
=== STEP  testing fabric_node_member attribute: role = zmtmw
=== STEP  testing fabric_node_member attribute: node = 100
=== STEP  testing fabric_node_member attribute: node = 4001
=== STEP  testing fabric_node_member attribute: node = zmtmw
=== STEP  testing fabric_node_member attribute: qkchg = zmtmw
=== STEP  testing fabric_node_member creation with required arguments and node_id
=== PAUSE TestAccAciFabricNodeMember_Negative
=== CONT  TestAccAciFabricNodeMemberDataSource_Basic
=== CONT  TestAccAciFabricNodeMember_Update
=== CONT  TestAccAciFabricNodeMember_Basic
=== CONT  TestAccAciFabricNodeMember_Negative
=== STEP  testing fabric_node_member destroy
--- PASS: TestAccAciFabricNodeMemberDataSource_Basic (76.53s)
=== STEP  testing fabric_node_member destroy
--- PASS: TestAccAciFabricNodeMember_Basic (113.95s)
=== STEP  testing fabric_node_member destroy
--- PASS: TestAccAciFabricNodeMember_Negative (169.38s)
=== STEP  testing fabric_node_member destroy
--- PASS: TestAccAciFabricNodeMember_Update (197.69s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   200.149s
=== RUN   TestAccAciQOSInstancePolicyDataSource_Basic
=== STEP  testing qos_instance_policy Data Source with required arguments only
=== STEP  testing qos_instance_policy Data Source with random attribute
=== STEP  testing qos_instance_policy Data Source with updated resource
--- PASS: TestAccAciQOSInstancePolicyDataSource_Basic (61.68s)
=== RUN   TestAccAciQOSInstancePolicy_Basic
=== STEP  testing qos_instance_policy creation with required arguments only
=== STEP  Basic: testing qos_instance_policy creation with optional parameters
--- PASS: TestAccAciQOSInstancePolicy_Basic (41.66s)
=== RUN   TestAccAciQOSInstancePolicy_Update
=== STEP  testing qos_instance_policy creation with required arguments only
=== STEP  testing qos_instance_policy attribute: etrap_age_timer = 500
=== STEP  testing qos_instance_policy attribute: etrap_bw_thresh = 500
=== STEP  testing qos_instance_policy attribute: etrap_byte_ct = 500
=== STEP  testing qos_instance_policy attribute: etrap_st = no
=== STEP  testing qos_instance_policy attribute: fabric_flush_interval = 1000
=== STEP  testing qos_instance_policy attribute: fabric_flush_interval = 550
=== STEP  testing qos_instance_policy attribute: fabric_flush_st = no
=== STEP  testing qos_instance_policy attribute: uburst_spine_queues = 100
=== STEP  testing qos_instance_policy attribute: uburst_spine_queues = 50
=== STEP  testing qos_instance_policy attribute: uburst_tor_queues = 100
=== STEP  testing qos_instance_policy attribute: uburst_tor_queues = 50
=== STEP  testing qos_instance_policy attribute: ctrl = none
--- PASS: TestAccAciQOSInstancePolicy_Update (153.72s)
=== RUN   TestAccAciQOSInstancePolicy_Negative
=== STEP  testing qos_instance_policy creation with required arguments only
=== STEP  testing qos_instance_policy attribute: description = wtwarkvvm7acj1ck6uq7ame3ydv8j7n8gkl66b0i83bfmq64bucvssoxnba6lyk8398jvwvlbzd9vsw4tcbszgivp20kiwig7didufsuaxf2zpo0vbalc0d8mcn8vtidt
=== STEP  testing qos_instance_policy attribute: annotation = vo93w0t1tqxp9zhzi6l2arzxa819upbhvtjpg0trlt6ewy638dvrbikneh1vgys2fvwui27om4b0z3kvicfg3u48oox9rzbp1l4gaj9s43be7lkcu4v64xte6pwzh4jqb
=== STEP  testing qos_instance_policy attribute: name_alias = ksf96m03vyt1hbs649povtrl8fxmpn7ajgsg4bp2zdqqgx8peqjd9pl9ur20rdvg
=== STEP  testing qos_instance_policy attribute: etrap_age_timer = 8alqj
=== STEP  testing qos_instance_policy attribute: etrap_age_timer = -1
=== STEP  testing qos_instance_policy attribute: etrap_bw_thresh = 8alqj
=== STEP  testing qos_instance_policy attribute: etrap_bw_thresh = -1
=== STEP  testing qos_instance_policy attribute: etrap_byte_ct = 8alqj
=== STEP  testing qos_instance_policy attribute: etrap_byte_ct = -1
=== STEP  testing qos_instance_policy attribute: etrap_st = 8alqj
=== STEP  testing qos_instance_policy attribute: fabric_flush_interval = 8alqj
=== STEP  testing qos_instance_policy attribute: fabric_flush_interval = 99
=== STEP  testing qos_instance_policy attribute: fabric_flush_interval = 1001
=== STEP  testing qos_instance_policy attribute: fabric_flush_st = 8alqj
=== STEP  testing qos_instance_policy attribute: ctrl = 8alqj
=== STEP  testing qos_instance_policy attribute: uburst_spine_queues = 8alqj
=== STEP  testing qos_instance_policy attribute: uburst_spine_queues = -1
=== STEP  testing qos_instance_policy attribute: uburst_spine_queues = 101
=== STEP  testing qos_instance_policy attribute: uburst_tor_queues = 8alqj
=== STEP  testing qos_instance_policy attribute: uburst_tor_queues = -1
=== STEP  testing qos_instance_policy attribute: uburst_tor_queues = 101
=== STEP  testing qos_instance_policy attribute: atpzt = 8alqj
--- PASS: TestAccAciQOSInstancePolicy_Negative (109.16s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   368.909s
=== RUN   TestAccAciCloudContextProfileDataSource_Basic
=== STEP  Basic: testing cloud_context_profile Data Source without  tenant_dn
=== STEP  Basic: testing cloud_context_profile Data Source without  name
=== STEP  testing cloud_context_profile Data Source with required arguments only
=== STEP  testing cloud_context_profile Data Source with random attribute
=== STEP  testing cloud_context_profile Data Source with invalid name
=== STEP  testing cloud_context_profile Data Source with updated resource
=== PAUSE TestAccAciCloudContextProfileDataSource_Basic
=== RUN   TestAccAciCloudContextProfile_Basic
=== STEP  Basic: testing cloud_context_profile creation without  tenant_dn
=== STEP  Basic: testing cloud_context_profile creation without  name
=== STEP  Basic: testing cloud_context_profile creation without  primary_cidr
=== STEP  Basic: testing cloud_context_profile creation without  region
=== STEP  Basic: testing cloud_context_profile creation without  cloud_vendor
=== STEP  Basic: testing cloud_context_profile creation without relation_cloud_rs_to_ctx
=== STEP  testing cloud_context_profile creation with required arguments only
=== STEP  Basic: testing cloud_context_profile creation with optional parameters
=== STEP  testing cloud_context_profile creation with invalid name =  y7cy6bjlo4bqvxymnyg27etfqygfv7boogf38agrmf4szqdkzkj7qylt686z36pzv
=== STEP  testing cloud_context_profile creation with invalid primary_cidr
=== STEP  testing cloud_context_profile creation with invalid region
=== STEP  testing cloud_context_profile creation with invalid cloud_vendor
=== STEP  Basic: testing cloud_context_profile updation without required parameters
=== STEP  testing cloud_context_profile creation with parent resource name acctest_uyfom, resource name acctest_snbiw and cidr 30.2.243.201/16
=== STEP  testing cloud_context_profile creation with required arguments only
=== STEP  testing cloud_context_profile creation with parent resource name acctest_snbiw, resource name acctest_uyfom and cidr 30.2.243.201/16
=== PAUSE TestAccAciCloudContextProfile_Basic
=== RUN   TestAccAciCloudContextProfile_Update
=== STEP  testing cloud_context_profile creation with required arguments only
=== STEP  testing cloud_context_profile attribute: type = hosted
=== STEP  testing cloud_context_profile attribute: type = container-overlay
=== STEP  testing cloud_context_profile creation with required arguments only
=== PAUSE TestAccAciCloudContextProfile_Update
=== RUN   TestAccAciCloudContextProfile_Negative
=== STEP  testing cloud_context_profile creation with required arguments only
=== STEP  Negative Case: testing cloud_context_profile creation with invalid parent Dn
=== STEP  testing cloud_context_profile attribute: description = aivmma1p8eaf4cu1mcm0kzvxplxwdg96z271ghsce6rp7sj31bpeu8hjokxtej89kmr7l1sa4qv3ghviwagpxix2u66wuc3xmodgs2t0g4xzqdjcs894repn2m8mp6xpx
=== STEP  testing cloud_context_profile attribute: annotation = 962trnbr4vuzoiikpdxb96q80pwkgihp7czr3d1nbowwgmdwsu6cd1vemoneb7zuchlj0xmbgeo1q6hazdvokke7rjy7tel06rihmnbqc3rqaizz6va7y4fzw6n71leuu
=== STEP  testing cloud_context_profile attribute: name_alias = 3hvxttnlgz76q63rfwk0zfy1dmrudbk4lu4udw4pqgqvd9hyw3ys1elvjs7fagnc
=== STEP  testing cloud_context_profile attribute: type = s2zon
=== STEP  testing cloud_context_profile attribute: hub_network = s2zon
=== STEP  testing cloud_context_profile attribute: querg = s2zon
=== STEP  testing cloud_context_profile creation with required arguments only
=== PAUSE TestAccAciCloudContextProfile_Negative
=== CONT  TestAccAciCloudContextProfileDataSource_Basic
=== CONT  TestAccAciCloudContextProfile_Update
=== CONT  TestAccAciCloudContextProfile_Negative
=== CONT  TestAccAciCloudContextProfile_Basic
=== STEP  testing cloud_context_profile destroy
--- PASS: TestAccAciCloudContextProfileDataSource_Basic (76.95s)
=== STEP  testing cloud_context_profile destroy
--- PASS: TestAccAciCloudContextProfile_Update (105.45s)
=== STEP  testing cloud_context_profile destroy
--- PASS: TestAccAciCloudContextProfile_Negative (116.06s)
=== STEP  testing cloud_context_profile destroy
--- PASS: TestAccAciCloudContextProfile_Basic (196.76s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   199.395s
=== RUN   TestAccAciLDAPProvider_Update
=== STEP  testing ldap_provider creation with required arguments only
=== STEP  testing ldap_provider attribute: port = 65535
=== STEP  testing ldap_provider attribute: port = 32767
=== STEP  testing ldap_provider attribute: retries = 2
=== STEP  testing ldap_provider attribute: timeout = 5
=== STEP  testing ldap_provider attribute: timeout = 18
=== STEP  testing ldap_provider creation with required arguments only
=== PAUSE TestAccAciLDAPProvider_Update
=== CONT  TestAccAciLDAPProvider_Update
=== STEP  testing ldap_provider destroy
--- PASS: TestAccAciLDAPProvider_Update (90.83s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   92.329s