### PR TITLE
added test script for l3out_path_attachment

### DIFF
--- a/testacc/data_source_aci_l3extrspathl3outatt_test.go
+++ b/testacc/data_source_aci_l3extrspathl3outatt_test.go
@@ -1,0 +1,279 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciL3outPathAttachmentDataSource_Basic(t *testing.T) {
+	resourceName := "aci_l3out_path_attachment.test"
+	dataSourceName := "data.aci_l3out_path_attachment.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3outPathAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateL3outPathAttachmentDSWithoutRequired(rName, rName, rName, rName, pathEp5, "logical_interface_profile_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateL3outPathAttachmentDSWithoutRequired(rName, rName, rName, rName, pathEp5, "target_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentConfigDataSource(rName, rName, rName, rName, pathEp5),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "logical_interface_profile_dn", resourceName, "logical_interface_profile_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "target_dn", resourceName, "target_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "addr", resourceName, "addr"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "autostate", resourceName, "autostate"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "encap", resourceName, "encap"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "encap_scope", resourceName, "encap_scope"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "if_inst_t", resourceName, "if_inst_t"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ipv6_dad", resourceName, "ipv6_dad"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "ll_addr", resourceName, "ll_addr"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "mac", resourceName, "mac"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "mode", resourceName, "mode"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "mtu", resourceName, "mtu"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "target_dscp", resourceName, "target_dscp"),
+				),
+			},
+			{
+				Config:      CreateAccL3outPathAttachmentDataSourceUpdate(rName, rName, rName, rName, pathEp5, randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+
+			{
+				Config:      CreateAccL3outPathAttachmentDSWithInvalidParentDn(rName, rName, rName, rName, pathEp5),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+
+			{
+				Config: CreateAccL3outPathAttachmentDataSourceUpdatedResource(rName, rName, rName, rName, pathEp5, "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccL3outPathAttachmentConfigDataSource(fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn string) string {
+	fmt.Println("=== STEP  testing l3out_path_attachment Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		target_dn  = "%s"
+		if_inst_t = "ext-svi"
+	}
+
+	data "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		target_dn  = aci_l3out_path_attachment.test.target_dn
+		depends_on = [ aci_l3out_path_attachment.test ]
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn)
+	return resource
+}
+
+func CreateL3outPathAttachmentDSWithoutRequired(fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing l3out_path_attachment creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		target_dn  = "%s"
+		if_inst_t = "ext-svi"
+	}
+	`
+	switch attrName {
+	case "logical_interface_profile_dn":
+		rBlock += `
+	data "aci_l3out_path_attachment" "test" {
+	#	logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		target_dn  = aci_l3out_path_attachment.test.target_dn
+		depends_on = [ aci_l3out_path_attachment.test ]
+	}
+		`
+	case "target_dn":
+		rBlock += `
+	data "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+	#	target_dn  = aci_l3out_path_attachment.test.target_dn
+		depends_on = [ aci_l3out_path_attachment.test ]
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn)
+}
+
+func CreateAccL3outPathAttachmentDSWithInvalidParentDn(fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn string) string {
+	fmt.Println("=== STEP  testing l3out_path_attachment Data Source with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		target_dn  = "%s"
+		if_inst_t = "ext-svi"
+	}
+
+	data "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = "${aci_logical_interface_profile.test.id}_invalid"
+		target_dn  = aci_l3out_path_attachment.test.target_dn
+		depends_on = [ aci_l3out_path_attachment.test ]
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn)
+	return resource
+}
+
+func CreateAccL3outPathAttachmentDataSourceUpdate(fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn, key, value string) string {
+	fmt.Println("=== STEP  testing l3out_path_attachment Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		target_dn  = "%s"
+		if_inst_t = "ext-svi"
+	}
+
+	data "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		target_dn  = aci_l3out_path_attachment.test.target_dn
+		if_inst_t = "ext-svi"
+		%s = "%s"
+		depends_on = [ aci_l3out_path_attachment.test ]
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn, key, value)
+	return resource
+}
+
+func CreateAccL3outPathAttachmentDataSourceUpdatedResource(fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn, key, value string) string {
+	fmt.Println("=== STEP  testing l3out_path_attachment Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		target_dn  = "%s"
+		if_inst_t = "ext-svi"
+		%s = "%s"
+	}
+
+	data "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		target_dn  = aci_l3out_path_attachment.test.target_dn
+		depends_on = [ aci_l3out_path_attachment.test ]
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn, key, value)
+	return resource
+}

