### PR TITLE
Added Cloud AWS Provider and Updated x509 Cert

### DIFF
--- a/testacc/data_source_aci_aaaConsoleAuth_test.go
+++ b/testacc/data_source_aci_aaaConsoleAuth_test.go
@@ -52,7 +52,7 @@ func TestAccAciConsoleAuthenticationDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccAciConsoleAuthenticationConfigDataSource() string {
-	fmt.Println("=== STEP  Testing console_authentication Data Source with required arguments only")
+	fmt.Println("=== STEP  Testing console_authentication Data Source")
 	resource := fmt.Sprintf(`
 	resource "aci_console_authentication" "test" {}
 

--- a/testacc/data_source_aci_aaadefaultauth_test.go
+++ b/testacc/data_source_aci_aaadefaultauth_test.go
@@ -53,7 +53,7 @@ func TestAccAciDefaultAuthenticationDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccDefaultAuthenticationConfigDataSource() string {
-	fmt.Println("=== STEP  testing default_authentication Data Source with required arguments only")
+	fmt.Println("=== STEP  testing default_authentication Data Source")
 	resource := fmt.Sprint(`
 	
 	resource "aci_default_authentication" "test" {

--- a/testacc/data_source_aci_aaausercert_test.go
+++ b/testacc/data_source_aci_aaausercert_test.go
@@ -35,6 +35,7 @@ func TestAccAcix509CertificateDataSource_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(dataSourceName, "local_user_dn", resourceName, "local_user_dn"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name", resourceName, "name"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "data", resourceName, "data"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
 					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),

--- a/testacc/data_source_aci_aaauserep_test.go
+++ b/testacc/data_source_aci_aaauserep_test.go
@@ -77,7 +77,7 @@ func TestAccAciWebTokenDataDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccWebTokenDataConfigDataSource() string {
-	fmt.Println("=== STEP  testing global_security Data Source with required arguments only")
+	fmt.Println("=== STEP  testing global_security Data Source")
 	resource := fmt.Sprintf(`
 
 	resource "aci_global_security" "test" {

--- a/testacc/data_source_aci_cloudawsprovider_test.go
+++ b/testacc/data_source_aci_cloudawsprovider_test.go
@@ -1,0 +1,182 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccAciCloudAWSProviderDataSource_Basic(t *testing.T) {
+	resourceName := "aci_cloud_aws_provider.test"
+	dataSourceName := "data.aci_cloud_aws_provider.test"
+	randomParameter := acctest.RandStringFromCharSet(10, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(10)
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudAWSProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateCloudAWSProviderDSWithoutRequired(fvTenantName, "147258147369", "tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudAWSProviderConfigDataSource(fvTenantName, "147258147369"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "tenant_dn", resourceName, "tenant_dn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "description", resourceName, "description"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "name_alias", resourceName, "name_alias"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "access_key_id", resourceName, "access_key_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "account_id", resourceName, "account_id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "email", resourceName, "email"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "http_proxy", resourceName, "http_proxy"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "is_account_in_org", resourceName, "is_account_in_org"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "is_trusted", resourceName, "is_trusted"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "provider_id", resourceName, "provider_id"),
+				),
+			},
+			{
+				Config:      CreateAccCloudAWSProviderDataSourceUpdate(fvTenantName, "147258147369", randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config:      CreateAccCloudAWSProviderDSWithInvalidParentDn(fvTenantName, "147258147369"),
+				ExpectError: regexp.MustCompile(`(.)+ Object may not exists`),
+			},
+			{
+				Config: CreateAccCloudAWSProviderDataSourceUpdatedResource(fvTenantName, "147258147369", "annotation", "orchestrator:terraform-testacc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceName, "annotation", resourceName, "annotation"),
+				),
+			},
+		},
+	})
+}
+
+func CreateAccCloudAWSProviderConfigDataSource(fvTenantName, accId string) string {
+	fmt.Println("=== STEP  testing cloud_aws_provider Data Source with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_cloud_aws_provider" "test" {
+		tenant_dn  = aci_tenant.test.id
+		account_id = "%s"
+		access_key_id = "AKIA5EO6KGEA74MUY673"
+		secret_access_key = "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"
+	}
+
+	data "aci_cloud_aws_provider" "test" {
+		tenant_dn  = aci_tenant.test.id
+		depends_on = [ aci_cloud_aws_provider.test ]
+	}
+	`, fvTenantName, accId)
+	return resource
+}
+
+func CreateCloudAWSProviderDSWithoutRequired(fvTenantName, accId, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_aws_provider Data Source without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_cloud_aws_provider" "test" {
+		tenant_dn  = aci_tenant.test.id
+		account_id = "%s"
+		access_key_id = "AKIA5EO6KGEA74MUY673"
+		secret_access_key = "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"
+	}
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	data "aci_cloud_aws_provider" "test" {
+	#	tenant_dn  = aci_tenant.test.id
+	
+		depends_on = [ aci_cloud_aws_provider.test ]
+	}
+		`
+
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, accId)
+}
+
+func CreateAccCloudAWSProviderDSWithInvalidParentDn(fvTenantName, accId string) string {
+	fmt.Println("=== STEP  testing cloud_aws_provider Data Source with Invalid Parent Dn")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_cloud_aws_provider" "test" {
+		tenant_dn  = aci_tenant.test.id
+		account_id = "%s"
+		access_key_id = "AKIA5EO6KGEA74MUY673"
+		secret_access_key = "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"
+	}
+
+	data "aci_cloud_aws_provider" "test" {
+		tenant_dn  = "${aci_tenant.test.id}_invalid"
+		depends_on = [ aci_cloud_aws_provider.test ]
+	}
+	`, fvTenantName, accId)
+	return resource
+}
+
+func CreateAccCloudAWSProviderDataSourceUpdate(fvTenantName, accId, key, value string) string {
+	fmt.Println("=== STEP  testing cloud_aws_provider Data Source with random attribute")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_cloud_aws_provider" "test" {
+		tenant_dn  = aci_tenant.test.id
+		account_id = "%s"
+		access_key_id = "AKIA5EO6KGEA74MUY673"
+		secret_access_key = "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"
+	}
+
+	data "aci_cloud_aws_provider" "test" {
+		tenant_dn  = aci_tenant.test.id
+		%s = "%s"
+		depends_on = [ aci_cloud_aws_provider.test ]
+	}
+	`, fvTenantName, accId, key, value)
+	return resource
+}
+
+func CreateAccCloudAWSProviderDataSourceUpdatedResource(fvTenantName, accId, key, value string) string {
+	fmt.Println("=== STEP  testing cloud_aws_provider Data Source with updated resource")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_cloud_aws_provider" "test" {
+		tenant_dn  = aci_tenant.test.id
+		account_id = "%s"
+		access_key_id = "AKIA5EO6KGEA74MUY673"
+		secret_access_key = "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"
+		%s = "%s"
+	}
+
+	data "aci_cloud_aws_provider" "test" {
+		tenant_dn  = aci_tenant.test.id
+		depends_on = [ aci_cloud_aws_provider.test ]
+	}
+	`, fvTenantName, accId, key, value)
+	return resource
+}

