### PR TITLE
added test files for 02-02-22

### DIFF
--- a/testacc/data_source_aci_configexportp_test.go
+++ b/testacc/data_source_aci_configexportp_test.go
@@ -1,0 +1,161 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciConfigurationExportPolicyDataSource_Basic(t *testing.T) {
+	resourceName := "aci_configuration_export_policy.test"
+	dataSourceName := "data.aci_configuration_export_policy.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciConfigurationExportPolicyDestroy,
+		Steps: []resource.TestStep{
+			
+			{
+				Config:      CreateConfigurationExportPolicyDSWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccConfigurationExportPolicyConfigDataSource(rName),
+				Check: resource.ComposeTestCheckFunc(
+					
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "admin_st", resourceName, "admin_st"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "format", resourceName, "format"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "include_secure_fields", resourceName, "include_secure_fields"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "max_snapshot_count", resourceName, "max_snapshot_count"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "snapshot", resourceName, "snapshot"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "target_dn", resourceName, "target_dn"),
+					
+				),
+			},
+			{
+				Config:      CreateAccConfigurationExportPolicyDataSourceUpdate(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			
+			{
+				Config:      CreateAccConfigurationExportPolicyDSWithInvalidName(rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccConfigurationExportPolicyDataSourceUpdatedResource(rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+
+func CreateAccConfigurationExportPolicyConfigDataSource(rName string) string {
+	fmt.Println("=== STEP  testing configuration_export_policy Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_configuration_export_policy" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_configuration_export_policy" "test" {
+	
+		name  = aci_configuration_export_policy.test.name
+		depends_on = [ aci_configuration_export_policy.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateConfigurationExportPolicyDSWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing configuration_export_policy Data Source without ",attrName)
+	rBlock := `
+	
+	resource "aci_configuration_export_policy" "test" {
+	
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_configuration_export_policy" "test" {
+	
+	#	name  = aci_configuration_export_policy.test.name
+		depends_on = [ aci_configuration_export_policy.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock,rName)
+}
+
+
+func CreateAccConfigurationExportPolicyDSWithInvalidName(rName string) string {
+	fmt.Println("=== STEP  testing configuration_export_policy Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_configuration_export_policy" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_configuration_export_policy" "test" {
+	
+		name  = "${aci_configuration_export_policy.test.name}_invalid"
+		depends_on = [ aci_configuration_export_policy.test ]
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccConfigurationExportPolicyDataSourceUpdate(rName, key, value string) string {
+	fmt.Println("=== STEP  testing configuration_export_policy Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_configuration_export_policy" "test" {
+	
+		name  = "%s"
+	}
+
+	data "aci_configuration_export_policy" "test" {
+	
+		name  = aci_configuration_export_policy.test.name
+		%s = "%s"
+		depends_on = [ aci_configuration_export_policy.test ]
+	}
+	`, rName,key,value)
+	return resource
+}
+
+func CreateAccConfigurationExportPolicyDataSourceUpdatedResource(rName, key, value string) string {
+	fmt.Println("=== STEP  testing configuration_export_policy Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_configuration_export_policy" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_configuration_export_policy" "test" {
+	
+		name  = aci_configuration_export_policy.test.name
+		depends_on = [ aci_configuration_export_policy.test ]
+	}
+	`, rName,key,value)
+	return resource
+}

--- a/testacc/data_source_aci_spanspanlbl_test.go
+++ b/testacc/data_source_aci_spanspanlbl_test.go
@@ -1,0 +1,219 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciSPANSourcedestinationGroupMatchLabelDataSource_Basic(t *testing.T) {
+	resourceName := "aci_span_sourcedestination_group_match_label.test"
+	dataSourceName := "data.aci_span_sourcedestination_group_match_label.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	spanSrcGrpName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:	  func(){ testAccPreCheck(t) },
+		ProviderFactories:    testAccProviders,
+		CheckDestroy: testAccCheckAciSPANSourcedestinationGroupMatchLabelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateSPANSourcedestinationGroupMatchLabelDSWithoutRequired(fvTenantName, spanSrcGrpName, rName,"span_source_group_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateSPANSourcedestinationGroupMatchLabelDSWithoutRequired(fvTenantName, spanSrcGrpName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccSPANSourcedestinationGroupMatchLabelConfigDataSource(fvTenantName, spanSrcGrpName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "span_source_group_dn", resourceName, "span_source_group_dn",),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "tag", resourceName, "tag"),
+					
+				),
+			},
+			{
+				Config:      CreateAccSPANSourcedestinationGroupMatchLabelDataSourceUpdate(fvTenantName, spanSrcGrpName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			
+			{
+				Config:      CreateAccSPANSourcedestinationGroupMatchLabelDSWithInvalidParentDn(fvTenantName, spanSrcGrpName, rName),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			
+			{
+				Config: CreateAccSPANSourcedestinationGroupMatchLabelDataSourceUpdatedResource(fvTenantName, spanSrcGrpName, rName, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+
+func CreateAccSPANSourcedestinationGroupMatchLabelConfigDataSource(fvTenantName, spanSrcGrpName, rName string) string {
+	fmt.Println("=== STEP  testing span_sourcedestination_group_match_label Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = aci_span_source_group.test.id
+		name  = "%s"
+	}
+
+	data "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = aci_span_source_group.test.id
+		name  = aci_span_sourcedestination_group_match_label.test.name
+		depends_on = [ aci_span_sourcedestination_group_match_label.test ]
+	}
+	`, fvTenantName, spanSrcGrpName, rName)
+	return resource
+}
+
+func CreateSPANSourcedestinationGroupMatchLabelDSWithoutRequired(fvTenantName, spanSrcGrpName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing span_sourcedestination_group_match_label Data Source without ",attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = aci_span_source_group.test.id
+		name  = "%s"
+	}
+	`
+	switch attrName {
+	case "span_source_group_dn":
+		rBlock += `
+	data "aci_span_sourcedestination_group_match_label" "test" {
+	#	span_source_group_dn  = aci_span_source_group.test.id
+		name  = aci_span_sourcedestination_group_match_label.test.name
+		depends_on = [ aci_span_sourcedestination_group_match_label.test ]
+	}
+		`
+	case "name":
+		rBlock += `
+	data "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = aci_span_source_group.test.id
+	#	name  = aci_span_sourcedestination_group_match_label.test.name
+		depends_on = [ aci_span_sourcedestination_group_match_label.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock,fvTenantName, spanSrcGrpName, rName)
+}
+
+func CreateAccSPANSourcedestinationGroupMatchLabelDSWithInvalidParentDn(fvTenantName, spanSrcGrpName, rName string) string {
+	fmt.Println("=== STEP  testing span_sourcedestination_group_match_label Data Source with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = aci_span_source_group.test.id
+		name  = "%s"
+	}
+
+	data "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = aci_span_source_group.test.id
+		name  = "${aci_span_sourcedestination_group_match_label.test.name}_invalid"
+		depends_on = [ aci_span_sourcedestination_group_match_label.test ]
+	}
+	`, fvTenantName, spanSrcGrpName, rName)
+	return resource
+}
+
+func CreateAccSPANSourcedestinationGroupMatchLabelDataSourceUpdate(fvTenantName, spanSrcGrpName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing span_sourcedestination_group_match_label Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = aci_span_source_group.test.id
+		name  = "%s"
+	}
+
+	data "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = aci_span_source_group.test.id
+		name  = aci_span_sourcedestination_group_match_label.test.name
+		%s = "%s"
+		depends_on = [ aci_span_sourcedestination_group_match_label.test ]
+	}
+	`, fvTenantName, spanSrcGrpName, rName,key,value)
+	return resource
+}
+
+func CreateAccSPANSourcedestinationGroupMatchLabelDataSourceUpdatedResource(fvTenantName, spanSrcGrpName, rName, key, value string) string {
+	fmt.Println("=== STEP  testing span_sourcedestination_group_match_label Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = aci_span_source_group.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+
+	data "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = aci_span_source_group.test.id
+		name  = aci_span_sourcedestination_group_match_label.test.name
+		depends_on = [ aci_span_sourcedestination_group_match_label.test ]
+	}
+	`, fvTenantName, spanSrcGrpName, rName,key,value)
+	return resource
+}

--- a/testacc/resource_aci_configexportp_test.go
+++ b/testacc/resource_aci_configexportp_test.go
@@ -1,0 +1,427 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciConfigurationExportPolicy_Basic(t *testing.T) {
+	var configuration_export_policy_default models.ConfigurationExportPolicy
+	var configuration_export_policy_updated models.ConfigurationExportPolicy
+	resourceName := "aci_configuration_export_policy.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciConfigurationExportPolicyDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateConfigurationExportPolicyWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccConfigurationExportPolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciConfigurationExportPolicyExists(resourceName, &configuration_export_policy_default),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "format", "json"),
+					resource.TestCheckResourceAttr(resourceName, "include_secure_fields", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "max_snapshot_count", "global-limit"),
+					resource.TestCheckResourceAttr(resourceName, "snapshot", "no"),
+					resource.TestCheckResourceAttr(resourceName, "target_dn", ""),
+				),
+			},
+			{
+				Config: CreateAccConfigurationExportPolicyConfigWithOptionalValues(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciConfigurationExportPolicyExists(resourceName, &configuration_export_policy_updated),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_configuration_export_policy"),
+					resource.TestCheckResourceAttr(resourceName, "admin_st", "triggered"),
+					resource.TestCheckResourceAttr(resourceName, "format", "xml"),
+					resource.TestCheckResourceAttr(resourceName, "include_secure_fields", "no"),
+					resource.TestCheckResourceAttr(resourceName, "max_snapshot_count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "snapshot", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "target_dn", fmt.Sprintf("uni/tn-%s", rName)),
+					testAccCheckAciConfigurationExportPolicyIdEqual(&configuration_export_policy_default, &configuration_export_policy_updated),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"admin_st"},
+			},
+			{
+				Config:      CreateAccConfigurationExportPolicyConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccConfigurationExportPolicyRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+
+			{
+				Config: CreateAccConfigurationExportPolicyConfigWithRequiredParams(rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciConfigurationExportPolicyExists(resourceName, &configuration_export_policy_updated),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciConfigurationExportPolicyIdNotEqual(&configuration_export_policy_default, &configuration_export_policy_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciConfigurationExportPolicy_Update(t *testing.T) {
+	var configuration_export_policy_default models.ConfigurationExportPolicy
+	var configuration_export_policy_updated models.ConfigurationExportPolicy
+	resourceName := "aci_configuration_export_policy.test"
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciConfigurationExportPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccConfigurationExportPolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciConfigurationExportPolicyExists(resourceName, &configuration_export_policy_default),
+				),
+			},
+			{
+				Config: CreateAccConfigurationExportPolicyUpdatedAttr(rName, "max_snapshot_count", "10"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciConfigurationExportPolicyExists(resourceName, &configuration_export_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "max_snapshot_count", "10"),
+					testAccCheckAciConfigurationExportPolicyIdEqual(&configuration_export_policy_default, &configuration_export_policy_updated),
+				),
+			},
+			{
+				Config: CreateAccConfigurationExportPolicyUpdatedAttr(rName, "max_snapshot_count", "5"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciConfigurationExportPolicyExists(resourceName, &configuration_export_policy_updated),
+					resource.TestCheckResourceAttr(resourceName, "max_snapshot_count", "5"),
+					testAccCheckAciConfigurationExportPolicyIdEqual(&configuration_export_policy_default, &configuration_export_policy_updated),
+				),
+			},
+
+			{
+				Config: CreateAccConfigurationExportPolicyConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciConfigurationExportPolicy_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciConfigurationExportPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccConfigurationExportPolicyConfig(rName),
+			},
+
+			{
+				Config:      CreateAccConfigurationExportPolicyUpdatedAttr(rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccConfigurationExportPolicyUpdatedAttr(rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccConfigurationExportPolicyUpdatedAttr(rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccConfigurationExportPolicyUpdatedAttr(rName, "admin_st", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccConfigurationExportPolicyUpdatedAttr(rName, "format", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccConfigurationExportPolicyUpdatedAttr(rName, "include_secure_fields", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccConfigurationExportPolicyUpdatedAttr(rName, "max_snapshot_count", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccConfigurationExportPolicyUpdatedAttr(rName, "max_snapshot_count", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccConfigurationExportPolicyUpdatedAttr(rName, "max_snapshot_count", "11"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccConfigurationExportPolicyUpdatedAttr(rName, "snapshot", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccConfigurationExportPolicyUpdatedAttr(rName, "target_dn", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccConfigurationExportPolicyUpdatedAttr(rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccConfigurationExportPolicyConfig(rName),
+			},
+		},
+	})
+}
+
+func TestAccAciConfigurationExportPolicy_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciConfigurationExportPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccConfigurationExportPolicyConfigMultiple(rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciConfigurationExportPolicyExists(name string, configuration_export_policy *models.ConfigurationExportPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("ConfigurationExportPolicy %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ConfigurationExportPolicy dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		configuration_export_policyFound := models.ConfigurationExportPolicyFromContainer(cont)
+		if configuration_export_policyFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("ConfigurationExportPolicy %s not found", rs.Primary.ID)
+		}
+		*configuration_export_policy = *configuration_export_policyFound
+		return nil
+	}
+}
+
+func testAccCheckAciConfigurationExportPolicyDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing configuration_export_policy destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_configuration_export_policy" {
+			cont, err := client.Get(rs.Primary.ID)
+			configuration_export_policy := models.ConfigurationExportPolicyFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("ConfigurationExportPolicy %s Still exists", configuration_export_policy.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciConfigurationExportPolicyIdEqual(m1, m2 *models.ConfigurationExportPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("configuration_export_policy DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciConfigurationExportPolicyIdNotEqual(m1, m2 *models.ConfigurationExportPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("configuration_export_policy DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateConfigurationExportPolicyWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing configuration_export_policy creation without ", attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_configuration_export_policy" "test" {
+	
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccConfigurationExportPolicyConfigWithRequiredParams(rName string) string {
+	fmt.Println("=== STEP  testing configuration_export_policy creation with updated name =", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_configuration_export_policy" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+func CreateAccConfigurationExportPolicyConfigUpdatedName(rName string) string {
+	fmt.Println("=== STEP  testing configuration_export_policy creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_configuration_export_policy" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccConfigurationExportPolicyConfig(rName string) string {
+	fmt.Println("=== STEP  testing configuration_export_policy creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_configuration_export_policy" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccConfigurationExportPolicyConfigMultiple(rName string) string {
+	fmt.Println("=== STEP  testing multiple configuration_export_policy creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_configuration_export_policy" "test" {
+	
+		name  = "%s_${count.index}"
+		count = 5
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccConfigurationExportPolicyConfigWithOptionalValues(rName string) string {
+	fmt.Println("=== STEP  Basic: testing configuration_export_policy creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_configuration_export_policy" "test" {
+	
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_configuration_export_policy"
+		admin_st = "triggered"
+		format = "xml"
+		include_secure_fields = "no"
+		max_snapshot_count = "1"
+		snapshot = "yes"
+		target_dn = aci_tenant.test.id
+		
+	}
+
+	resource "aci_tenant" "test" {
+		name = "%s"
+	}
+	`, rName, rName)
+
+	return resource
+}
+
+func CreateAccConfigurationExportPolicyRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing configuration_export_policy updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_configuration_export_policy" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_configuration_export_policy"
+		admin_st = "triggered"
+		format = "xml"
+		include_secure_fields = "no"
+		max_snapshot_count = "1"
+		snapshot = "yes"
+		target_dn = ""
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccConfigurationExportPolicyUpdatedAttr(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing configuration_export_policy attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_configuration_export_policy" "test" {
+	
+		name  = "%s"
+		%s = "%s"
+	}
+	`, rName, attribute, value)
+	return resource
+}
+
+func CreateAccConfigurationExportPolicyUpdatedAttrList(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing configuration_export_policy attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_configuration_export_policy" "test" {
+	
+		name  = "%s"
+		%s = %s
+	}
+	`, rName, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_spanspanlbl_test.go
+++ b/testacc/resource_aci_spanspanlbl_test.go
@@ -1,0 +1,492 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciSPANSourcedestinationGroupMatchLabel_Basic(t *testing.T) {
+	var span_sourcedestination_group_match_label_default models.SPANSourcedestinationGroupMatchLabel
+	var span_sourcedestination_group_match_label_updated models.SPANSourcedestinationGroupMatchLabel
+	resourceName := "aci_span_sourcedestination_group_match_label.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	spanSrcGrpName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSPANSourcedestinationGroupMatchLabelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateSPANSourcedestinationGroupMatchLabelWithoutRequired(fvTenantName, spanSrcGrpName, rName, "span_source_group_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateSPANSourcedestinationGroupMatchLabelWithoutRequired(fvTenantName, spanSrcGrpName, rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccSPANSourcedestinationGroupMatchLabelConfig(fvTenantName, spanSrcGrpName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelExists(resourceName, &span_sourcedestination_group_match_label_default),
+					resource.TestCheckResourceAttr(resourceName, "span_source_group_dn", fmt.Sprintf("uni/tn-%s/srcgrp-%s", fvTenantName, spanSrcGrpName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "tag"),
+				),
+			},
+			{
+				Config: CreateAccSPANSourcedestinationGroupMatchLabelConfigWithOptionalValues(fvTenantName, spanSrcGrpName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelExists(resourceName, &span_sourcedestination_group_match_label_updated),
+					resource.TestCheckResourceAttr(resourceName, "span_source_group_dn", fmt.Sprintf("uni/tn-%s/srcgrp-%s", fvTenantName, spanSrcGrpName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_span_sourcedestination_group_match_label"),
+					resource.TestCheckResourceAttr(resourceName, "tag", "blue"),
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelIdEqual(&span_sourcedestination_group_match_label_default, &span_sourcedestination_group_match_label_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config:      CreateAccSPANSourcedestinationGroupMatchLabelConfigUpdatedName(fvTenantName, spanSrcGrpName, acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccSPANSourcedestinationGroupMatchLabelRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccSPANSourcedestinationGroupMatchLabelConfigWithRequiredParams(rNameUpdated, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelExists(resourceName, &span_sourcedestination_group_match_label_updated),
+					resource.TestCheckResourceAttr(resourceName, "span_source_group_dn", fmt.Sprintf("uni/tn-%s/srcgrp-%s", rNameUpdated, rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelIdNotEqual(&span_sourcedestination_group_match_label_default, &span_sourcedestination_group_match_label_updated),
+				),
+			},
+			{
+				Config: CreateAccSPANSourcedestinationGroupMatchLabelConfig(fvTenantName, spanSrcGrpName, rName),
+			},
+			{
+				Config: CreateAccSPANSourcedestinationGroupMatchLabelConfigWithRequiredParams(rName, rNameUpdated),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelExists(resourceName, &span_sourcedestination_group_match_label_updated),
+					resource.TestCheckResourceAttr(resourceName, "span_source_group_dn", fmt.Sprintf("uni/tn-%s/srcgrp-%s", rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelIdNotEqual(&span_sourcedestination_group_match_label_default, &span_sourcedestination_group_match_label_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciSPANSourcedestinationGroupMatchLabel_Update(t *testing.T) {
+	var span_sourcedestination_group_match_label_default models.SPANSourcedestinationGroupMatchLabel
+	var span_sourcedestination_group_match_label_updated models.SPANSourcedestinationGroupMatchLabel
+	resourceName := "aci_span_sourcedestination_group_match_label.test"
+	rName := makeTestVariable(acctest.RandString(5))
+
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	spanSrcGrpName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSPANSourcedestinationGroupMatchLabelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccSPANSourcedestinationGroupMatchLabelConfig(fvTenantName, spanSrcGrpName, rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelExists(resourceName, &span_sourcedestination_group_match_label_default),
+				),
+			},
+
+			{
+				Config: CreateAccSPANSourcedestinationGroupMatchLabelUpdatedAttr(fvTenantName, spanSrcGrpName, rName, "tag", "black"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelExists(resourceName, &span_sourcedestination_group_match_label_updated),
+					resource.TestCheckResourceAttr(resourceName, "tag", "black"),
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelIdEqual(&span_sourcedestination_group_match_label_default, &span_sourcedestination_group_match_label_updated),
+				),
+			},
+
+			{
+				Config: CreateAccSPANSourcedestinationGroupMatchLabelUpdatedAttr(fvTenantName, spanSrcGrpName, rName, "tag", "gray"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelExists(resourceName, &span_sourcedestination_group_match_label_updated),
+					resource.TestCheckResourceAttr(resourceName, "tag", "gray"),
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelIdEqual(&span_sourcedestination_group_match_label_default, &span_sourcedestination_group_match_label_updated),
+				),
+			},
+			{
+				Config: CreateAccSPANSourcedestinationGroupMatchLabelUpdatedAttr(fvTenantName, spanSrcGrpName, rName, "tag", "green"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelExists(resourceName, &span_sourcedestination_group_match_label_updated),
+					resource.TestCheckResourceAttr(resourceName, "tag", "green"),
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelIdEqual(&span_sourcedestination_group_match_label_default, &span_sourcedestination_group_match_label_updated),
+				),
+			},
+
+			{
+				Config: CreateAccSPANSourcedestinationGroupMatchLabelUpdatedAttr(fvTenantName, spanSrcGrpName, rName, "tag", "red"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelExists(resourceName, &span_sourcedestination_group_match_label_updated),
+					resource.TestCheckResourceAttr(resourceName, "tag", "red"),
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelIdEqual(&span_sourcedestination_group_match_label_default, &span_sourcedestination_group_match_label_updated),
+				),
+			},
+			{
+				Config: CreateAccSPANSourcedestinationGroupMatchLabelUpdatedAttr(fvTenantName, spanSrcGrpName, rName, "tag", "white"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelExists(resourceName, &span_sourcedestination_group_match_label_updated),
+					resource.TestCheckResourceAttr(resourceName, "tag", "white"),
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelIdEqual(&span_sourcedestination_group_match_label_default, &span_sourcedestination_group_match_label_updated),
+				),
+			},
+
+			{
+				Config: CreateAccSPANSourcedestinationGroupMatchLabelUpdatedAttr(fvTenantName, spanSrcGrpName, rName, "tag", "yellow"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelExists(resourceName, &span_sourcedestination_group_match_label_updated),
+					resource.TestCheckResourceAttr(resourceName, "tag", "yellow"),
+					testAccCheckAciSPANSourcedestinationGroupMatchLabelIdEqual(&span_sourcedestination_group_match_label_default, &span_sourcedestination_group_match_label_updated),
+				),
+			},
+
+			{
+				Config: CreateAccSPANSourcedestinationGroupMatchLabelConfig(fvTenantName, spanSrcGrpName, rName),
+			},
+		},
+	})
+}
+
+func TestAccAciSPANSourcedestinationGroupMatchLabel_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	spanSrcGrpName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciSPANSourcedestinationGroupMatchLabelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccSPANSourcedestinationGroupMatchLabelConfig(fvTenantName, spanSrcGrpName, rName),
+			},
+			{
+				Config:      CreateAccSPANSourcedestinationGroupMatchLabelWithInValidParentDn(rName),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccSPANSourcedestinationGroupMatchLabelUpdatedAttr(fvTenantName, spanSrcGrpName, rName, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccSPANSourcedestinationGroupMatchLabelUpdatedAttr(fvTenantName, spanSrcGrpName, rName, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccSPANSourcedestinationGroupMatchLabelUpdatedAttr(fvTenantName, spanSrcGrpName, rName, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccSPANSourcedestinationGroupMatchLabelUpdatedAttr(fvTenantName, spanSrcGrpName, rName, "tag", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccSPANSourcedestinationGroupMatchLabelUpdatedAttr(fvTenantName, spanSrcGrpName, rName, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccSPANSourcedestinationGroupMatchLabelConfig(fvTenantName, spanSrcGrpName, rName),
+			},
+		},
+	})
+}
+
+func testAccCheckAciSPANSourcedestinationGroupMatchLabelExists(name string, span_sourcedestination_group_match_label *models.SPANSourcedestinationGroupMatchLabel) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("SPANSourcedestinationGroupMatchLabel %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No SPANSourcedestinationGroupMatchLabel dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		span_sourcedestination_group_match_labelFound := models.SPANSourcedestinationGroupMatchLabelFromContainer(cont)
+		if span_sourcedestination_group_match_labelFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("SPANSourcedestinationGroupMatchLabel %s not found", rs.Primary.ID)
+		}
+		*span_sourcedestination_group_match_label = *span_sourcedestination_group_match_labelFound
+		return nil
+	}
+}
+
+func testAccCheckAciSPANSourcedestinationGroupMatchLabelDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing span_sourcedestination_group_match_label destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_span_sourcedestination_group_match_label" {
+			cont, err := client.Get(rs.Primary.ID)
+			span_sourcedestination_group_match_label := models.SPANSourcedestinationGroupMatchLabelFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("SPANSourcedestinationGroupMatchLabel %s Still exists", span_sourcedestination_group_match_label.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciSPANSourcedestinationGroupMatchLabelIdEqual(m1, m2 *models.SPANSourcedestinationGroupMatchLabel) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("span_sourcedestination_group_match_label DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciSPANSourcedestinationGroupMatchLabelIdNotEqual(m1, m2 *models.SPANSourcedestinationGroupMatchLabel) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("span_sourcedestination_group_match_label DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateSPANSourcedestinationGroupMatchLabelWithoutRequired(fvTenantName, spanSrcGrpName, rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing span_sourcedestination_group_match_label creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		
+	}
+	
+	resource "aci_span_source_group" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	`
+	switch attrName {
+	case "span_source_group_dn":
+		rBlock += `
+	resource "aci_span_sourcedestination_group_match_label" "test" {
+	#	span_source_group_dn  = aci_span_source_group.test.id
+		name  = "%s"
+	}
+		`
+	case "name":
+		rBlock += `
+	resource "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = aci_span_source_group.test.id
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, spanSrcGrpName, rName)
+}
+
+func CreateAccSPANSourcedestinationGroupMatchLabelConfigWithRequiredParams(prName, rName string) string {
+	fmt.Printf("=== STEP  testing span_sourcedestination_group_match_label creation with parent resource name %s and resource name %s\n", prName, rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = aci_span_source_group.test.id
+		name  = "%s"
+	}
+	`, prName, prName, rName)
+	return resource
+}
+func CreateAccSPANSourcedestinationGroupMatchLabelConfigUpdatedName(fvTenantName, spanSrcGrpName, rName string) string {
+	fmt.Println("=== STEP  testing span_sourcedestination_group_match_label creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = aci_span_source_group.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, spanSrcGrpName, rName)
+	return resource
+}
+
+func CreateAccSPANSourcedestinationGroupMatchLabelConfig(fvTenantName, spanSrcGrpName, rName string) string {
+	fmt.Println("=== STEP  testing span_sourcedestination_group_match_label creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = aci_span_source_group.test.id
+		name  = "%s"
+	}
+	`, fvTenantName, spanSrcGrpName, rName)
+	return resource
+}
+
+func CreateAccSPANSourcedestinationGroupMatchLabelWithInValidParentDn(rName string) string {
+	fmt.Println("=== STEP  Negative Case: testing span_sourcedestination_group_match_label creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = aci_tenant.test.id
+		name  = "%s"	
+	}
+	`, rName, rName)
+	return resource
+}
+
+func CreateAccSPANSourcedestinationGroupMatchLabelConfigWithOptionalValues(fvTenantName, spanSrcGrpName, rName string) string {
+	fmt.Println("=== STEP  Basic: testing span_sourcedestination_group_match_label creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = "${aci_span_source_group.test.id}"
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_span_sourcedestination_group_match_label"
+		tag = "blue"
+		
+	}
+	`, fvTenantName, spanSrcGrpName, rName)
+
+	return resource
+}
+
+func CreateAccSPANSourcedestinationGroupMatchLabelRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing span_sourcedestination_group_match_label updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_span_sourcedestination_group_match_label" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_span_sourcedestination_group_match_label"
+		tag = "alice-blue"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccSPANSourcedestinationGroupMatchLabelUpdatedAttr(fvTenantName, spanSrcGrpName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing span_sourcedestination_group_match_label attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = aci_span_source_group.test.id
+		name  = "%s"
+		%s = "%s"
+	}
+	`, fvTenantName, spanSrcGrpName, rName, attribute, value)
+	return resource
+}
+
+func CreateAccSPANSourcedestinationGroupMatchLabelUpdatedAttrList(fvTenantName, spanSrcGrpName, rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing span_sourcedestination_group_match_label attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_span_source_group" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_span_sourcedestination_group_match_label" "test" {
+		span_source_group_dn  = aci_span_source_group.test.id
+		name  = "%s"
+		%s = %s
+	}
+	`, fvTenantName, spanSrcGrpName, rName, attribute, value)
+	return resource
+}


### PR DESCRIPTION
=== RUN   TestAccAciSPANSourcedestinationGroupMatchLabelDataSource_Basic
=== STEP  Basic: testing span_sourcedestination_group_match_label Data Source without  span_source_group_dn
=== STEP  Basic: testing span_sourcedestination_group_match_label Data Source without  name
=== STEP  testing span_sourcedestination_group_match_label Data Source with required arguments only
=== STEP  testing span_sourcedestination_group_match_label Data Source with random attribute
=== STEP  testing span_sourcedestination_group_match_label Data Source with Invalid Parent Dn
=== STEP  testing span_sourcedestination_group_match_label Data Source with updated resource
=== PAUSE TestAccAciSPANSourcedestinationGroupMatchLabelDataSource_Basic
=== RUN   TestAccAciSPANSourcedestinationGroupMatchLabel_Basic
=== STEP  Basic: testing span_sourcedestination_group_match_label creation without  span_source_group_dn
=== STEP  Basic: testing span_sourcedestination_group_match_label creation without  name
=== STEP  testing span_sourcedestination_group_match_label creation with required arguments only
=== STEP  Basic: testing span_sourcedestination_group_match_label creation with optional parameters
=== STEP  testing span_sourcedestination_group_match_label creation with invalid name =  dpwuyjt8ejnn4s8ip8sptw79oshhev2v9611s0zejxocu73zxx2u7blm3stphjyc1
=== STEP  Basic: testing span_sourcedestination_group_match_label updation without required parameters
=== STEP  testing span_sourcedestination_group_match_label creation with parent resource name acctest_kuqd8 and resource name acctest_kps8e
=== STEP  testing span_sourcedestination_group_match_label creation with required arguments only
=== STEP  testing span_sourcedestination_group_match_label creation with parent resource name acctest_kps8e and resource name acctest_kuqd8
=== PAUSE TestAccAciSPANSourcedestinationGroupMatchLabel_Basic
=== RUN   TestAccAciSPANSourcedestinationGroupMatchLabel_Update
=== STEP  testing span_sourcedestination_group_match_label creation with required arguments only
=== STEP  testing span_sourcedestination_group_match_label attribute: tag = black
=== STEP  testing span_sourcedestination_group_match_label attribute: tag = gray
=== STEP  testing span_sourcedestination_group_match_label attribute: tag = green
=== STEP  testing span_sourcedestination_group_match_label attribute: tag = red
=== STEP  testing span_sourcedestination_group_match_label attribute: tag = white
=== STEP  testing span_sourcedestination_group_match_label attribute: tag = yellow
=== STEP  testing span_sourcedestination_group_match_label creation with required arguments only
=== PAUSE TestAccAciSPANSourcedestinationGroupMatchLabel_Update
=== RUN   TestAccAciSPANSourcedestinationGroupMatchLabel_Negative
=== STEP  testing span_sourcedestination_group_match_label creation with required arguments only
=== STEP  Negative Case: testing span_sourcedestination_group_match_label creation with invalid parent Dn
=== STEP  testing span_sourcedestination_group_match_label attribute: description = bhqvd2e14b2ny0dh6nf4x7n47vlp2t4p9ky8ire31e803ky4n3otw0bx4soca2eirr28x6ynj78cgfvxiuzagrl6ll8j26f0rygltjj9pnwo0qjy0m3rj2orezxop1ets
=== STEP  testing span_sourcedestination_group_match_label attribute: annotation = ttmyk6vflw4vy42xiuljaa2z037vtlaszozii0n91dif2ny77tk1g4uejco76nn7hxr7aptaccj4srtmact4mlms28sbmk42vpseifyhbifn9kycg711fon4pkkwi1y2a
=== STEP  testing span_sourcedestination_group_match_label attribute: name_alias = 1n2dcvrmqa2pd93hfuho7dnwsb67x37ez67o111x93ry488xcrabveg7trq7ttai
=== STEP  testing span_sourcedestination_group_match_label attribute: tag = b1mgl
=== STEP  testing span_sourcedestination_group_match_label attribute: bwuos = b1mgl
=== STEP  testing span_sourcedestination_group_match_label creation with required arguments only
=== PAUSE TestAccAciSPANSourcedestinationGroupMatchLabel_Negative
=== CONT  TestAccAciSPANSourcedestinationGroupMatchLabelDataSource_Basic
=== CONT  TestAccAciSPANSourcedestinationGroupMatchLabel_Update
=== CONT  TestAccAciSPANSourcedestinationGroupMatchLabel_Negative
=== CONT  TestAccAciSPANSourcedestinationGroupMatchLabel_Basic
=== STEP  testing span_sourcedestination_group_match_label destroy
--- PASS: TestAccAciSPANSourcedestinationGroupMatchLabelDataSource_Basic (36.28s)
=== STEP  testing span_sourcedestination_group_match_label destroy
--- PASS: TestAccAciSPANSourcedestinationGroupMatchLabel_Negative (61.66s)
=== STEP  testing span_sourcedestination_group_match_label destroy
--- PASS: TestAccAciSPANSourcedestinationGroupMatchLabel_Basic (76.92s)
=== STEP  testing span_sourcedestination_group_match_label destroy
--- PASS: TestAccAciSPANSourcedestinationGroupMatchLabel_Update (88.60s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   89.822s
=== RUN   TestAccAciConfigurationExportPolicyDataSource_Basic
=== STEP  Basic: testing configuration_export_policy Data Source without  name
=== STEP  testing configuration_export_policy Data Source with required arguments only
=== STEP  testing configuration_export_policy Data Source with random attribute
=== STEP  testing configuration_export_policy Data Source with invalid name
=== STEP  testing configuration_export_policy Data Source with updated resource
=== PAUSE TestAccAciConfigurationExportPolicyDataSource_Basic
=== RUN   TestAccAciConfigurationExportPolicy_Basic
=== STEP  Basic: testing configuration_export_policy creation without  name
=== STEP  testing configuration_export_policy creation with required arguments only
=== STEP  Basic: testing configuration_export_policy creation with optional parameters
=== STEP  testing configuration_export_policy creation with invalid name =  a8318t0xs39lrncvo0ma2f6yq3q8q8qit8i014df8n44nnd2wk0aushj4u640tgje
=== STEP  Basic: testing configuration_export_policy updation without required parameters
=== STEP  testing configuration_export_policy creation with updated name = acctest_qxpyx
=== PAUSE TestAccAciConfigurationExportPolicy_Basic
=== RUN   TestAccAciConfigurationExportPolicy_Update
=== STEP  testing configuration_export_policy creation with required arguments only
=== STEP  testing configuration_export_policy attribute: max_snapshot_count = 10
=== STEP  testing configuration_export_policy attribute: max_snapshot_count = 5
=== STEP  testing configuration_export_policy creation with required arguments only
=== PAUSE TestAccAciConfigurationExportPolicy_Update
=== RUN   TestAccAciConfigurationExportPolicy_Negative
=== STEP  testing configuration_export_policy creation with required arguments only
=== STEP  testing configuration_export_policy attribute: description = 13ywgnqmr8oqkdgxuis081su0owfmq6csl6m8klk3yhd1ns9fo21vs4ntzvdq2mc8y6kzq47xd31h8sjg6c6tdx9vphpvm7m8aidz4pnloowbvjzu0h06ino2k7vthp77
=== STEP  testing configuration_export_policy attribute: annotation = 20taiq4s0knt7ti89h0masuauyh2m9vimmk6n3znsxwhrxn83zt7hr6yb2bc6sysd4w2q2qxy27ewmoqcr4ru8pq6jp6po6h7rj2mp3rawnl4a4twbhwsoi3m78c6p9bq
=== STEP  testing configuration_export_policy attribute: name_alias = uw8gae1tawun0kfeiv6nnztqovenm12o8nzo2yq6ba91t63j3eouxgk7vf9dgrig
=== STEP  testing configuration_export_policy attribute: admin_st = cla6d
=== STEP  testing configuration_export_policy attribute: format = cla6d
=== STEP  testing configuration_export_policy attribute: include_secure_fields = cla6d
=== STEP  testing configuration_export_policy attribute: max_snapshot_count = cla6d
=== STEP  testing configuration_export_policy attribute: max_snapshot_count = -1
=== STEP  testing configuration_export_policy attribute: max_snapshot_count = 11
=== STEP  testing configuration_export_policy attribute: snapshot = cla6d
=== STEP  testing configuration_export_policy attribute: target_dn = cla6d
=== STEP  testing configuration_export_policy attribute: lxmmo = cla6d
=== STEP  testing configuration_export_policy creation with required arguments only
=== PAUSE TestAccAciConfigurationExportPolicy_Negative
=== RUN   TestAccAciConfigurationExportPolicy_MultipleCreateDelete
=== STEP  testing multiple configuration_export_policy creation with required arguments only
=== PAUSE TestAccAciConfigurationExportPolicy_MultipleCreateDelete
=== CONT  TestAccAciConfigurationExportPolicyDataSource_Basic
=== CONT  TestAccAciConfigurationExportPolicy_Negative
=== CONT  TestAccAciConfigurationExportPolicy_MultipleCreateDelete
=== CONT  TestAccAciConfigurationExportPolicy_Basic
=== CONT  TestAccAciConfigurationExportPolicy_Update
=== STEP  testing configuration_export_policy destroy
--- PASS: TestAccAciConfigurationExportPolicy_MultipleCreateDelete (34.59s)
=== STEP  testing configuration_export_policy destroy
--- PASS: TestAccAciConfigurationExportPolicyDataSource_Basic (57.73s)
=== STEP  testing configuration_export_policy destroy
--- PASS: TestAccAciConfigurationExportPolicy_Update (78.41s)
=== STEP  testing configuration_export_policy destroy
--- PASS: TestAccAciConfigurationExportPolicy_Basic (80.14s)
=== STEP  testing configuration_export_policy destroy
--- PASS: TestAccAciConfigurationExportPolicy_Negative (90.28s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   91.603s