--- a/testacc/provider_test.go
+++ b/testacc/provider_test.go
@@ -63,6 +63,11 @@ const fabricNodeMemNodeId2 = "302"
 const fabricNodeMemNodeId3 = "303"
 const fabricNodeMemNodeId4 = "304"
 const fabricNodeMemNodeId5 = "306"
+const pathEp1 = "topology/pod-1/paths-101/pathep-[eth1/1]"
+const pathEp2 = "topology/pod-1/paths-101/pathep-[eth1/12]"
+const pathEp3 = "topology/pod-1/paths-101/pathep-[eth1/6]"
+const pathEp4 = "topology/pod-1/paths-101/pathep-[eth1/17]"
+const pathEp5 = "topology/pod-1/paths-101/pathep-[eth1/34]"
 
 func init() {
 	testAccProvider = aci.Provider()

--- a/testacc/resource_aci_l3extrspathl3outatt_test.go
+++ b/testacc/resource_aci_l3extrspathl3outatt_test.go
@@ -1,0 +1,675 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciL3outPathAttachment_Basic(t *testing.T) {
+	var l3out_path_attachment_default models.L3outPathAttachment
+	var l3out_path_attachment_updated models.L3outPathAttachment
+	resourceName := "aci_l3out_path_attachment.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3outPathAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateL3outPathAttachmentWithoutRequired(rName, rName, rName, rName, pathEp1, "ext-svi", "logical_interface_profile_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateL3outPathAttachmentWithoutRequired(rName, rName, rName, rName, pathEp1, "ext-svi", "target_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateL3outPathAttachmentWithoutRequired(rName, rName, rName, rName, pathEp1, "ext-svi", "if_inst_t"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentConfig(rName, rName, rName, rName, pathEp1, "ext-svi"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outPathAttachmentExists(resourceName, &l3out_path_attachment_default),
+					resource.TestCheckResourceAttr(resourceName, "logical_interface_profile_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s/lifp-%s", rName, rName, rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "target_dn", pathEp1),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "addr", "0.0.0.0"),
+					resource.TestCheckResourceAttr(resourceName, "autostate", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "encap", "unknown"),
+					resource.TestCheckResourceAttr(resourceName, "encap_scope", "local"),
+					resource.TestCheckResourceAttr(resourceName, "if_inst_t", "ext-svi"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_dad", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "ll_addr", "::"),
+					resource.TestCheckResourceAttr(resourceName, "mac", "00:22:BD:F8:19:FF"),
+					resource.TestCheckResourceAttr(resourceName, "mode", "regular"),
+					resource.TestCheckResourceAttr(resourceName, "mtu", "inherit"),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "unspecified"),
+				),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentConfigWithOptionalValues(rName, rName, rName, rName, pathEp1, "ext-svi"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outPathAttachmentExists(resourceName, &l3out_path_attachment_updated),
+					resource.TestCheckResourceAttr(resourceName, "logical_interface_profile_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s/lifp-%s", rName, rName, rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "target_dn", pathEp1),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "addr", "10.20.30.40/16"),
+					resource.TestCheckResourceAttr(resourceName, "autostate", "enabled"),
+					resource.TestCheckResourceAttr(resourceName, "encap", "unknown"),
+					resource.TestCheckResourceAttr(resourceName, "encap_scope", "ctx"),
+					resource.TestCheckResourceAttr(resourceName, "if_inst_t", "ext-svi"),
+					resource.TestCheckResourceAttr(resourceName, "ipv6_dad", "disabled"),
+					resource.TestCheckResourceAttr(resourceName, "ll_addr", "fe80::1"),
+					resource.TestCheckResourceAttr(resourceName, "mac", "00:22:BD:F8:19:F0"),
+					resource.TestCheckResourceAttr(resourceName, "mode", "native"),
+					resource.TestCheckResourceAttr(resourceName, "mtu", "576"),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF11"),
+					testAccCheckAciL3outPathAttachmentIdEqual(&l3out_path_attachment_default, &l3out_path_attachment_updated),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+			{
+				Config:      CreateAccL3outPathAttachmentRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config:      CreateAccL3outPathAttachmentConfigWithRequiredParams(rName, rName, "ext-svi"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccL3outPathAttachmentConfigWithRequiredParams(rName, pathEp1, rName),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentConfigWithRequiredParams(rName, pathEp1, "l3-port"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outPathAttachmentExists(resourceName, &l3out_path_attachment_updated),
+					resource.TestCheckResourceAttr(resourceName, "logical_interface_profile_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s/lifp-%s", rName, rName, rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "target_dn", pathEp1),
+					resource.TestCheckResourceAttr(resourceName, "if_inst_t", "l3-port"),
+					testAccCheckAciL3outPathAttachmentIdEqual(&l3out_path_attachment_default, &l3out_path_attachment_updated),
+				),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentConfigWithRequiredParams(rName, pathEp1, "sub-interface"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outPathAttachmentExists(resourceName, &l3out_path_attachment_updated),
+					resource.TestCheckResourceAttr(resourceName, "logical_interface_profile_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s/lifp-%s", rName, rName, rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "target_dn", pathEp1),
+					resource.TestCheckResourceAttr(resourceName, "if_inst_t", "sub-interface"),
+					testAccCheckAciL3outPathAttachmentIdEqual(&l3out_path_attachment_default, &l3out_path_attachment_updated),
+				),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentConfigWithRequiredParams(rName, pathEp1, "unspecified"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outPathAttachmentExists(resourceName, &l3out_path_attachment_updated),
+					resource.TestCheckResourceAttr(resourceName, "logical_interface_profile_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s/lifp-%s", rName, rName, rName, rName)),
+					resource.TestCheckResourceAttr(resourceName, "target_dn", pathEp1),
+					resource.TestCheckResourceAttr(resourceName, "if_inst_t", "unspecified"),
+					testAccCheckAciL3outPathAttachmentIdEqual(&l3out_path_attachment_default, &l3out_path_attachment_updated),
+				),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentConfig(rName, rName, rName, rName, pathEp1, "ext-svi"),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentConfigWithRequiredParams(rNameUpdated, pathEp1, "ext-svi"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outPathAttachmentExists(resourceName, &l3out_path_attachment_updated),
+					resource.TestCheckResourceAttr(resourceName, "logical_interface_profile_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s/lifp-%s", rNameUpdated, rNameUpdated, rNameUpdated, rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "target_dn", pathEp1),
+					resource.TestCheckResourceAttr(resourceName, "if_inst_t", "ext-svi"),
+					testAccCheckAciL3outPathAttachmentIdNotEqual(&l3out_path_attachment_default, &l3out_path_attachment_updated),
+				),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentConfig(rName, rName, rName, rName, pathEp1, "ext-svi"),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentConfigWithRequiredParams(rNameUpdated, pathEp2, "ext-svi"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outPathAttachmentExists(resourceName, &l3out_path_attachment_updated),
+					resource.TestCheckResourceAttr(resourceName, "logical_interface_profile_dn", fmt.Sprintf("uni/tn-%s/out-%s/lnodep-%s/lifp-%s", rNameUpdated, rNameUpdated, rNameUpdated, rNameUpdated)),
+					resource.TestCheckResourceAttr(resourceName, "target_dn", pathEp2),
+					resource.TestCheckResourceAttr(resourceName, "if_inst_t", "ext-svi"),
+					testAccCheckAciL3outPathAttachmentIdNotEqual(&l3out_path_attachment_default, &l3out_path_attachment_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciL3outPathAttachment_Update(t *testing.T) {
+	var l3out_path_attachment_default models.L3outPathAttachment
+	var l3out_path_attachment_updated models.L3outPathAttachment
+	resourceName := "aci_l3out_path_attachment.test"
+	rName := makeTestVariable(acctest.RandString(5))
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3outPathAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccL3outPathAttachmentConfig(rName, rName, rName, rName, pathEp3, "ext-svi"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outPathAttachmentExists(resourceName, &l3out_path_attachment_default),
+				),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp3, "ext-svi", "mode", "untagged"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outPathAttachmentExists(resourceName, &l3out_path_attachment_updated),
+					resource.TestCheckResourceAttr(resourceName, "mode", "untagged"),
+					testAccCheckAciL3outPathAttachmentIdEqual(&l3out_path_attachment_default, &l3out_path_attachment_updated),
+				),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp3, "ext-svi", "mtu", "9216"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outPathAttachmentExists(resourceName, &l3out_path_attachment_updated),
+					resource.TestCheckResourceAttr(resourceName, "mtu", "9216"),
+					testAccCheckAciL3outPathAttachmentIdEqual(&l3out_path_attachment_default, &l3out_path_attachment_updated),
+				),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp3, "ext-svi", "mtu", "4896"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outPathAttachmentExists(resourceName, &l3out_path_attachment_updated),
+					resource.TestCheckResourceAttr(resourceName, "mtu", "4896"),
+					testAccCheckAciL3outPathAttachmentIdEqual(&l3out_path_attachment_default, &l3out_path_attachment_updated),
+				),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp3, "ext-svi", "target_dscp", "AF21"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outPathAttachmentExists(resourceName, &l3out_path_attachment_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF21"),
+					testAccCheckAciL3outPathAttachmentIdEqual(&l3out_path_attachment_default, &l3out_path_attachment_updated),
+				),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp3, "ext-svi", "target_dscp", "AF31"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outPathAttachmentExists(resourceName, &l3out_path_attachment_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF31"),
+					testAccCheckAciL3outPathAttachmentIdEqual(&l3out_path_attachment_default, &l3out_path_attachment_updated),
+				),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp3, "ext-svi", "target_dscp", "AF41"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outPathAttachmentExists(resourceName, &l3out_path_attachment_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "AF41"),
+					testAccCheckAciL3outPathAttachmentIdEqual(&l3out_path_attachment_default, &l3out_path_attachment_updated),
+				),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp3, "ext-svi", "target_dscp", "CS0"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outPathAttachmentExists(resourceName, &l3out_path_attachment_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "CS0"),
+					testAccCheckAciL3outPathAttachmentIdEqual(&l3out_path_attachment_default, &l3out_path_attachment_updated),
+				),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp3, "ext-svi", "target_dscp", "EF"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outPathAttachmentExists(resourceName, &l3out_path_attachment_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "EF"),
+					testAccCheckAciL3outPathAttachmentIdEqual(&l3out_path_attachment_default, &l3out_path_attachment_updated),
+				),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp3, "ext-svi", "target_dscp", "VA"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciL3outPathAttachmentExists(resourceName, &l3out_path_attachment_updated),
+					resource.TestCheckResourceAttr(resourceName, "target_dscp", "VA"),
+					testAccCheckAciL3outPathAttachmentIdEqual(&l3out_path_attachment_default, &l3out_path_attachment_updated),
+				),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentConfig(rName, rName, rName, rName, pathEp3, "ext-svi"),
+			},
+		},
+	})
+}
+
+func TestAccAciL3outPathAttachment_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciL3outPathAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccL3outPathAttachmentConfig(rName, rName, rName, rName, pathEp4, "ext-svi"),
+			},
+			{
+				Config:      CreateAccL3outPathAttachmentWithInValidParentDn(rName, pathEp4),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp4, "ext-svi", "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp4, "ext-svi", "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp4, "ext-svi", "addr", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp4, "ext-svi", "autostate", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp4, "ext-svi", "encap", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp4, "ext-svi", "encap_scope", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp4, "ext-svi", "ipv6_dad", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp4, "ext-svi", "ll_addr", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+
+			{
+				Config:      CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp4, "ext-svi", "mac", acctest.RandStringFromCharSet(5, "ghijklmnopqrstuvwxyz")),
+				ExpectError: regexp.MustCompile(`invalid MAC format`),
+			},
+
+			{
+				Config:      CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp4, "ext-svi", "mode", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+
+			{
+				Config:      CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp4, "ext-svi", "mtu", randomValue),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp4, "ext-svi", "mtu", "575"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+			{
+				Config:      CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp4, "ext-svi", "mtu", "9217"),
+				ExpectError: regexp.MustCompile(`out of range`),
+			},
+
+			{
+				Config:      CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp4, "ext-svi", "target_dscp", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccL3outPathAttachmentUpdatedAttr(rName, rName, rName, rName, pathEp4, "ext-svi", randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccL3outPathAttachmentConfig(rName, rName, rName, rName, pathEp4, "ext-svi"),
+			},
+		},
+	})
+}
+
+func testAccCheckAciL3outPathAttachmentExists(name string, l3out_path_attachment *models.L3outPathAttachment) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("L3out Path Attachment %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No L3out Path Attachment dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		l3out_path_attachmentFound := models.L3outPathAttachmentFromContainer(cont)
+		if l3out_path_attachmentFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("L3out Path Attachment %s not found", rs.Primary.ID)
+		}
+		*l3out_path_attachment = *l3out_path_attachmentFound
+		return nil
+	}
+}
+
+func testAccCheckAciL3outPathAttachmentDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing l3out_path_attachment destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_l3out_path_attachment" {
+			cont, err := client.Get(rs.Primary.ID)
+			l3out_path_attachment := models.L3outPathAttachmentFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("L3out Path Attachment %s Still exists", l3out_path_attachment.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciL3outPathAttachmentIdEqual(m1, m2 *models.L3outPathAttachment) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("l3out_path_attachment DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciL3outPathAttachmentIdNotEqual(m1, m2 *models.L3outPathAttachment) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("l3out_path_attachment DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateL3outPathAttachmentWithoutRequired(fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn, instType, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing l3out_path_attachment creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+		
+	}	
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	`
+	switch attrName {
+	case "logical_interface_profile_dn":
+		rBlock += `
+	resource "aci_l3out_path_attachment" "test" {
+	#	logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		target_dn  = "%s"
+		if_inst_t = "%s"
+	}
+		`
+	case "target_dn":
+		rBlock += `
+	resource "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+	#	target_dn  = "%s"
+		if_inst_t = "%s"
+	}
+		`
+	case "if_inst_t":
+		rBlock += `
+	resource "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		target_dn  = "%s"
+	#	if_inst_t = "%s"
+	}
+		`
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn, instType)
+}
+
+func CreateAccL3outPathAttachmentConfigWithUpdatedIfInstT(fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn, ifInstT string) string {
+	fmt.Println("=== STEP  testing l3out_path_attachment creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		target_dn  = "%s"
+		if_inst_t = "%s"
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn, ifInstT)
+	return resource
+}
+func CreateAccL3outPathAttachmentConfigWithRequiredParams(rName, tdn, instType string) string {
+	fmt.Printf("=== STEP  testing l3out_path_attachment creation with parent resource name %s, target_dn %s and if_inst_t %s\n", rName, tdn, instType)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		target_dn  = "%s"
+		if_inst_t = "%s"
+	}
+	`, rName, rName, rName, rName, tdn, instType)
+	return resource
+}
+
+func CreateAccL3outPathAttachmentConfig(fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn, instType string) string {
+	fmt.Println("=== STEP  testing l3out_path_attachment creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		target_dn  = "%s"
+		if_inst_t = "%s"
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn, instType)
+	return resource
+}
+
+func CreateAccL3outPathAttachmentWithInValidParentDn(rName, tDn string) string {
+	fmt.Println("=== STEP  Negative Case: testing l3out_path_attachment creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_tenant" "test"{
+		name = "%s"
+	}
+	resource "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = aci_tenant.test.id
+		target_dn  = "%s"
+		if_inst_t = "ext-svi"	
+	}
+	`, rName, tDn)
+	return resource
+}
+
+func CreateAccL3outPathAttachmentConfigWithOptionalValues(fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn, instType string) string {
+	fmt.Println("=== STEP  Basic: testing l3out_path_attachment creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = "${aci_logical_interface_profile.test.id}"
+		target_dn  = "%s"
+		if_inst_t = "%s"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		addr = "10.20.30.40/16"
+		autostate = "enabled"
+		encap_scope = "ctx"
+		ipv6_dad = "disabled"
+		ll_addr = "fe80::1"
+		mac = "00:22:BD:F8:19:F0"
+		mode = "native"
+		mtu = "576"
+		target_dscp = "AF11"
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn, instType)
+
+	return resource
+}
+
+func CreateAccL3outPathAttachmentRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing l3out_path_attachment updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_l3out_path_attachment" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		addr = ""
+		autostate = "enabled"
+		encap = ""
+		encap_scope = "ctx"
+		ipv6_dad = "disabled"
+		ll_addr = ""
+		mac = ""
+		mode = "native"
+		mtu = "577"
+		target_dscp = "1"
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccL3outPathAttachmentUpdatedAttr(fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn, instType, attribute, value string) string {
+	fmt.Printf("=== STEP  testing l3out_path_attachment attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	
+	}
+	
+	resource "aci_l3_outside" "test" {
+		name 		= "%s"
+		tenant_dn = aci_tenant.test.id
+	}
+	
+	resource "aci_logical_node_profile" "test" {
+		name 		= "%s"
+		l3_outside_dn = aci_l3_outside.test.id
+	}
+	
+	resource "aci_logical_interface_profile" "test" {
+		name 		= "%s"
+		logical_node_profile_dn = aci_logical_node_profile.test.id
+	}
+	
+	resource "aci_l3out_path_attachment" "test" {
+		logical_interface_profile_dn  = aci_logical_interface_profile.test.id
+		target_dn  = "%s"
+		if_inst_t = "%s"
+		%s = "%s"
+	}
+	`, fvTenantName, l3extOutName, l3extLNodePName, l3extLIfPName, tDn, instType, attribute, value)
+	return resource
+}