--- a/testacc/data_source_aci_edrErrDisRecoverPol_test.go
+++ b/testacc/data_source_aci_edrErrDisRecoverPol_test.go
@@ -50,7 +50,7 @@ func TestAccAciErrorDisableRecoveryDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccErrorDisabledRecoveryConfigDataSource() string {
-	fmt.Println("=== STEP  Testing error_disable_recovery Data Source with required arguments only")
+	fmt.Println("=== STEP  Testing error_disable_recovery Data Source")
 	resource := fmt.Sprintf(`
 
 	resource "aci_error_disable_recovery" "test" {

--- a/testacc/data_source_aci_epcontrolp_test.go
+++ b/testacc/data_source_aci_epcontrolp_test.go
@@ -53,7 +53,7 @@ func TestAccAciEndpointControlsDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccEndpointControlsConfigDataSource() string {
-	fmt.Println("=== STEP  testing endpoint_controls Data Source with required arguments only")
+	fmt.Println("=== STEP  testing endpoint_controls Data Source")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_endpoint_controls" "test" {

--- a/testacc/data_source_aci_eploopprotectp_test.go
+++ b/testacc/data_source_aci_eploopprotectp_test.go
@@ -54,7 +54,7 @@ func TestAccAciEndpointLoopProtectionDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccEndpointLoopProtectionConfigDataSource() string {
-	fmt.Println("=== STEP  testing endpoint_loop_protection Data Source with required arguments only")
+	fmt.Println("=== STEP  testing endpoint_loop_protection Data Source")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_endpoint_loop_protection" "test" {

--- a/testacc/data_source_aci_infraporttrackpol_test.go
+++ b/testacc/data_source_aci_infraporttrackpol_test.go
@@ -53,7 +53,7 @@ func TestAccAciPortTrackingDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccPortTrackingConfigDataSource() string {
-	fmt.Println("=== STEP  testing port_tracking Data Source with required arguments only")
+	fmt.Println("=== STEP  testing port_tracking Data Source")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_port_tracking" "test" {

--- a/testacc/data_source_aci_infrasetpol_test.go
+++ b/testacc/data_source_aci_infrasetpol_test.go
@@ -61,7 +61,7 @@ func TestAccAciFabricWideSettingsPolicyDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccFabricWideSettingsPolicyConfigDataSource() string {
-	fmt.Println("=== STEP  testing fabric_wide_settings_policy Data Source with required arguments only")
+	fmt.Println("=== STEP  testing fabric_wide_settings_policy Data Source")
 	resource := fmt.Sprintf(`
 
 	resource "aci_fabric_wide_settings" "test" {

--- a/testacc/data_source_aci_mcpinstpol_test.go
+++ b/testacc/data_source_aci_mcpinstpol_test.go
@@ -58,7 +58,7 @@ func TestAccAciMCPInstancePolicyDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccMCPInstancePolicyConfigDataSource(rName string) string {
-	fmt.Println("=== STEP  testing mcp_instance_policy Data Source with required arguments only")
+	fmt.Println("=== STEP  testing mcp_instance_policy Data Source")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_mcp_instance_policy" "test" {

--- a/testacc/data_source_aci_pkiexportencryptionkey_test.go
+++ b/testacc/data_source_aci_pkiexportencryptionkey_test.go
@@ -53,7 +53,7 @@ func TestAccAciAESEncryptionPassphraseandKeysforConfigExportImportDataSource_Bas
 }
 
 func CreateAccAESEncryptionPassphraseandKeysforConfigExportImportConfigDataSource() string {
-	fmt.Println("=== STEP  testing encryption_key Data Source with required arguments only")
+	fmt.Println("=== STEP  testing encryption_key Data Source")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_encryption_key" "test" {

--- a/testacc/data_source_aci_qosinstpol_test.go
+++ b/testacc/data_source_aci_qosinstpol_test.go
@@ -58,7 +58,7 @@ func TestAccAciQOSInstancePolicyDataSource_Basic(t *testing.T) {
 }
 
 func CreateAccQOSInstancePolicyConfigDataSource() string {
-	fmt.Println("=== STEP  testing qos_instance_policy Data Source with required arguments only")
+	fmt.Println("=== STEP  testing qos_instance_policy Data Source")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_qos_instance_policy" "test" {}

--- a/testacc/resource_aci_aaaConsoleAuth_test.go
+++ b/testacc/resource_aci_aaaConsoleAuth_test.go
@@ -246,7 +246,7 @@ func testAccCheckAccAciConsoleAuthenticationIdEqual(m1, m2 *models.ConsoleAuthen
 }
 
 func CreateAccAciConsoleAuthenticationConfig() string {
-	fmt.Println("=== STEP  Testing console_authentication creation with required arguments only")
+	fmt.Println("=== STEP  Testing console_authentication creation")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_console_authentication" "test" {}
@@ -281,4 +281,3 @@ func CreateAccAciConsoleAuthenticationUpdatedAttr(attribute, value string) strin
 	`, attribute, value)
 	return resource
 }
-

--- a/testacc/resource_aci_aaadefaultauth_test.go
+++ b/testacc/resource_aci_aaadefaultauth_test.go
@@ -228,7 +228,7 @@ func testAccCheckAciDefaultAuthenticationIdEqual(m1, m2 *models.DefaultAuthentic
 }
 
 func CreateAccDefaultAuthenticationConfig() string {
-	fmt.Println("=== STEP  testing default_authentication creation with required arguments only")
+	fmt.Println("=== STEP  testing default_authentication creation")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_default_authentication" "test" {

--- a/testacc/resource_aci_aaausercert_test.go
+++ b/testacc/resource_aci_aaausercert_test.go
@@ -69,6 +69,10 @@ func TestAccAcix509Certificate_Basic(t *testing.T) {
 				ExpectError: regexp.MustCompile(`property name of (.)+ failed validation`),
 			},
 			{
+				Config:      CreateAccx509CertificateConfigUpdatedData(aaaUserName, rName),
+				ExpectError: regexp.MustCompile(`Validation of (.)+ X509 Certificate submitted failed - error returned by low level validation routine is`),
+			},
+			{
 				Config:      CreateAccx509CertificateRemovingRequiredField(),
 				ExpectError: regexp.MustCompile(`Missing required argument`),
 			},
@@ -293,6 +297,24 @@ func CreateAccx509CertificateConfigUpdatedName(aaaUserName, rName string) string
 		EOF
 	}
 	`, aaaUserName, rName, certificate_terraformuser)
+	return resource
+}
+
+func CreateAccx509CertificateConfigUpdatedData(aaaUserName, rName string) string {
+	fmt.Println("=== STEP  testing x509_certificate creation with invalid Data = ", rName)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_local_user" "test" {
+		name 		= "%s"
+		pwd = "Test_coverage"
+	}
+	
+	resource "aci_x509_certificate" "test" {
+		local_user_dn  = aci_local_user.test.id
+		name  = "%s"
+		data = "%s"
+	}
+	`, aaaUserName, rName, rName)
 	return resource
 }
 

--- a/testacc/resource_aci_aaauserep_test.go
+++ b/testacc/resource_aci_aaauserep_test.go
@@ -624,7 +624,7 @@ func testAccCheckAciWebTokenDataIdEqual(m1, m2 *models.UserManagement) resource.
 }
 
 func CreateAccWebTokenDataConfig() string {
-	fmt.Println("=== STEP  testing global_security creation with required arguments only")
+	fmt.Println("=== STEP  testing global_security creation")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_global_security" "test" {}

--- a/testacc/resource_aci_cloudawsprovider_test.go
+++ b/testacc/resource_aci_cloudawsprovider_test.go
@@ -1,0 +1,385 @@
+package testacc
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/ciscoecosystem/aci-go-client/client"
+	"github.com/ciscoecosystem/aci-go-client/models"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccAciCloudAWSProvider_Basic(t *testing.T) {
+	var cloud_aws_provider_default models.CloudAWSProvider
+	var cloud_aws_provider_updated models.CloudAWSProvider
+	resourceName := "aci_cloud_aws_provider.test"
+	rNameUpdated := makeTestVariable(acctest.RandString(5))
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudAWSProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      CreateCloudAWSProviderWithoutRequired(fvTenantName, "147258369147", "tenant_dn"),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudAWSProviderConfig(fvTenantName, "147258369147"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudAWSProviderExists(resourceName, &cloud_aws_provider_default),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", fvTenantName)),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", ""),
+					resource.TestCheckResourceAttr(resourceName, "access_key_id", "AKIA5EO6KGEA74MUY673"),
+					resource.TestCheckResourceAttr(resourceName, "account_id", "147258369147"),
+					resource.TestCheckResourceAttr(resourceName, "email", ""),
+					resource.TestCheckResourceAttr(resourceName, "http_proxy", ""),
+					resource.TestCheckResourceAttr(resourceName, "is_account_in_org", "no"),
+					resource.TestCheckResourceAttr(resourceName, "is_trusted", "no"),
+					resource.TestCheckResourceAttr(resourceName, "provider_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "region", ""),
+				),
+			},
+			{
+				Config: CreateAccCloudAWSProviderConfigWithOptionalValues(fvTenantName, "147258369147"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudAWSProviderExists(resourceName, &cloud_aws_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", fvTenantName)),
+					resource.TestCheckResourceAttr(resourceName, "annotation", "orchestrator:terraform_testacc"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created while acceptance testing"),
+					resource.TestCheckResourceAttr(resourceName, "name_alias", "test_cloud_aws_provider"),
+					resource.TestCheckResourceAttr(resourceName, "access_key_id", "AKIA5EO6KGEA74MUY656"),
+					resource.TestCheckResourceAttr(resourceName, "account_id", "147258369147"),
+					resource.TestCheckResourceAttr(resourceName, "email", "testmail"),
+					resource.TestCheckResourceAttr(resourceName, "http_proxy", "http_proxy_test"),
+					resource.TestCheckResourceAttr(resourceName, "is_account_in_org", "yes"),
+					resource.TestCheckResourceAttr(resourceName, "is_trusted", "no"),
+					resource.TestCheckResourceAttr(resourceName, "provider_id", "provider_test"),
+					resource.TestCheckResourceAttr(resourceName, "region", ""),
+					testAccCheckAciCloudAWSProviderIdEqual(&cloud_aws_provider_default, &cloud_aws_provider_updated),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"secret_access_key"},
+			},
+			{
+				Config:      CreateAccCloudAWSProviderRemovingRequiredField(),
+				ExpectError: regexp.MustCompile(`Missing required argument`),
+			},
+			{
+				Config: CreateAccCloudAWSProviderConfigWithRequiredParams(rNameUpdated, "147258369147"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudAWSProviderExists(resourceName, &cloud_aws_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "tenant_dn", fmt.Sprintf("uni/tn-%s", rNameUpdated)),
+					testAccCheckAciCloudAWSProviderIdNotEqual(&cloud_aws_provider_default, &cloud_aws_provider_updated),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAciCloudAWSProvider_Update(t *testing.T) {
+	var cloud_aws_provider_default models.CloudAWSProvider
+	var cloud_aws_provider_updated models.CloudAWSProvider
+	resourceName := "aci_cloud_aws_provider.test"
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudAWSProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccCloudAWSProviderConfig(fvTenantName, "147258369258"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudAWSProviderExists(resourceName, &cloud_aws_provider_default),
+				),
+			},
+			{
+				Config: CreateAccCloudAWSProviderUpdatedAttr(fvTenantName, "147258369258", "is_trusted", "yes"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAciCloudAWSProviderExists(resourceName, &cloud_aws_provider_updated),
+					resource.TestCheckResourceAttr(resourceName, "is_trusted", "yes"),
+					testAccCheckAciCloudAWSProviderIdEqual(&cloud_aws_provider_default, &cloud_aws_provider_updated),
+				),
+			},
+			{
+				Config: CreateAccCloudAWSProviderConfig(fvTenantName, "147258369258"),
+			},
+		},
+	})
+}
+
+func TestAccAciCloudAWSProvider_Negative(t *testing.T) {
+	rName := makeTestVariable(acctest.RandString(5))
+	fvTenantName := makeTestVariable(acctest.RandString(5))
+	randomParameter := acctest.RandStringFromCharSet(5, "abcdefghijklmnopqrstuvwxyz")
+	randomValue := acctest.RandString(5)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testAccCheckAciCloudAWSProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: CreateAccCloudAWSProviderConfig(fvTenantName, "147258369369"),
+			},
+			{
+				Config:      CreateAccCloudAWSProviderWithInValidParentDn(rName, "147258369369"),
+				ExpectError: regexp.MustCompile(`unknown property value`),
+			},
+			{
+				Config:      CreateAccCloudAWSProviderUpdatedAttr(fvTenantName, "147258369369", "description", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccCloudAWSProviderUpdatedAttr(fvTenantName, "147258369369", "annotation", acctest.RandString(129)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccCloudAWSProviderUpdatedAttr(fvTenantName, "147258369369", "name_alias", acctest.RandString(64)),
+				ExpectError: regexp.MustCompile(`failed validation for value '(.)+'`),
+			},
+			{
+				Config:      CreateAccCloudAWSProviderUpdatedAttr(fvTenantName, "147258369369", "email", acctest.RandString(513)),
+				ExpectError: regexp.MustCompile(`property email of awsprovider failed validation for value`),
+			},
+			{
+				Config:      CreateAccCloudAWSProviderUpdatedAttr(fvTenantName, "147258369369", "http_proxy", acctest.RandString(513)),
+				ExpectError: regexp.MustCompile(`property httpProxy of awsprovider failed validation for value`),
+			},
+			{
+				Config:      CreateAccCloudAWSProviderUpdatedAttr(fvTenantName, "147258369369", "is_account_in_org", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccCloudAWSProviderUpdatedAttr(fvTenantName, "147258369369", "is_trusted", randomValue),
+				ExpectError: regexp.MustCompile(`expected(.)+ to be one of (.)+, got(.)+`),
+			},
+			{
+				Config:      CreateAccCloudAWSProviderUpdatedAttr(fvTenantName, "147258369369", "provider_id", acctest.RandString(513)),
+				ExpectError: regexp.MustCompile(`property providerId of awsprovider failed validation for value`),
+			},
+			{
+				Config:      CreateAccCloudAWSProviderUpdatedAttr(fvTenantName, "147258369369", randomParameter, randomValue),
+				ExpectError: regexp.MustCompile(`An argument named (.)+ is not expected here.`),
+			},
+			{
+				Config: CreateAccCloudAWSProviderConfig(fvTenantName, "147258369369"),
+			},
+		},
+	})
+}
+
+func testAccCheckAciCloudAWSProviderExists(name string, cloud_aws_provider *models.CloudAWSProvider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Cloud AWS Provider %s not found", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Cloud AWS Provider dn was set")
+		}
+
+		client := testAccProvider.Meta().(*client.Client)
+
+		cont, err := client.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		cloud_aws_providerFound := models.CloudAWSProviderFromContainer(cont)
+		if cloud_aws_providerFound.DistinguishedName != rs.Primary.ID {
+			return fmt.Errorf("Cloud AWS Provider %s not found", rs.Primary.ID)
+		}
+		*cloud_aws_provider = *cloud_aws_providerFound
+		return nil
+	}
+}
+
+func testAccCheckAciCloudAWSProviderDestroy(s *terraform.State) error {
+	fmt.Println("=== STEP  testing cloud_aws_provider destroy")
+	client := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "aci_cloud_aws_provider" {
+			cont, err := client.Get(rs.Primary.ID)
+			cloud_aws_provider := models.CloudAWSProviderFromContainer(cont)
+			if err == nil {
+				return fmt.Errorf("Cloud AWS Provider %s Still exists", cloud_aws_provider.DistinguishedName)
+			}
+		} else {
+			continue
+		}
+	}
+	return nil
+}
+
+func testAccCheckAciCloudAWSProviderIdEqual(m1, m2 *models.CloudAWSProvider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName != m2.DistinguishedName {
+			return fmt.Errorf("cloud_aws_provider DNs are not equal")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAciCloudAWSProviderIdNotEqual(m1, m2 *models.CloudAWSProvider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if m1.DistinguishedName == m2.DistinguishedName {
+			return fmt.Errorf("cloud_aws_provider DNs are equal")
+		}
+		return nil
+	}
+}
+
+func CreateCloudAWSProviderWithoutRequired(fvTenantName, accId, attrName string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_aws_provider creation without ", attrName)
+	rBlock := `
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	`
+	switch attrName {
+	case "tenant_dn":
+		rBlock += `
+	resource "aci_cloud_aws_provider" "test" {
+	#	tenant_dn  = aci_tenant.test.id
+		account_id = "%s"
+		access_key_id = "AKIA5EO6KGEA74MUY673"
+		secret_access_key = "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"
+	}
+		`
+
+	}
+	return fmt.Sprintf(rBlock, fvTenantName, accId)
+}
+
+func CreateAccCloudAWSProviderConfigWithRequiredParams(fvTenantName, accId string) string {
+	fmt.Println("=== STEP  testing cloud_aws_provider creation with updated naming arguments")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_cloud_aws_provider" "test" {
+		tenant_dn  = aci_tenant.test.id
+		account_id = "%s"
+		access_key_id = "AKIA5EO6KGEA74MUY673"
+		secret_access_key = "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"
+	}
+	`, fvTenantName, accId)
+	return resource
+}
+func CreateAccCloudAWSProviderConfig(fvTenantName, accId string) string {
+	fmt.Println("=== STEP  testing cloud_aws_provider creation with required arguments only")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_cloud_aws_provider" "test" {
+		tenant_dn  = aci_tenant.test.id
+		account_id = "%s"
+		access_key_id = "AKIA5EO6KGEA74MUY673"
+		secret_access_key = "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"
+	}
+	`, fvTenantName, accId)
+	return resource
+}
+
+func CreateAccCloudAWSProviderWithInValidParentDn(rName, accId string) string {
+	fmt.Println("=== STEP  Negative Case: testing cloud_aws_provider creation with invalid parent Dn")
+	resource := fmt.Sprintf(`
+	resource "aci_aaa_domain" "test"{
+		name = "%s"
+	}
+	resource "aci_cloud_aws_provider" "test" {
+		tenant_dn  = aci_aaa_domain.test.id	
+		account_id = "%s"
+		access_key_id = "AKIA5EO6KGEA74MUY673"
+		secret_access_key = "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"
+	}
+	`, rName, accId)
+	return resource
+}
+
+func CreateAccCloudAWSProviderConfigWithOptionalValues(fvTenantName, accId string) string {
+	fmt.Println("=== STEP  Basic: testing cloud_aws_provider creation with optional parameters")
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_cloud_aws_provider" "test" {
+		tenant_dn  = "${aci_tenant.test.id}"
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_cloud_aws_provider"
+		email = "testmail"
+		http_proxy = "http_proxy_test"
+		is_account_in_org = "yes"
+		is_trusted = "no"
+		provider_id = "provider_test"
+		region = ""
+		account_id = "%s"
+		access_key_id = "AKIA5EO6KGEA74MUY656"
+		secret_access_key = "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"
+	}
+	`, fvTenantName, accId)
+
+	return resource
+}
+
+func CreateAccCloudAWSProviderRemovingRequiredField() string {
+	fmt.Println("=== STEP  Basic: testing cloud_aws_provider updation without required parameters")
+	resource := fmt.Sprintf(`
+	resource "aci_cloud_aws_provider" "test" {
+		description = "created while acceptance testing"
+		annotation = "orchestrator:terraform_testacc"
+		name_alias = "test_cloud_aws_provider"
+		access_key_id = ""
+		account_id = ""
+		email = ""
+		http_proxy = ""
+		is_account_in_org = "yes"
+		is_trusted = "yes"
+		provider_id = ""
+		region = ""
+	}
+	`)
+
+	return resource
+}
+
+func CreateAccCloudAWSProviderUpdatedAttr(fvTenantName, accId, attribute, value string) string {
+	fmt.Printf("=== STEP  testing cloud_aws_provider attribute: %s = %s \n", attribute, value)
+	resource := fmt.Sprintf(`
+	
+	resource "aci_tenant" "test" {
+		name 		= "%s"
+	}
+	
+	resource "aci_cloud_aws_provider" "test" {
+		tenant_dn  = aci_tenant.test.id
+		account_id = "%s"
+		access_key_id = "AKIA5EO6KGEA74MUY673"
+		secret_access_key = "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"
+		%s = "%s"
+	}
+	`, fvTenantName, accId, attribute, value)
+	return resource
+}

