### PR TITLE
added test script for aci_local_user

### DIFF
--- a/aci/data_source_aci_aaauser.go
+++ b/aci/data_source_aci_aaauser.go
@@ -95,12 +95,6 @@ func dataSourceAciLocalUser() *schema.Resource {
 				Computed: true,
 			},
 
-			"pwd": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
 			"pwd_life_time": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,

--- a/aci/resource_aci_aaauser.go
+++ b/aci/resource_aci_aaauser.go
@@ -185,7 +185,6 @@ func setLocalUserAttributes(aaaUser *models.LocalUser, d *schema.ResourceData) (
 	d.Set("account_status", aaaUserMap["accountStatus"])
 	d.Set("annotation", aaaUserMap["annotation"])
 	d.Set("cert_attribute", aaaUserMap["certAttribute"])
-	d.Set("clear_pwd_history", aaaUserMap["clearPwdHistory"])
 	d.Set("email", aaaUserMap["email"])
 	d.Set("expiration", aaaUserMap["expiration"])
 	d.Set("expires", aaaUserMap["expires"])
@@ -193,7 +192,9 @@ func setLocalUserAttributes(aaaUser *models.LocalUser, d *schema.ResourceData) (
 	d.Set("last_name", aaaUserMap["lastName"])
 	d.Set("name_alias", aaaUserMap["nameAlias"])
 	d.Set("otpenable", aaaUserMap["otpenable"])
-	d.Set("otpkey", aaaUserMap["otpkey"])
+	if aaaUserMap["otpkey"] == "DISABLEDDISABLED" {
+		d.Set("otpkey", "DISABLEDDISABLED")
+	}
 	d.Set("phone", aaaUserMap["phone"])
 	if aaaUserMap["pwdLifeTime"] == "no-password-expire" {
 		d.Set("pwd_life_time", "0")

--- a/testacc/data_source_aci_aaauser_test.go
+++ b/testacc/data_source_aci_aaauser_test.go
@@ -1,0 +1,172 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciLocalUserDataSource_Basic(t *testing.T) {
+	resourceName := "aci_local_user.test"
+	dataSourceName := "data.aci_local_user.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	password := fmt.Sprintf("%s%s%s", acctest.RandStringFromCharSet(6, "abcdefghjiklmnopqrstuvwxyz"), acctest.RandStringFromCharSet(1, "ABCDEFGHIJKLMNOPQRSTUVWXYZ"), acctest.RandStringFromCharSet(1, "@#$%^&*()-_!`~+="))
+	passwordOther := fmt.Sprintf("%s%s%s", acctest.RandStringFromCharSet(6, "abcdefghjiklmnopqrstuvwxyz"), acctest.RandStringFromCharSet(1, "ABCDEFGHIJKLMNOPQRSTUVWXYZ"), acctest.RandStringFromCharSet(1, "@#$%^&*()-_!`~+="))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLocalUserDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateLocalUserDSWithoutRequired(rName, password, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLocalUserConfigDataSource(rName, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "account_status", resourceName, "account_status"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "cert_attribute", resourceName, "cert_attribute"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "clear_pwd_history", resourceName, "clear_pwd_history"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "email", resourceName, "email"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "expiration", resourceName, "expiration"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "expires", resourceName, "expires"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "first_name", resourceName, "first_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "last_name", resourceName, "last_name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "otpenable", resourceName, "otpenable"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "otpkey", resourceName, "otpkey"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "phone", resourceName, "phone"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "pwd_life_time", resourceName, "pwd_life_time"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "pwd_update_required", resourceName, "pwd_update_required"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "rbac_string", resourceName, "rbac_string"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "unix_user_id", resourceName, "unix_user_id"),
+				),
+			},
+			{
+				Config:      CreateAccLocalUserDataSourceUpdate(rName, password, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccLocalUserDSWithInvalidName(rName, password),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccLocalUserDataSourceUpdatedResource(rName, passwordOther, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccLocalUserConfigDataSource(rName, pwd string) string {
+	fmt.Println("=== STEP  testing local_user Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+	
+		name  = "%s"
+		pwd = "%s"
+	}
+
+	data "aci_local_user" "test" {
+	
+		name  = aci_local_user.test.name
+		depends_on = [ aci_local_user.test ]
+	}
+	`, rName, pwd)
+	return resource
+}
+
+func CreateLocalUserDSWithoutRequired(rName, pwd, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing local_user Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_local_user" "test" {
+	
+		name  = "%s"
+		pwd = "%s"
+	}
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	data "aci_local_user" "test" {
+	
+	#	name  = aci_local_user.test.name
+		depends_on = [ aci_local_user.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName, pwd)
+}
+
+func CreateAccLocalUserDSWithInvalidName(rName, pwd string) string {
+	fmt.Println("=== STEP  testing local_user Data Source with invalid name")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+	
+		name  = "%s"
+		pwd = "%s"
+	}
+
+	data "aci_local_user" "test" {
+	
+		name  = "${aci_local_user.test.name}_invalid"
+		depends_on = [ aci_local_user.test ]
+	}
+	`, rName, pwd)
+	return resource
+}
+
+func CreateAccLocalUserDataSourceUpdate(rName, pwd, key, value string) string {
+	fmt.Println("=== STEP  testing local_user Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+	
+		name  = "%s"
+		pwd = "%s"
+	}
+
+	data "aci_local_user" "test" {
+	
+		name  = aci_local_user.test.name
+		%s = "%s"
+		depends_on = [ aci_local_user.test ]
+	}
+	`, rName, pwd, key, value)
+	return resource
+}
+
+func CreateAccLocalUserDataSourceUpdatedResource(rName, pwd, key, value string) string {
+	fmt.Println("=== STEP  testing local_user Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+	
+		name  = "%s"
+		pwd = "%s"
+		%s = "%s"
+	}
+
+	data "aci_local_user" "test" {
+	
+		name  = aci_local_user.test.name
+		depends_on = [ aci_local_user.test ]
+	}
+	`, rName, pwd, key, value)
+	return resource
+}

--- a/testacc/resource_aci_aaauser_test.go
+++ b/testacc/resource_aci_aaauser_test.go
@@ -1,0 +1,533 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciLocalUser_Basic(t *testing.T) {
+	var local_user_default models.LocalUser
+	var local_user_updated models.LocalUser
+	resourceName := "aci_local_user.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	password := fmt.Sprintf("%s%s%s", acctest.RandStringFromCharSet(6, "abcdefghjiklmnopqrstuvwxyz"), acctest.RandStringFromCharSet(1, "ABCDEFGHIJKLMNOPQRSTUVWXYZ"), acctest.RandStringFromCharSet(1, "@#$%^&*()-_!`~+="))
+	password1 := fmt.Sprintf("%s%s%s", acctest.RandStringFromCharSet(6, "abcdefghjiklmnopqrstuvwxyz"), acctest.RandStringFromCharSet(1, "ABCDEFGHIJKLMNOPQRSTUVWXYZ"), acctest.RandStringFromCharSet(1, "@#$%^&*()-_!`~+="))
+	password2 := fmt.Sprintf("%s%s%s", acctest.RandStringFromCharSet(6, "abcdefghjiklmnopqrstuvwxyz"), acctest.RandStringFromCharSet(1, "ABCDEFGHIJKLMNOPQRSTUVWXYZ"), acctest.RandStringFromCharSet(1, "@#$%^&*()-_!`~+="))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLocalUserDestroy,
+		Steps: []resource.TestStep{
+
+			{
+				Config:      CreateLocalUserWithoutRequired(rName, "name"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccLocalUserConfig(rName, password),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLocalUserExists(resourceName, &local_user_default),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "account_status", "active"),
+					resource.TestCheckResourceAttr(resourceName, "cert_attribute", ""),
+					resource.TestCheckResourceAttr(resourceName, "email", ""),
+					resource.TestCheckResourceAttr(resourceName, "expiration", "never"),
+					resource.TestCheckResourceAttr(resourceName, "expires", "no"),
+					resource.TestCheckResourceAttr(resourceName, "first_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "last_name", ""),
+					resource.TestCheckResourceAttr(resourceName, "otpenable", "no"),
+					resource.TestCheckResourceAttr(resourceName, "otpkey", "DISABLEDDISABLED"),
+					resource.TestCheckResourceAttr(resourceName, "phone", ""),
+					resource.TestCheckResourceAttr(resourceName, "pwd", password),
+					resource.TestCheckResourceAttr(resourceName, "pwd_life_time", "0"),
+					resource.TestCheckResourceAttr(resourceName, "pwd_update_required", "no"),
+					resource.TestCheckResourceAttr(resourceName, "rbac_string", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "unix_user_id"),
+				),
+			},
+			{
+				Config: CreateAccLocalUserConfigWithOptionalValues(rName, password1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLocalUserExists(resourceName, &local_user_updated),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_local_user"),
+					resource.TestCheckResourceAttr(resourceName, "account_status", "inactive"),
+					resource.TestCheckResourceAttr(resourceName, "cert_attribute", "test_cert_attribute"),
+					resource.TestCheckResourceAttr(resourceName, "clear_pwd_history", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "email", "test@email.com"),
+					resource.TestCheckResourceAttr(resourceName, "expiration", "2030-12-12T00:00:00.000+00:00"),
+					resource.TestCheckResourceAttr(resourceName, "expires", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "first_name", "test_first_name"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", "test_last_name"),
+					resource.TestCheckResourceAttr(resourceName, "otpenable", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "otpkey", "667PNG5QJW2VAVQA"),
+					resource.TestCheckResourceAttr(resourceName, "phone", "1234567890"),
+					resource.TestCheckResourceAttr(resourceName, "pwd", password1),
+					resource.TestCheckResourceAttr(resourceName, "pwd_life_time", "3650"),
+					resource.TestCheckResourceAttr(resourceName, "pwd_update_required", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "rbac_string", "test_rbac_string"),
+					resource.TestCheckResourceAttrSet(resourceName, "unix_user_id"),
+					testAccCheckAciLocalUserIdEqual(&local_user_default, &local_user_updated),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"pwd", "clear_pwd_history", "otpkey"},
+			},
+			{
+				Config: CreateAccLocalUserUpdatedAttr(rName, password, "pwd_life_time", "1825"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLocalUserExists(resourceName, &local_user_updated),
+					resource.TestCheckResourceAttr(resourceName, "pwd_life_time", "1825"),
+					testAccCheckAciLocalUserIdEqual(&local_user_default, &local_user_updated),
+				),
+			},
+			{
+				Config:      CreateAccLocalUserConfigUpdatedName(acctest.RandString(65)),
+				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
+			},
+
+			{
+				Config:      CreateAccLocalUserRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+
+			{
+				Config: CreateAccLocalUserConfigWithRequiredParams(rNameUpdated, password2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLocalUserExists(resourceName, &local_user_updated),
+
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdated),
+					testAccCheckAciLocalUserIdNotEqual(&local_user_default, &local_user_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciLocalUser_Update(t *testing.T) {
+	var local_user_default models.LocalUser
+	var local_user_updated models.LocalUser
+	resourceName := "aci_local_user.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	password := fmt.Sprintf("%s%s%s", acctest.RandStringFromCharSet(6, "abcdefghjiklmnopqrstuvwxyz"), acctest.RandStringFromCharSet(1, "ABCDEFGHIJKLMNOPQRSTUVWXYZ"), acctest.RandStringFromCharSet(1, "@#$%^&*()-_!`~+="))
+	passwodUpdated := fmt.Sprintf("%s%s%s", acctest.RandStringFromCharSet(6, "abcdefghjiklmnopqrstuvwxyz"), acctest.RandStringFromCharSet(1, "ABCDEFGHIJKLMNOPQRSTUVWXYZ"), acctest.RandStringFromCharSet(1, "@#$%^&*()-_!`~+="))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLocalUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLocalUserConfig(rName, password),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLocalUserExists(resourceName, &local_user_default),
+				),
+			},
+			{
+				Config: CreateAccLocalUserUpdatedAttr(rName, passwodUpdated, "clear_pwd_history", "no"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciLocalUserExists(resourceName, &local_user_updated),
+					resource.TestCheckResourceAttr(resourceName, "clear_pwd_history", "no"),
+					testAccCheckAciLocalUserIdEqual(&local_user_default, &local_user_updated),
+				),
+			},
+			{
+				Config: CreateAccLocalUserConfig(rName, passwodUpdated),
+			},
+		},
+	})
+}
+
+func TestAccAciLocalUser_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+	password1 := fmt.Sprintf("%s%s%s", acctest.RandStringFromCharSet(6, "abcdefghjiklmnopqrstuvwxyz"), acctest.RandStringFromCharSet(1, "ABCDEFGHIJKLMNOPQRSTUVWXYZ"), acctest.RandStringFromCharSet(1, "@#$%^&*()-_!`~+="))
+	password2 := fmt.Sprintf("%s%s%s", acctest.RandStringFromCharSet(6, "abcdefghjiklmnopqrstuvwxyz"), acctest.RandStringFromCharSet(1, "ABCDEFGHIJKLMNOPQRSTUVWXYZ"), acctest.RandStringFromCharSet(1, "@#$%^&*()-_!`~+="))
+	password3 := fmt.Sprintf("%s%s%s", acctest.RandStringFromCharSet(6, "abcdefghjiklmnopqrstuvwxyz"), acctest.RandStringFromCharSet(1, "ABCDEFGHIJKLMNOPQRSTUVWXYZ"), acctest.RandStringFromCharSet(1, "@#$%^&*()-_!`~+="))
+	password4 := fmt.Sprintf("%s%s%s", acctest.RandStringFromCharSet(6, "abcdefghjiklmnopqrstuvwxyz"), acctest.RandStringFromCharSet(1, "ABCDEFGHIJKLMNOPQRSTUVWXYZ"), acctest.RandStringFromCharSet(1, "@#$%^&*()-_!`~+="))
+	password5 := fmt.Sprintf("%s%s%s", acctest.RandStringFromCharSet(6, "abcdefghjiklmnopqrstuvwxyz"), acctest.RandStringFromCharSet(1, "ABCDEFGHIJKLMNOPQRSTUVWXYZ"), acctest.RandStringFromCharSet(1, "@#$%^&*()-_!`~+="))
+	passwordWithoutSpecialChars := fmt.Sprintf("%s%s", acctest.RandStringFromCharSet(6, "abcdefghjiklmnopqrstuvwxyz"), acctest.RandStringFromCharSet(2, "ABCDEFGHIJKLMNOPQRSTUVWXYZ"))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLocalUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLocalUserConfig(rName, password1),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password1, "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password1, "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password1, "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password1, "account_status", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password2, "cert_attribute", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password2, "clear_pwd_history", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password2, "email", randomValue),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password2, "expiration", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password2, "expires", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password3, "first_name", acctest.RandString(33)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password3, "last_name", acctest.RandString(33)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password3, "otpenable", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password3, "otpkey", randomValue),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password3, "phone", acctest.RandString(33)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttrPassword(rName, randomValue),
+				ExpectError: regexp.MustCompile(`password must be minimum 8 characters`),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttrPassword(rName, acctest.RandString(8)),
+				ExpectError: regexp.MustCompile(`password strength check`),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttrPassword(rName, passwordWithoutSpecialChars),
+				ExpectError: regexp.MustCompile(`password strength check`),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password4, "pwd_life_time", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password4, "pwd_life_time", "-1"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password4, "pwd_life_time", "3651"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password4, "pwd_update_required", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccLocalUserUpdatedAttr(rName, password4, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccLocalUserConfig(rName, password5),
+			},
+		},
+	})
+}
+
+func TestAccAciLocalUser_MultipleCreateDelete(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	password := fmt.Sprintf("%s%s%s", acctest.RandStringFromCharSet(6, "abcdefghjiklmnopqrstuvwxyz"), acctest.RandStringFromCharSet(1, "ABCDEFGHIJKLMNOPQRSTUVWXYZ"), acctest.RandStringFromCharSet(1, "@#$%^&*()-_!`~+="))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciLocalUserDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccLocalUserConfigMultiple(rName, password),
+			},
+		},
+	})
+}
+
+func testAccCheckAciLocalUserExists(name string, local_user *models.LocalUser) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("LocalUser %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No LocalUser dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		local_userFound := models.LocalUserFromContainer(cont)
+		if local_userFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("LocalUser %s not found", rs.Primary.ID)
+		}
+		*local_user = *local_userFound
+		return nil
+	}
+}
+
+func testAccCheckAciLocalUserDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing local_user destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_local_user" {
+			cont, err := client.Get(rs.Primary.ID)
+			local_user := models.LocalUserFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("LocalUser %s Still exists", local_user.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciLocalUserIdEqual(m1, m2 *models.LocalUser) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("local_user DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciLocalUserIdNotEqual(m1, m2 *models.LocalUser) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("local_user DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateLocalUserWithoutRequired(rName, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing local_user creation without ", attrName)
+	rBlock := `
+	
+	`
+	switch attrName {
+	case "name":
+		rBlock += `
+	resource "aci_local_user" "test" {
+	
+	#	name  = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, rName)
+}
+
+func CreateAccLocalUserConfigWithRequiredParams(rName, pwd string) string {
+	fmt.Println("=== STEP  testing local_user creation with updated name =", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+	
+		name  = "%s"
+		pwd = "%s"
+	}
+	`, rName, pwd)
+	return resource
+}
+func CreateAccLocalUserConfigUpdatedName(rName string) string {
+	fmt.Println("=== STEP  testing local_user creation with invalid name = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+	
+		name  = "%s"
+	}
+	`, rName)
+	return resource
+}
+
+func CreateAccLocalUserConfig(rName, pwd string) string {
+	fmt.Println("=== STEP  testing local_user creation with required arguments and valid pwd only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+	
+		name  = "%s"
+		pwd = "%s"
+	}
+	`, rName, pwd)
+	return resource
+}
+
+func CreateAccLocalUserConfigMultiple(rName, pwd string) string {
+	fmt.Println("=== STEP  testing multiple local_user creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+	
+		name  = "%s_${count.index}"
+		pwd = "%s${count.index}"
+		count = 5
+	}
+	`, rName, pwd)
+	return resource
+}
+
+func CreateAccLocalUserConfigWithOptionalValues(rName, pwd string) string {
+	fmt.Println("=== STEP  Basic: testing local_user creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+	
+		name  = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_local_user"
+		account_status = "inactive"
+		cert_attribute = "test_cert_attribute"
+		clear_pwd_history = "yes"
+		email = "test@email.com"
+		expiration = "2030-12-12T00:00:00.000+00:00"
+		expires = "yes"
+		first_name = "test_first_name"
+		last_name = "test_last_name"
+		otpenable = "yes"
+		otpkey = "667PNG5QJW2VAVQA"
+		phone = "1234567890"
+		pwd = "%s"
+		pwd_life_time = "3650"
+		pwd_update_required = "yes"
+		rbac_string = "test_rbac_string"
+	}
+	`, rName, pwd)
+
+	return resource
+}
+
+func CreateAccLocalUserRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing local_user updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_local_user" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_local_user"
+		account_status = "blocked"
+		cert_attribute = ""
+		clear_pwd_history = "yes"
+		email = ""
+		expiration = ""
+		expires = "yes"
+		first_name = ""
+		last_name = ""
+		otpenable = "yes"
+		otpkey = ""
+		phone = ""
+		pwd = ""
+		pwd_life_time = "1"
+		pwd_update_required = "yes"
+		rbac_string = ""
+		restricted_rbac_user = "yes"
+		
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccLocalUserUpdatedAttrPassword(rName, password string) string {
+	fmt.Printf("=== STEP  testing local_user attribute: pwd = %s \n", password)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+	
+		name  = "%s"
+		pwd = "%s"
+	}
+	`, rName, password)
+	return resource
+}
+
+func CreateAccLocalUserUpdatedAttr(rName, password, attribute, value string) string {
+	fmt.Printf("=== STEP  testing local_user attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+	
+		name  = "%s"
+		pwd = "%s"
+		%s = "%s"
+	}
+	`, rName, password, attribute, value)
+	return resource
+}
+
+func CreateAccLocalUserUpdatedAttrList(rName, attribute, value string) string {
+	fmt.Printf("=== STEP  testing local_user attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+	
+		name  = "%s"
+		%s = %s
+	}
+	`, rName, attribute, value)
+	return resource
+}

--- a/website/docs/d/local_user.html.markdown
+++ b/website/docs/d/local_user.html.markdown
@@ -40,7 +40,6 @@ data "aci_local_user" "example" {
 - `otpenable` - (Optional) flag to enable OTP for the user.
 - `otpkey` - (Optional) OTP-key for object user.
 - `phone` - (Optional) Phone number of the local user.
-- `pwd` - (Optional) System user password.
 - `pwd_life_time` - (Optional) The lifetime of the local user password.
 - `pwd_update_required` - (Optional) A boolean value indicating whether this account needs password update.
 - `rbac_string` - (Optional) RBAC-string of the local user.

--- a/website/docs/r/configuration_export_policy.html.markdown
+++ b/website/docs/r/configuration_export_policy.html.markdown
@@ -32,7 +32,7 @@ resource "aci_configuration_export_policy" "example" {
 
 - `name` - (Required) Name of Object configuration export policy.
 - `admin_st` - (Optional) Admin state of the export policy. A policy can be triggered at any time by setting the admin_st to triggered. The value on APIC will reset back to untriggered once trigger is done. 
-  Allowed values: "untriggered", "triggered". Default value is "untriggered".
+  Allowed values: "untriggered", "triggered".
 - `annotation` - (Optional) Annotation for object configuration export policy.
 - `description` - (Optional) Description for object configuration export policy.
 - `format` - (Optional) Export data format.

--- a/website/docs/r/local_user.html.markdown
+++ b/website/docs/r/local_user.html.markdown
@@ -23,7 +23,7 @@ resource "aci_local_user" "example" {
     clear_pwd_history   = "no"
     description         = "from terraform"
     email               = "example@email.com"
-    expiration          = "2030-01-01 00:00:00"
+    expiration          = "2030-12-12T00:00:00.000+00:00"
     expires             = "yes"
     first_name          = "fname"
     last_name           = "lname"
@@ -45,7 +45,7 @@ resource "aci_local_user" "example" {
   Allowed values: "active", "inactive". Default value: "active".
 - `annotation` - (Optional) Annotation for object locally authenticated user.
 - `cert_attribute` - (Optional) cert-attribute for object locally authenticated user.
-- `clear_pwd_history` - (Optional) Allows the administrator to clear the password history of a locally-authenticated user. This is a trigger type attribute, So the value will reset to "no" once histry is cleared. Allowed values: "no", "yes". Default value: no.
+- `clear_pwd_history` - (Optional) Allows the administrator to clear the password history of a locally-authenticated user. This is a trigger type attribute, So the value will reset to "no" once histry is cleared. Allowed values: "no", "yes".
 - `description` - (Optional) Specifies a description of the policy definition.
 - `email` - (Optional) The email address of the locally-authenticated user.
 - `expiration` - (Optional) The expiration date of the locally-authenticated user account. The expires property must be enabled to activate an expiration date in format: YYYY-MM-DD HH:MM:SS. Default value: "never".


### PR DESCRIPTION
=== RUN   TestAccAciLocalUserDataSource_Basic
=== STEP  Basic: testing local_user Data Source without  name
=== STEP  testing local_user Data Source with required arguments only
=== STEP  testing local_user Data Source with random attribute
=== STEP  testing local_user Data Source with invalid name
=== STEP  testing local_user Data Source with updated resource
=== PAUSE TestAccAciLocalUserDataSource_Basic
=== RUN   TestAccAciLocalUser_Basic
=== STEP  Basic: testing local_user creation without  name
=== STEP  testing local_user creation with required arguments and valid pwd only
=== STEP  Basic: testing local_user creation with optional parameters
=== STEP  testing local_user attribute: pwd_life_time = 1825
=== STEP  testing local_user creation with invalid name =  0z0yd8ma6uuy7r3wiq9vu02yyl347uwjd9fncc7h3l2y6glezdcf6zgxp92dotcju
=== STEP  Basic: testing local_user updation without required parameters
=== STEP  testing local_user creation with updated name = acctest_j8x26
=== PAUSE TestAccAciLocalUser_Basic
=== RUN   TestAccAciLocalUser_Update
=== STEP  testing local_user creation with required arguments and valid pwd only
=== STEP  testing local_user attribute: clear_pwd_history = no
=== STEP  testing local_user creation with required arguments and valid pwd only
=== PAUSE TestAccAciLocalUser_Update
=== RUN   TestAccAciLocalUser_Negative
=== STEP  testing local_user creation with required arguments and valid pwd only
=== STEP  testing local_user attribute: description = zjalnoc4te7mhan42r9m94bpt6na2z7sjafyd0rwgwzhdawny3usvy6favw7pu48zopt2et3l60i3jq4imm7nqbalzcr6i32kzh82jqbm4icceelms80x6ub4vnh8sf8c
=== STEP  testing local_user attribute: annotation = ggwmyh1o3q0os1bvr04czywtou0vt2ckfkxsn6hg9d2hynunk07xlwc9ozdo2j2xqwyp7st1b2d0i6ly749mhgqfwbs7rmsceh7fyn6jvbp41ot0lz2kjuqlnwn44v68m
=== STEP  testing local_user attribute: name_alias = fuun9m6472pysk1nvhlcu38asdl8tdok4xpghgvlx0t03kkvaoxoxcdcpmb2wob8
=== STEP  testing local_user attribute: account_status = vkrdu
=== STEP  testing local_user attribute: cert_attribute = 22r41is4rqiqy9w7n23r3gv993620d4nsbib28zsizeg7wpmymaeex4rcilan376ahleolptro8rv2julfjjrn8njrcz8h2lcr1k38qc12q633itob7hs4ldaf9a29bgx
=== STEP  testing local_user attribute: clear_pwd_history = vkrdu
=== STEP  testing local_user attribute: email = vkrdu
=== STEP  testing local_user attribute: expiration = vkrdu
=== STEP  testing local_user attribute: expires = vkrdu
=== STEP  testing local_user attribute: first_name = zccjnxer13diugxmhjf3aoovvpygaf09h
=== STEP  testing local_user attribute: last_name = guq0e1zbywt01vl4d4v7izyr3mbec01zw
=== STEP  testing local_user attribute: otpenable = vkrdu
=== STEP  testing local_user attribute: otpkey = vkrdu
=== STEP  testing local_user attribute: phone = zxesu9gdduq88tmogx039s8v8lba2tdq4
=== STEP  testing local_user attribute: pwd = vkrdu
=== STEP  testing local_user attribute: pwd = pelyw3up
=== STEP  testing local_user attribute: pwd = aaesfkVW
=== STEP  testing local_user attribute: pwd_life_time = vkrdu
=== STEP  testing local_user attribute: pwd_life_time = -1
=== STEP  testing local_user attribute: pwd_life_time = 3651
=== STEP  testing local_user attribute: pwd_update_required = vkrdu
=== STEP  testing local_user attribute: pbycu = vkrdu
=== STEP  testing local_user creation with required arguments and valid pwd only
=== PAUSE TestAccAciLocalUser_Negative
=== RUN   TestAccAciLocalUser_MultipleCreateDelete
=== STEP  testing multiple local_user creation with required arguments only
=== PAUSE TestAccAciLocalUser_MultipleCreateDelete
=== CONT  TestAccAciLocalUserDataSource_Basic
=== CONT  TestAccAciLocalUser_Negative
=== CONT  TestAccAciLocalUser_Update
=== CONT  TestAccAciLocalUser_MultipleCreateDelete
=== CONT  TestAccAciLocalUser_Basic
=== STEP  testing local_user destroy
--- PASS: TestAccAciLocalUser_MultipleCreateDelete (21.58s)
=== STEP  testing local_user destroy
--- PASS: TestAccAciLocalUserDataSource_Basic (40.45s)
=== STEP  testing local_user destroy
--- PASS: TestAccAciLocalUser_Update (46.64s)
=== STEP  testing local_user destroy
--- PASS: TestAccAciLocalUser_Basic (72.80s)
=== STEP  testing local_user destroy
--- PASS: TestAccAciLocalUser_Negative (118.51s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   119.915s