### PR DESCRIPTION
=== RUN   TestAccAciL3outPathAttachmentDataSource_Basic
=== STEP  Basic: testing l3out_path_attachment creation without  logical_interface_profile_dn
=== STEP  Basic: testing l3out_path_attachment creation without  target_dn
=== STEP  testing l3out_path_attachment Data Source with required arguments only
=== STEP  testing l3out_path_attachment Data Source with random attribute
=== STEP  testing l3out_path_attachment Data Source with Invalid Parent Dn
=== STEP  testing l3out_path_attachment Data Source with updated resource
=== PAUSE TestAccAciL3outPathAttachmentDataSource_Basic
=== RUN   TestAccAciL3outPathAttachment_Basic
=== STEP  Basic: testing l3out_path_attachment creation without  logical_interface_profile_dn
=== STEP  Basic: testing l3out_path_attachment creation without  target_dn
=== STEP  Basic: testing l3out_path_attachment creation without  if_inst_t
=== STEP  testing l3out_path_attachment creation with required arguments only
=== STEP  Basic: testing l3out_path_attachment creation with optional parameters
=== STEP  Basic: testing l3out_path_attachment updation without required parameters
=== STEP  testing l3out_path_attachment creation with parent resource name acctest_81ey1, target_dn acctest_81ey1 and if_inst_t ext-svi
=== STEP  testing l3out_path_attachment creation with parent resource name acctest_81ey1, target_dn topology/pod-1/paths-101/pathep-[eth1/1] and if_inst_t acctest_81ey1
=== STEP  testing l3out_path_attachment creation with parent resource name acctest_81ey1, target_dn topology/pod-1/paths-101/pathep-[eth1/1] and if_inst_t l3-port
=== STEP  testing l3out_path_attachment creation with parent resource name acctest_81ey1, target_dn topology/pod-1/paths-101/pathep-[eth1/1] and if_inst_t sub-interface
=== STEP  testing l3out_path_attachment creation with parent resource name acctest_81ey1, target_dn topology/pod-1/paths-101/pathep-[eth1/1] and if_inst_t unspecified
=== STEP  testing l3out_path_attachment creation with required arguments only
=== STEP  testing l3out_path_attachment creation with parent resource name acctest_4noaz, target_dn topology/pod-1/paths-101/pathep-[eth1/1] and if_inst_t ext-svi
=== STEP  testing l3out_path_attachment creation with required arguments only
=== STEP  testing l3out_path_attachment creation with parent resource name acctest_4noaz, target_dn topology/pod-1/paths-101/pathep-[eth1/12] and if_inst_t ext-svi
=== STEP  testing l3out_path_attachment destroy
--- PASS: TestAccAciL3outPathAttachment_Basic (148.38s)
=== RUN   TestAccAciL3outPathAttachment_Update
=== STEP  testing l3out_path_attachment creation with required arguments only
=== STEP  testing l3out_path_attachment attribute: mode = untagged
=== STEP  testing l3out_path_attachment attribute: mtu = 9216
=== STEP  testing l3out_path_attachment attribute: mtu = 4896
=== STEP  testing l3out_path_attachment attribute: target_dscp = AF21
=== STEP  testing l3out_path_attachment attribute: target_dscp = AF31
=== STEP  testing l3out_path_attachment attribute: target_dscp = AF41
=== STEP  testing l3out_path_attachment attribute: target_dscp = CS0
=== STEP  testing l3out_path_attachment attribute: target_dscp = EF
=== STEP  testing l3out_path_attachment attribute: target_dscp = VA
=== STEP  testing l3out_path_attachment creation with required arguments only
=== STEP  testing l3out_path_attachment destroy
--- PASS: TestAccAciL3outPathAttachment_Update (129.39s)
=== RUN   TestAccAciL3outPathAttachment_Negative
=== STEP  testing l3out_path_attachment creation with required arguments only
=== STEP  Negative Case: testing l3out_path_attachment creation with invalid parent Dn
=== STEP  testing l3out_path_attachment attribute: description = s6v6t8jzdwlfsyjiojs62ofhwemf67numr4h7l9cm4kps0vlxgozo8a9isdp6e7b28gmb0sut3lwtee3ceoqphta93ud3620qyn6kensxtxrbi2hm1s8p3m86ixi4qort
=== STEP  testing l3out_path_attachment attribute: annotation = gvkq3nwck7k0anz30yo34ijdxkzckp94rueq33fbku9063v0gievm2dzofiihg7yvbm2s6uhuizl37m01wtkncd9ye4vhwtnidmwa07jw4kqa4y9mkl4sk0k13a7o0yc4
=== STEP  testing l3out_path_attachment attribute: addr = z0hio
=== STEP  testing l3out_path_attachment attribute: autostate = z0hio
=== STEP  testing l3out_path_attachment attribute: encap = z0hio
=== STEP  testing l3out_path_attachment attribute: encap_scope = z0hio
=== STEP  testing l3out_path_attachment attribute: ipv6_dad = z0hio
=== STEP  testing l3out_path_attachment attribute: ll_addr = z0hio
=== STEP  testing l3out_path_attachment attribute: mac = xpgpu
=== STEP  testing l3out_path_attachment attribute: mode = z0hio
=== STEP  testing l3out_path_attachment attribute: mtu = z0hio
=== STEP  testing l3out_path_attachment attribute: mtu = 575
=== STEP  testing l3out_path_attachment attribute: mtu = 9217
=== STEP  testing l3out_path_attachment attribute: target_dscp = z0hio
=== STEP  testing l3out_path_attachment attribute: iulin = z0hio
=== STEP  testing l3out_path_attachment creation with required arguments only
=== STEP  testing l3out_path_attachment destroy
--- PASS: TestAccAciL3outPathAttachment_Negative (88.01s)
=== CONT  TestAccAciL3outPathAttachmentDataSource_Basic
=== STEP  testing l3out_path_attachment destroy
--- PASS: TestAccAciL3outPathAttachmentDataSource_Basic (35.18s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   402.529s