--- a/testacc/resource_aci_edrErrDisRecoverPol_test.go
+++ b/testacc/resource_aci_edrErrDisRecoverPol_test.go
@@ -197,7 +197,7 @@ func testAccCheckAciErrorDisabledRecoveryIdEqual(m1, m2 *models.ErrorDisabledRec
 }
 
 func CreateAccErrorDisabledRecoveryConfig() string {
-	fmt.Println("=== STEP  Testing error_disable_recovery creation with required arguments only")
+	fmt.Println("=== STEP  Testing error_disable_recovery creation")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_error_disable_recovery" "test" {}

--- a/testacc/resource_aci_epcontrolp_test.go
+++ b/testacc/resource_aci_epcontrolp_test.go
@@ -257,7 +257,7 @@ func testAccCheckAciEndpointControlsIdEqual(m1, m2 *models.EndpointControlPolicy
 }
 
 func CreateAccEndpointControlsConfig() string {
-	fmt.Println("=== STEP  testing endpoint_controls creation with required arguments only")
+	fmt.Println("=== STEP  testing endpoint_controls creation")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_endpoint_controls" "test" {

--- a/testacc/resource_aci_eploopprotectp_test.go
+++ b/testacc/resource_aci_eploopprotectp_test.go
@@ -264,7 +264,7 @@ func testAccCheckAciEndpointLoopProtectionIdEqual(m1, m2 *models.EPLoopProtectio
 }
 
 func CreateAccEndpointLoopProtectionConfig() string {
-	fmt.Println("=== STEP  testing endpoint_loop_protection creation with required arguments only")
+	fmt.Println("=== STEP  testing endpoint_loop_protection creation")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_endpoint_loop_protection" "test" {

--- a/testacc/resource_aci_infraporttrackpol_test.go
+++ b/testacc/resource_aci_infraporttrackpol_test.go
@@ -264,7 +264,7 @@ func testAccCheckAciPortTrackingIdEqual(m1, m2 *models.PortTracking) resource.Te
 }
 
 func CreateAccPortTrackingConfig() string {
-	fmt.Println("=== STEP  testing port_tracking creation with required arguments only")
+	fmt.Println("=== STEP  testing port_tracking creation")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_port_tracking" "test" {}

--- a/testacc/resource_aci_infrasetpol_test.go
+++ b/testacc/resource_aci_infrasetpol_test.go
@@ -299,7 +299,7 @@ func testAccCheckAciFabricWideSettingsPolicyIdEqual(m1, m2 *models.FabricWideSet
 }
 
 func CreateAccFabricWideSettingsPolicyConfig() string {
-	fmt.Println("=== STEP  testing fabric_wide_settings_policy creation with required arguments only")
+	fmt.Println("=== STEP  testing fabric_wide_settings_policy creation")
 	resource := fmt.Sprintf(`
 
 	resource "aci_fabric_wide_settings" "test" {}

--- a/testacc/resource_aci_mcpinstpol_test.go
+++ b/testacc/resource_aci_mcpinstpol_test.go
@@ -394,7 +394,7 @@ func CreateMCPInstancePolicyWithoutRequired(key, attrName string) string {
 }
 
 func CreateAccMCPInstancePolicyConfig(key string) string {
-	fmt.Println("=== STEP  testing mcp_instance_policy creation with required arguments only")
+	fmt.Println("=== STEP  testing mcp_instance_policy creation")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_mcp_instance_policy" "test" {

--- a/testacc/resource_aci_pkiexportencryptionkey_test.go
+++ b/testacc/resource_aci_pkiexportencryptionkey_test.go
@@ -206,7 +206,7 @@ func testAccCheckAciAESEncryptionPassphraseandKeysforConfigExportImportIdEqual(m
 }
 
 func CreateAccAESEncryptionPassphraseandKeysforConfigExportImportConfig() string {
-	fmt.Println("=== STEP  Basic: testing encryption_key creation with required parameters")
+	fmt.Println("=== STEP  Basic: testing encryption_key")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_encryption_key" "test" {}

--- a/testacc/resource_aci_qosinstpol_test.go
+++ b/testacc/resource_aci_qosinstpol_test.go
@@ -393,7 +393,7 @@ func restoreQOSInstancePolicy(QOSInstancePolicy *models.QOSInstancePolicy) strin
 }
 
 func CreateAccQOSInstancePolicyConfig() string {
-	fmt.Println("=== STEP  testing qos_instance_policy creation with required arguments only")
+	fmt.Println("=== STEP  testing qos_instance_policy creation")
 	resource := fmt.Sprintf(`
 	
 	resource "aci_qos_instance_policy" "test" {


### PR DESCRIPTION
$ go test -v -run TestAccAcix509Certificate_Basic -timeout=60m
=== RUN   TestAccAcix509Certificate_Basic
=== STEP  Basic: testing x509_certificate creation without  local_user_dn
=== STEP  Basic: testing x509_certificate creation without  name
=== STEP  Basic: testing x509_certificate creation without  data
=== STEP  testing x509_certificate creation with required arguments only
=== STEP  Basic: testing x509_certificate creation with optional parameters
=== STEP  testing x509_certificate creation with invalid name =  wh7gevrxap34dipocfh6smq8zpmf0a3qvepnv3ys23zuqu84spknfr96boqczfxhd
=== STEP  testing x509_certificate creation with invalid Data =  acctest_adp40
=== STEP  Basic: testing x509_certificate updation without required parameters
=== STEP  testing x509_certificate creation with updated naming arguments
=== STEP  testing x509_certificate creation with required arguments only
=== STEP  testing x509_certificate creation with updated naming arguments
=== PAUSE TestAccAcix509Certificate_Basic
=== CONT  TestAccAcix509Certificate_Basic
=== STEP  testing x509_certificate destroy
--- PASS: TestAccAcix509Certificate_Basic (217.15s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   219.144s



$ go test -v -run TestAccAcix509CertificateDataSource_Basic -timeout=60m
=== RUN   TestAccAcix509CertificateDataSource_Basic
=== STEP  Basic: testing x509_certificate Data Source without  local_user_dn
=== STEP  Basic: testing x509_certificate Data Source without  name
=== STEP  testing x509_certificate Data Source with required arguments only
=== STEP  testing x509_certificate Data Source with random attribute
=== STEP  testing x509_certificate Data Source with Invalid Parent Dn
=== STEP  testing x509_certificate Data Source with updated resource
=== PAUSE TestAccAcix509CertificateDataSource_Basic
=== CONT  TestAccAcix509CertificateDataSource_Basic
=== STEP  testing x509_certificate destroy
--- PASS: TestAccAcix509CertificateDataSource_Basic (89.26s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   90.882s


$ go test -v -run TestAccAciCloudAWSProvider_Basic -timeout=60m
=== RUN   TestAccAciCloudAWSProvider_Basic
=== STEP  Basic: testing cloud_aws_provider creation without  tenant_dn
=== STEP  testing cloud_aws_provider creation with required arguments only
=== STEP  Basic: testing cloud_aws_provider creation with optional parameters
=== STEP  Basic: testing cloud_aws_provider updation without required parameters
=== STEP  testing cloud_aws_provider creation with updated naming arguments
=== PAUSE TestAccAciCloudAWSProvider_Basic
=== CONT  TestAccAciCloudAWSProvider_Basic
=== STEP  testing cloud_aws_provider destroy
--- PASS: TestAccAciCloudAWSProvider_Basic (127.56s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   131.437s

$ go test -v -run TestAccAciCloudAWSProviderDataSource_Basic -timeout=60m
=== RUN   TestAccAciCloudAWSProviderDataSource_Basic
=== STEP  Basic: testing cloud_aws_provider Data Source without  tenant_dn
=== STEP  testing cloud_aws_provider Data Source with required arguments only
=== STEP  testing cloud_aws_provider Data Source with random attribute
=== STEP  testing cloud_aws_provider Data Source with Invalid Parent Dn
=== STEP  testing cloud_aws_provider Data Source with updated resource
=== PAUSE TestAccAciCloudAWSProviderDataSource_Basic
=== CONT  TestAccAciCloudAWSProviderDataSource_Basic
=== STEP  testing cloud_aws_provider destroy
--- PASS: TestAccAciCloudAWSProviderDataSource_Basic (97.19s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   99.700s

$ go test -v -run TestAccAciCloudAWSProvider_Update -timeout=60m
=== RUN   TestAccAciCloudAWSProvider_Update
=== STEP  testing cloud_aws_provider creation with required arguments only
=== STEP  testing cloud_aws_provider attribute: is_trusted = yes
=== STEP  testing cloud_aws_provider creation with required arguments only
=== PAUSE TestAccAciCloudAWSProvider_Update
=== CONT  TestAccAciCloudAWSProvider_Update
=== STEP  testing cloud_aws_provider destroy
--- PASS: TestAccAciCloudAWSProvider_Update (157.30s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   160.490s

$ go test -v -run TestAccAciCloudAWSProvider_Negative -timeout=60m
=== RUN   TestAccAciCloudAWSProvider_Negative
=== STEP  testing cloud_aws_provider creation with required arguments only
=== STEP  Negative Case: testing cloud_aws_provider creation with invalid parent Dn
=== STEP  testing cloud_aws_provider attribute: description = irezwijricdrjoz3pmwfhpb6umjbaddjdezlfxrbtqy6h80i2nft3djjaspxfohlfbphrnl9a6ofoe82h76uuf7sbuibpyahf0b01l1xskghk8bcfqhwnrvf0ljm4b3x7
=== STEP  testing cloud_aws_provider attribute: annotation = ekvvqb9xfbu1v1btp92myfymz3wah7e084p7jzkyu1umzx8okkt4qeoalfvrock68840s2dfr0qdbjrhwrg9420n4qbzoqpvionpmlq3zbzz6f1e6q7h0keebcl7dydiz
=== STEP  testing cloud_aws_provider attribute: name_alias = 4quduxvxunpvj92t68gglx0946luwdqsij40seyhmnyow86ftogthjv1b8lw0t0u
=== STEP  testing cloud_aws_provider attribute: email = 1d1rdy3otccr9lvu2qgrtsp4cmcyp80ma74gmznb7eqbzwe1xyow4an61td7yi8frgksx3n37n7d9ssxflsemtmw247wobfxsdbaxhurn6gpvo3qt1zujjn4lvijw82j4xbqoc1nd60i8s4by0bubqkcqzcjbi9npfkjpqu8eplziim0erxx4eo8drdpm1he3eytp8nakjdnvrj2dphmkvp39up26esvjemrg77gxpbi36kkzkg9bgix6ajz1uyt0gs1l1g6rk481nx8jtxmfquid49ybi3zkpypa2vtyyee6ik0rhy6dkpwoku6k3d3efn7y12ce944gr8ezxk71bng3o1eoeu8i9bhdm111i9i1wlcupul6bfgs2vtadg6hyprv16tdw6jlfpbjjga9rzbzkkuihwfxluc6c8yxvlhxublsegpk1t07ewuhahhgo1n96bt4qhdzed4azvgl1jtv2ysx4piy3laqpqhwc9cxdemfilfjtfoizh3xpecy
=== STEP  testing cloud_aws_provider attribute: http_proxy = sx4phjj0w7ps73g2k7f62fju0zucaqso49jneqr8s2ub31dar9npdf32mj1uz1tbnlibf3ebdzu3gmajkc8skt4nq9v0jp0h3fzw917j77e1azoporv06u4qhjpg6lmlpw8cjdpxa3ysf4gu9xx4abxqtt74kljh6eg4yy90wnje16e2tp79iy1u8udu2vu1ufha6jjxe7uabqemj9b9y1mfezgotn9tctnidgy1ynxb47flz1m3d4kjzmal9r6s2409grw36q2pmhiuys4lhsy1howu0nxl3hndwf2txqmpl3t89hk43lqp0yyctqcty9fwnk2vgueaibr3tmn0vfzfk3sr6cqhep0zytbrup0m0hyk6txhtu4fu88nwdmhqh30yqv7vygy3x27nyci3jrzu7q4wmlmkiz1ypgxl0d120n843jti6to6dfzbdqehd6w1n3m6smc7igmnioifp2dvx8xg8bff1vg4ihmozcyhuwu0cs6kq6ackwhanu37
=== STEP  testing cloud_aws_provider attribute: is_account_in_org = lk6wg
=== STEP  testing cloud_aws_provider attribute: is_trusted = lk6wg
=== STEP  testing cloud_aws_provider attribute: provider_id = fxp2es68jm8mxabcvgt67pe3ra2atowyd31n0oflxe0xvn07asgnh1vugfih640kmazyn96p2m2g69x6hiy2e463buuewcm3pe7m6izpdy1lc6drjy6ikefig3e2kw7kr82xcs08gaercphg3w774j8gzj6qnbgivdtd8kvqfexha890i0mm6fwwksyitluqu2jmsr2xa6f1qs48fg2t93bwyzinj69mlxbxudfkkhp6n4agfa8htz0iy8ymrf6c7ju8khtnx0pqrtqvhejr7b2qc4gtkp7tvvpgg87bpscwejx9dot60i6i4obqag2wlu9md9rmutmfzi8saseu99yi1fywp016xhpt1k1ywr7ezh16z1lqca2eox1fmozx4nlcn3fvv8rknv8q7yefrskpxi676wftxrmtcrq6xzs7luv69yzzgq81lxadauposlq600zp0aj7khtqffn3txde9ntvfaaof7iwg7202ztihsjb07rlgxyo1gh1hcsj6
=== STEP  testing cloud_aws_provider attribute: afgnv = lk6wg
=== STEP  testing cloud_aws_provider creation with required arguments only
=== PAUSE TestAccAciCloudAWSProvider_Negative
=== CONT  TestAccAciCloudAWSProvider_Negative
=== STEP  testing cloud_aws_provider destroy
--- PASS: TestAccAciCloudAWSProvider_Negative (241.96s)
PASS
ok      github.com/terraform-providers/terraform-provider-aci/testacc   244.974s