### PR TITLE
updated typo in l3extIp

### DIFF
--- a/testacc/resource_aci_l3extip_test.go
+++ b/testacc/resource_aci_l3extip_test.go
@@ -67,7 +67,7 @@ func TestAccAciL3outPathAttachmentSecondaryIp_Basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config:      CreateAccL3outPathAttachmentSecondaryIpWithInavalidIP(rName, pathEp1),
+				Config:      CreateAccL3outPathAttachmentSecondaryIpWithInvalidIP(rName, pathEp1),
 				ExpectError: regexp.MustCompile(`unknown property value (.)+`),
 			},
 
@@ -312,7 +312,7 @@ func CreateAccL3outPathAttachmentSecondaryIpConfigWithRequiredParams(name, tdn, 
 	return resource
 }
 
-func CreateAccL3outPathAttachmentSecondaryIpWithInavalidIP(name, tdn string) string {
+func CreateAccL3outPathAttachmentSecondaryIpWithInvalidIP(name, tdn string) string {
 	fmt.Println("=== STEP  testing l3out_path_attachment_secondary_ip creation with invalid ip")
 	resource := fmt.Sprintf(`
 	resource "aci_tenant" "test" {


### PR DESCRIPTION
=== RUN   TestAccAciL3outPathAttachmentSecondaryIp_Basic
=== STEP  Basic: testing l3out_path_attachment_secondary_ip creation without  addr
=== STEP  Basic: testing l3out_path_attachment_secondary_ip creation without  l3out_path_attachment_dn
=== STEP  testing l3out_path_attachment_secondary_ip creation with required arguments only
=== STEP  Basic: testing l3out_path_attachment_secondary_ip creation with optional parameters
=== STEP  testing l3out_path_attachment_secondary_ip creation with invalid ip
=== STEP  Basic: testing l3out_path_attachment_secondary_ip updation without required parameters
=== STEP  testing l3out_path_attachment_secondary_ip creation with parent resource name acctest_9lhhg, tdn topology/pod-1/paths-101/pathep-[eth1/1] and addr 10.1.47.134/16
=== STEP  testing l3out_path_attachment_secondary_ip creation with required arguments only
=== STEP  testing l3out_path_attachment_secondary_ip creation with parent resource name acctest_xnajd, tdn topology/pod-1/paths-101/pathep-[eth1/1] and addr 10.0.230.19/16
=== PAUSE TestAccAciL3outPathAttachmentSecondaryIp_Basic
=== CONT  TestAccAciL3outPathAttachmentSecondaryIp_Basic
=== STEP  testing l3out_path_attachment_secondary_ip destroy
--- PASS: TestAccAciL3outPathAttachmentSecondaryIp_Basic (84.07s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   85.634s
